### PR TITLE
move 'use strict' to start of node plugin server

### DIFF
--- a/plugin/node/src/dist/app/app.js
+++ b/plugin/node/src/dist/app/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var express = require('express');
 var http = require('http');
 var uuid = require('node-uuid');
@@ -35,7 +37,6 @@ app.post('/evaluate', function(request, response){
 });
 
 function processCode(code) {
-    'use strict';
     var returnValue;
     var result;
     try {


### PR DESCRIPTION
per spec
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions_and_function_scope/Strict_mode

> "To invoke strict mode for an entire script, put the exact statement
> "use strict"; (or 'use strict';) before any other statements."
