### PR TITLE
Fix an ipython plugin reconnecting issue

### DIFF
--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -39,8 +39,10 @@ define(function(require, exports, module) {
       var kernel = null;
       var self = this;
 
-      // check in kernel table if shellID exists, then do nothing or still callback?
       if (kernels[shellID]) {
+        bkHelper.fcall(function() {
+          cb(shellID);
+        });
         return;
       }
 
@@ -103,7 +105,7 @@ define(function(require, exports, module) {
           console.error("TIMED OUT - waiting for ipython kernel to start");
         }
       };
-      setTimeout(spin, 0);
+      bkHelper.fcall(spin);
     },
     evaluate: function(code, modelOutput) {
       if (_theCancelFunction) {

--- a/plugin/ipythonPlugins/src/dist/iruby/iruby.js
+++ b/plugin/ipythonPlugins/src/dist/iruby/iruby.js
@@ -41,6 +41,9 @@ define(function(require, exports, module) {
 
       // check in kernel table if shellID exists, then do nothing or still callback?
       if (kernels[shellID]) {
+        bkHelper.fcall(function() {
+          cb(shellID);
+        });
         return;
       }
 
@@ -103,7 +106,7 @@ define(function(require, exports, module) {
           console.error("TIMED OUT - waiting for ipython kernel to start");
         }
       };
-      setTimeout(spin, 0);
+      bkHelper.fcall(spin);
     },
     evaluate: function(code, modelOutput) {
       if (_theCancelFunction) {

--- a/plugin/ipythonPlugins/src/dist/julia/julia.js
+++ b/plugin/ipythonPlugins/src/dist/julia/julia.js
@@ -41,6 +41,9 @@ define(function(require, exports, module) {
 
       // check in kernel table if shellID exists, then do nothing or still callback?
       if (kernels[shellID]) {
+        bkHelper.fcall(function() {
+          cb(shellID);
+        });
         return;
       }
 
@@ -103,7 +106,7 @@ define(function(require, exports, module) {
           console.error("TIMED OUT - waiting for ipython kernel to start");
         }
       };
-      setTimeout(spin, 0);
+      bkHelper.fcall(spin);
     },
     evaluate: function(code, modelOutput) {
       if (_theCancelFunction) {


### PR DESCRIPTION
with requireJS, loading module (JS file) will only run the code in the file the first time. We can no longer rely on reloading file to reset variables.

Also, use bkHelper.fcall to make async func call instead of setTimeout
