### PR TITLE
Fix #353, handle server disconnects on client(mainapp).

### DIFF
--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -289,7 +289,7 @@
 
         modalDialogOp.setStrategy(strategy);
         var dd = $dialog.dialog(options);
-        dd.open().then(function(result) {
+        return dd.open().then(function(result) {
           dd.$scope.$destroy();
           if (callback) {
             callback(result);

--- a/core/src/main/web/app/mainapp/mainapp.html
+++ b/core/src/main/web/app/mainapp/mainapp.html
@@ -35,7 +35,7 @@
             ""}}</font></span>
         </li>
         <li class="pull-right" style="padding: 10px 54px; cursor: default;">
-          <span ng-show="disconnected"><font color="red">offline</font></span>
+          <span ng-show="disconnected" class="offline-label" ng-click="promptToSave()" eat-click>offline</span>
         </li>
       </ul>
     </div>

--- a/core/src/main/web/app/styles/header.scss
+++ b/core/src/main/web/app/styles/header.scss
@@ -68,6 +68,11 @@ html .navbar {
         display: block;
         padding: 10px 5px;
     }
+
+    span.offline-label {
+        color: #FF0000;
+        cursor: pointer;
+    }
 }
 
 html .navbar a.brand, html .navbar .nav > li > a {
@@ -75,7 +80,7 @@ html .navbar a.brand, html .navbar .nav > li > a {
     text-shadow: none;
 }
 
-.navbar-fixed-top .navbar-inner{
+.navbar-fixed-top .navbar-inner {
     background:         #3f5264;
     box-shadow:         none;
     -webkit-box-shadow: none;

--- a/core/src/main/web/app/utils/basic/commonutils.js
+++ b/core/src/main/web/app/utils/basic/commonutils.js
@@ -185,6 +185,31 @@
         return event.button === 1 // middle click
             || (event.button === 0 // left click
             && (navigator.appVersion.indexOf("Mac") !== -1 ? event.metaKey : event.ctrlKey));
+      },
+      saveAsClientFile: function (data, filename) {
+        if (!data) {
+          console.error('commonUtils.saveAsClientFile: No data');
+          return;
+        }
+
+        if (!filename) {
+          filename = 'console.json';
+        }
+
+        if (typeof data === "object") {
+          data = JSON.stringify(data, undefined, 4)
+        }
+
+        var blob = new Blob([data], {type: 'text/json'}),
+            e = document.createEvent('MouseEvents'),
+            a = document.createElement('a')
+
+        a.download = filename
+        a.href = window.URL.createObjectURL(blob)
+        a.dataset.downloadurl = ['text/json', a.download, a.href].join(':')
+        e.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0,
+            false, false, false, false, 0, null)
+        a.dispatchEvent(e)
       }
     };
   });

--- a/core/src/main/web/app/utils/utils.js
+++ b/core/src/main/web/app/utils/utils.js
@@ -64,6 +64,9 @@
       findTable: function(elem) {
         return commonUtils.findTable(elem);
       },
+      saveAsClientFile: function(data, filename) {
+        return commonUtils.saveAsClientFile(data, filename);
+      },
 
       // wrap angularUtils
       refreshRootScope: function() {


### PR DESCRIPTION
When server disconnects, there will be a dialog prompting the user
about server has disconnected and asking to save the notebook
as a file on the client side. If user chose not to, the dialog is
dismissed and beaker starts hijacking keypress events to prompt the
same dialog again on such events. The dialog can also be opened by
clicking on the red 'offline' label on the nav bar.
