### PR TITLE
Fix #441 by reverting 9569e61. Fix memory leak in session manager instead.

### DIFF
--- a/core/src/main/web/app/mainapp/services/notebookcellmodelmanager.js
+++ b/core/src/main/web/app/mainapp/services/notebookcellmodelmanager.js
@@ -145,8 +145,6 @@
       reset: function(_cells_) {
         if (_cells_) {
           cells = _cells_;
-        } else {
-          cells = [];
         }
         this.clipboard = null;
         recreateCellMap();

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -71,7 +71,11 @@
         },
         set: function(v) {
           _v = v;
-          bkNotebookCellModelManager.reset(_v.cells);
+          if (this.isEmpty()) {
+            bkNotebookCellModelManager.reset([]);
+          } else {
+            bkNotebookCellModelManager.reset(_v.cells);
+          }
         },
         isEmpty: function() {
           return _.isEmpty(_v);


### PR DESCRIPTION
When notebookcellmodelmanager.reset() is called with no arguments,
it should keep the cells as is and just rebuild the cell map,
which was broken by 9569e61.

After this fix, if one want to reset the cells to empty, [] needs
to be passed explicitly. As a result, when session model manager
resets the notebook model, it now calls reset([]) instead of reset().
