### PR TITLE
Spot/469 (simplify plugin manager)

### DIFF
--- a/core/src/main/web/app/helpers/evaluatepluginmanager.js
+++ b/core/src/main/web/app/helpers/evaluatepluginmanager.js
@@ -18,7 +18,7 @@
  */
 (function() {
   'use strict';
-  var module = angular.module('bk.evaluatePluginManager', ['bk.utils', 'bk.evaluatorManager']);
+  var module = angular.module('bk.evaluatePluginManager', ['bk.utils']);
   module.factory('bkEvaluatePluginManager', function(bkUtils) {
       var nameToUrlMap = {};
       var plugins = {};

--- a/core/src/main/web/app/helpers/evaluatepluginmanager.js
+++ b/core/src/main/web/app/helpers/evaluatepluginmanager.js
@@ -18,7 +18,7 @@
  */
 (function() {
   'use strict';
-  var module = angular.module('bk.evaluatePluginManager', ['bk.utils']);
+  var module = angular.module('bk.evaluatePluginManager', ['bk.utils', 'bk.evaluatorManager']);
   module.factory('bkEvaluatePluginManager', function(bkUtils) {
       var nameToUrlMap = {};
       var plugins = {};

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -65,7 +65,7 @@
                 status = "active";
               else {
                 for (var l in loadingPlugins) {
-                  if (l.plugin == p) {
+                  if (loadingPlugins[l].plugin == p) {
                     status = "loading";
                     break;
                   }

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -40,6 +40,16 @@
           getAllEvaluators: function() {
             return bkEvaluatorManager.getAllEvaluators();
           },
+          getEvaluatorsWithSpec: function() {
+	    var activePlugins = bkEvaluatorManager.getAllEvaluators();
+            var result = {};
+            for (var p in activePlugins) {
+	      if (Object.keys(activePlugins[p].spec).length > 0) {
+		result[p] = activePlugins[p];
+	      }
+	    }
+	    return result;
+          },
           getLoadingEvaluators: function() {
             return bkEvaluatorManager.getLoadingEvaluators();
           },
@@ -47,14 +57,6 @@
             var knownPlugins = bkEvaluatePluginManager.getKnownEvaluatorPlugins();
             var activePlugins = bkEvaluatorManager.getAllEvaluators();
             var loadingPlugins = bkEvaluatorManager.getLoadingEvaluators();
-            console.log("known plugs:");
-            console.log(knownPlugins);
-            console.log("active plugs:");
-            console.log(activePlugins);
-            console.log("loading plugs:");
-            console.log(loadingPlugins);
-            if (loadingPlugins.length > 0)
-              console.log(loadingPlugins[0]);
             var result = {};
             for (var p in knownPlugins) {
               var status = false;
@@ -73,8 +75,6 @@
               }
               result[p] = status;
             }
-            console.log("result:");
-            console.log(result);
             return result;
           },
           setNewPluginNameOrUrl: function(pluginNameOrUrl) {

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -80,8 +80,11 @@
           setNewPluginNameOrUrl: function(pluginNameOrUrl) {
             this.newPluginNameOrUrl = pluginNameOrUrl;
           },
-          addPlugin: function() {
+          addPlugin: function(name) {
             var plugin = this.newPluginNameOrUrl;
+	    if (name) {
+		plugin = name;
+	    }
             var newEvaluatorObj = {
               name: "",
               plugin: plugin

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -37,6 +37,7 @@
         };
         $scope.evalTabOp = {
           newPluginNameOrUrl: "",
+	  showURL: false,
           getAllEvaluators: function() {
             return bkEvaluatorManager.getAllEvaluators();
           },
@@ -82,6 +83,7 @@
           },
           addPlugin: function(name) {
             var plugin = this.newPluginNameOrUrl;
+	    $scope.evalTabOp.showURL = false;
 	    if (name) {
 		plugin = name;
 	    }

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -44,7 +44,38 @@
             return bkEvaluatorManager.getLoadingEvaluators();
           },
           getKnownEvaluatePlugins: function(name) {
-            return bkEvaluatePluginManager.getKnownEvaluatorPlugins();
+            var knownPlugins = bkEvaluatePluginManager.getKnownEvaluatorPlugins();
+            var activePlugins = bkEvaluatorManager.getAllEvaluators();
+            var loadingPlugins = bkEvaluatorManager.getLoadingEvaluators();
+            console.log("known plugs:");
+            console.log(knownPlugins);
+            console.log("active plugs:");
+            console.log(activePlugins);
+            console.log("loading plugs:");
+            console.log(loadingPlugins);
+            if (loadingPlugins.length > 0)
+              console.log(loadingPlugins[0]);
+            var result = {};
+            for (var p in knownPlugins) {
+              var status = false;
+              if (activePlugins[p])
+                status = "active";
+              else {
+                for (var l in loadingPlugins) {
+                  if (l.plugin == p) {
+                    status = "loading";
+                    break;
+                  }
+                }
+                if (!status) {
+                  status = "known";
+                }
+              }
+              result[p] = status;
+            }
+            console.log("result:");
+            console.log(result);
+            return result;
           },
           setNewPluginNameOrUrl: function(pluginNameOrUrl) {
             this.newPluginNameOrUrl = pluginNameOrUrl;

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
@@ -21,9 +21,9 @@
     <div>
       <button ng-repeat="(pluginName, pluginStatus) in evalTabOp.getKnownEvaluatePlugins()"
               ng-click="evalTabOp.addPlugin(pluginName)">
-        <span ng-show="pluginStatus=='active'">A</span>
-        <span ng-show="pluginStatus=='loading'">L</span>
-        <span ng-show="pluginStatus=='known'">K</span>
+        <span ng-show="pluginStatus=='active'" class="plugin-active">&#x25cf;</span>
+        <span ng-show="pluginStatus=='loading'" class="plugin-loading">&#x25cf;</span>
+        <span ng-show="pluginStatus=='known'" class="plugin-known">&#x25cf;</span>
         {{pluginName}}
       </button><button ng-click="evalTabOp.showURL = !evalTabOp.showURL">From URL...</button>
     </div>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
@@ -25,9 +25,10 @@
         <span ng-show="pluginStatus=='loading'">L</span>
         <span ng-show="pluginStatus=='known'">K</span>
         {{pluginName}}
-      </button>
+      </button><button ng-click="evalTabOp.showURL = !evalTabOp.showURL">From URL...</button>
     </div>
-    <div class="input-append addeval">
+    <br>
+    <div ng-show="evalTabOp.showURL" class="input-append addeval">
       <input type="text" bk-enter='evalTabOp.addPlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
       <button class="btn" ng-click='evalTabOp.addPlugin()'>Add Plugin from URL</button>
     </div>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
@@ -20,7 +20,7 @@
   <div class="modal-body modal-large">
     <div>
       <button ng-repeat="(pluginName, pluginStatus) in evalTabOp.getKnownEvaluatePlugins()"
-              ng-click="evalTabOp.setNewPluginNameOrUrl(pluginName)">
+              ng-click="evalTabOp.addPlugin(pluginName)">
         <span ng-show="pluginStatus=='active'">A</span>
         <span ng-show="pluginStatus=='loading'">L</span>
         <span ng-show="pluginStatus=='known'">K</span>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
@@ -32,7 +32,7 @@
       <button class="btn" ng-click='evalTabOp.addPlugin()'>Add Plugin from URL</button>
     </div>
     <tabs>
-      <pane ng-repeat="(evaluatorName, evaluator) in evalTabOp.getAllEvaluators()" heading="{{evaluatorName}}">
+      <pane ng-repeat="(evaluatorName, evaluator) in evalTabOp.getEvaluatorsWithSpec()" heading="{{evaluatorName}}">
         <bk-plugin-manager-evaluator-settings>
         </bk-plugin-manager-evaluator-settings>
       </pane>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
@@ -18,34 +18,23 @@
     <h3>Plugin Manager</h3>
   </div>
   <div class="modal-body modal-large">
+    <div>
+      <button ng-repeat="(pluginName, pluginStatus) in evalTabOp.getKnownEvaluatePlugins()"
+              ng-click="evalTabOp.setNewPluginNameOrUrl(pluginName)">
+        <span ng-show="pluginStatus=='active'">A</span>
+        <span ng-show="pluginStatus=='loading'">L</span>
+        <span ng-show="pluginStatus=='known'">K</span>
+        {{pluginName}}
+      </button>
+    </div>
+    <div class="input-append addeval">
+      <input type="text" bk-enter='evalTabOp.addPlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
+      <button class="btn" ng-click='evalTabOp.addPlugin()'>Add Plugin from URL</button>
+    </div>
     <tabs>
-      <pane heading="Evaluators">
-        <div>
-          <button ng-repeat="(pluginName, pluginUrl) in evalTabOp.getKnownEvaluatePlugins()"
-                  ng-click="evalTabOp.setNewPluginNameOrUrl(pluginName)">{{pluginName}}
-          </button>
-        </div>
-        <div class="input-append addeval">
-          <input type="text" bk-enter='evalTabOp.addPlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
-          <button class="btn" ng-click='evalTabOp.addPlugin()'>Add Plugin from URL</button>
-        </div>
-        <accordion>
-          <bk-plugin-manager-evaluator-settings ng-repeat="(evaluatorName, evaluator) in evalTabOp.getAllEvaluators()">
-          </bk-plugin-manager-evaluator-settings>
-          <div ng-repeat="evaluator in evalTabOp.getLoadingEvaluators()"><accordion-group heading="Loading {{evaluator.plugin}}..."></accordion-group></div>
-        </accordion>
-      </pane>
-      <pane heading="Menus">
-        <div class="input-append">
-          <input type="text" ng-model="menuTabOp.newMenuPluginUrl"></input>
-          <button class="btn" ng-click='menuTabOp.addMenuPlugin()'>Add Plugin from URL</button>
-        </div>
-        <div ng-repeat="plugin in menuTabOp.getMenuPlugins()">
-          {{plugin.url}}
-        </div>
-        <div ng-repeat="plugin in menuTabOp.getLoadingPlugins()">
-          Loading {{plugin.getUrl()}}
-        </div>
+      <pane ng-repeat="(evaluatorName, evaluator) in evalTabOp.getAllEvaluators()" heading="{{evaluatorName}}">
+        <bk-plugin-manager-evaluator-settings>
+        </bk-plugin-manager-evaluator-settings>
       </pane>
     </tabs>
   </div>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.html
@@ -21,11 +21,11 @@
     <div>
       <button ng-repeat="(pluginName, pluginStatus) in evalTabOp.getKnownEvaluatePlugins()"
               ng-click="evalTabOp.addPlugin(pluginName)">
-        <span ng-show="pluginStatus=='active'" class="plugin-active">&#x25cf;</span>
-        <span ng-show="pluginStatus=='loading'" class="plugin-loading">&#x25cf;</span>
-        <span ng-show="pluginStatus=='known'" class="plugin-known">&#x25cf;</span>
+        <span ng-show="pluginStatus=='active'" class="plugin-active plugin-status">&#x25cf;</span>
+        <span ng-show="pluginStatus=='loading'" class="plugin-loading plugin-status">&#x25cf;</span>
+        <span ng-show="pluginStatus=='known'" class="plugin-known plugin-status">&#x25cf;</span>
         {{pluginName}}
-      </button><button ng-click="evalTabOp.showURL = !evalTabOp.showURL">From URL...</button>
+      </button><button ng-click="evalTabOp.showURL = !evalTabOp.showURL"><span class="plugin-invisible plugin-status">&#x25cf;</span>From URL...</button>
     </div>
     <br>
     <div ng-show="evalTabOp.showURL" class="input-append addeval">

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
@@ -26,8 +26,7 @@
       $compile, bkSessionManager) {
     return {
       restrict: 'E',
-      template: '<div><accordion-group heading="{{evaluatorName}} (plugin: {{evaluator.settings.plugin}})">' +
-          '<div class="bbody"></div></accordion-group></div>',
+      template: '<div class="bbody"></div>',
       controller: function($scope) {
         $scope.set = function(val) {
           $scope.evaluator.perform(val);

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -65,7 +65,7 @@
 }
 
 .plugin-active {
-  color: green;
+  color: limegreen;
 }
 
 .plugin-loading {
@@ -73,5 +73,14 @@
 }
 
 .plugin-known {
-  color: gray;
+  color: lightgray;
+}
+
+.plugin-invisible {
+  opacity: 0.0;
+}
+
+.plugin-status {
+  font-size: 150%;
+  vertical-align: -2px;
 }

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -63,3 +63,15 @@
 .cl {
   clear: both;
 }
+
+.plugin-active {
+  color: green;
+}
+
+.plugin-loading {
+  color: yellow;
+}
+
+.plugin-known {
+  color: gray;
+}

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -69,7 +69,7 @@
 }
 
 .plugin-loading {
-  color: yellow;
+  color: orange;
 }
 
 .plugin-known {


### PR DESCRIPTION
Addresses Issue #469:
- Remove the "menus" panel (this can be set from the prefs file).
- Get rid of the text field next to "Add plugin from URL".
- When a user clicks one of the plugin buttons, it just loads.  It has a status light that cycles from gray to yellow to green.
- The "Add plugin from URL" button becomes just another button in the big list (on the far right) with label "Open from URL...", which opens a field where you enter the URL and confirm.
- change the accordion list into tabbed panels.  plugins with no parameters do not create a panel.
