### PR TITLE
Fix #377, fix expanding relative path on Windows

### DIFF
--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -204,7 +204,7 @@
               result = homeDir + "/"
             } else if (_.string.startsWith(result, '~/')) {
               result = result.replace('~', homeDir);
-            } else if (!_.string.startsWith(result, '/')) {
+            } else if (!_.string.startsWith(result, '/') && !result.match(/^\w+:\\/)) {
               result = pwd + "/" + result;
             }
             if (!_.string.endsWith(result, '.bkr')


### PR DESCRIPTION
Before this change, we determine if an input is relative path only take
into account of unix, that is whether a path starts with "/".
This doesn't work on Windows where paths like "C:\Users\Foo" shouldn't
be expanded.
