### PR TITLE
Fixed a bug that gradle build break when using project-dir '-p'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ def versionHtml() {
 }
 
 task writeVersion {
-    new File('core/src/main/web/template/version.html').write(versionHtml())
+    file('core/src/main/web/template/version.html').write(versionHtml())
 }
 
 task makeDist(type:Exec) {


### PR DESCRIPTION
Use [file()](http://www.gradle.org/docs/current/javadoc/org/gradle/api/Project.html#file%28java.lang.Object%29), so the path is relative to the project directory.
