### PR TITLE
[Bunsen] Use notebook ids instead of names for notebooks stored in Bunsen

### DIFF
--- a/core/src/main/web/app/helpers/bunsenhelper.js
+++ b/core/src/main/web/app/helpers/bunsenhelper.js
@@ -55,7 +55,7 @@
         var saveData = bkSessionManager.getSaveData();
         var serializedNotebook = {
           data: saveData.notebookModelAsString,
-          name: $routeParams.notebookName
+          id: $routeParams.notebookId
         };
         bunsenSave(serializedNotebook, 'update');
       },


### PR DESCRIPTION
This is needed for https://github.com/twosigma/bunsen/pull/131 to work properly.
