### PR TITLE
Fix #370, fix session saving from the control panel

### DIFF
--- a/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
+++ b/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
@@ -70,9 +70,9 @@
                   // save session
                   var saveSession = function() {
                     var notebookModelAsString = bkUtils.toPrettyJson(notebookModel);
-                    if (!_.isEmpty(session.notebookUri)) {
+                    if (session.isSavable()) {
                       var fileSaver = bkCoreManager.getFileSaver(session.uriType);
-                      return fileSaver.save(session.notebookUri, notebookModelAsString);
+                      return fileSaver.save(session.notebookUri, notebookModelAsString, true);
                     } else {
                       var deferred = bkUtils.newDeferred();
                       bkCoreManager.showDefaultSavingFileChooser().then(function(pathInfo) {


### PR DESCRIPTION
Use the isSavable() of session manager to determine whether a notebook
is savable. And if so, beaker will just save it with the 'overwrite'
flag turned on.
Please note that with this change, for the sessions that are not
savable (read-only or new notebook), we still don't have the nice
state machine from spec of #247 yet. #415 was logged for
implementing that.
