### PR TITLE
Fixed #5, duplicate entries in recent menu

### DIFF
--- a/shared/src/main/java/com/twosigma/beaker/rest/RecentMenuRest.java
+++ b/shared/src/main/java/com/twosigma/beaker/rest/RecentMenuRest.java
@@ -115,7 +115,7 @@ public class RecentMenuRest {
     }
     private static String transformUrl(String input) {
         String ret;
-        if (input.contains(":/")) {
+        if (input.contains(":/") || input.startsWith("file:")) {
             ret = input;
         } else {
             ret = "file:" + input;


### PR DESCRIPTION
Note this doesn't addressed the fact that ~/.beaker/conf/recentDocuments might be corrupted with entries with multiple "file:" prefix. Users are recommended to delete or manually fix the file.
