### PR TITLE
Fix #493, make insert cell menu a split UI

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/cell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/cell-directive.js
@@ -82,6 +82,9 @@
           },
           attachCell: function(newCell) {
             notebookCellOp.insertAfter($scope.cellmodel.id, newCell);
+          },
+          prevCell: function() {
+            return $scope.cellmodel;
           }
         };
 

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
@@ -62,28 +62,9 @@
           }
         }
 
-        // find the first code cell starting with the startCell and scan
-        // using the direction, if the startCell is a code cell, it will be returned.
-        var findCodeCell = function(startCell, forward) {
-          var cell = startCell;
-          while (cell) {
-            if (cellOps.getCellType(cell.id) === "code") {
-              return cell;
-            }
-            cell = forward ? cellOps.getNext(cell.id) : cellOps.getPrev(cell.id);
-          }
-          return null;
-        };
-
         // get the last code cell in the notebook
         var getLastCodeCell = function() {
-          return _(cellOps.getCells())
-              .chain()
-              .filter(function(c) {
-                return c.type === "code";
-              })
-              .last()
-              .value();
+          return _.last(cellOps.getAllCodeCells());
         };
 
 
@@ -98,7 +79,9 @@
           // If a prev cell is not given, use the very last code cell in the notebook.
           // If there is no code cell in the notebook, use the first evaluator in the list
           var prevCell = $scope.config && $scope.config.prevCell && $scope.config.prevCell();
-          var codeCell = findCodeCell(prevCell) || findCodeCell(prevCell, true) || getLastCodeCell();
+          var codeCell = (prevCell && cellOps.findCodeCell(prevCell.id))
+              || (prevCell && cellOps.findCodeCell(prevCell.id, true))
+              || getLastCodeCell();
           var evaluatorName = codeCell ?
               codeCell.evaluator : _.keys(bkEvaluatorManager.getAllEvaluators())[0];
           $scope.newCodeCell(evaluatorName);

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
@@ -20,6 +20,7 @@
 
   module.directive('bkNewCellMenu', function(
       bkUtils, bkSessionManager, bkEvaluatorManager) {
+    var cellOps = bkSessionManager.getNotebookCellOp();
     return {
       restrict: 'E',
       templateUrl: "./app/mainapp/components/notebook/newcellmenu.html",
@@ -54,15 +55,54 @@
         };
 
         function attachCell(cell) {
-          var cellOp = bkSessionManager.getNotebookCellOp();
-
           if ($scope.config && $scope.config.attachCell) {
             return $scope.config.attachCell(cell);
+          } else {
+            cellOps.insertLast(cell);
           }
-
-          bkSessionManager.getRawNotebookModel().cells
-          cellOp.insertLast(cell);
         }
+
+        // find the first code cell starting with the startCell and scan
+        // using the direction, if the startCell is a code cell, it will be returned.
+        var findCodeCell = function(startCell, forward) {
+          var cell = startCell;
+          while (cell) {
+            if (cellOps.getCellType(cell.id) === "code") {
+              return cell;
+            }
+            cell = forward ? cellOps.getNext(cell.id) : cellOps.getPrev(cell.id);
+          }
+          return null;
+        };
+
+        // get the last code cell in the notebook
+        var getLastCodeCell = function() {
+          return _(cellOps.getCells())
+              .chain()
+              .filter(function(c) {
+                return c.type === "code";
+              })
+              .last()
+              .value();
+        };
+
+
+        $scope.insertDefaultCodeCell = function(event) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          // by default, insert a code cell (and use the best evaluator with best guess)
+          // If a prev cell is given, first scan toward top of the notebook, and use the evaluator
+          // of the first code cell found. If not found, scan toward bottom, and use the evaluator
+          // of the first code cell found.
+          // If a prev cell is not given, use the very last code cell in the notebook.
+          // If there is no code cell in the notebook, use the first evaluator in the list
+          var prevCell = $scope.config && $scope.config.prevCell && $scope.config.prevCell();
+          var codeCell = findCodeCell(prevCell) || findCodeCell(prevCell, true) || getLastCodeCell();
+          var evaluatorName = codeCell ?
+              codeCell.evaluator : _.keys(bkEvaluatorManager.getAllEvaluators())[0];
+          $scope.newCodeCell(evaluatorName);
+        };
       },
       link: function(scope, element, attrs) {
         scope.moveMenu = function(event) {

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu.html
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu.html
@@ -15,7 +15,9 @@
 -->
 <div class="dropdown new-cell-menu" ng-mouseover="mouseOver=true" ng-mouseleave="mouseOver=false">
   <a class="dropdown-toggle">
-    <div ng-click="moveMenu($event)" class="insert-cell-indicator" ng-class="mouseOver && 'expanded'">+ Insert Cell
+    <div ng-click="insertDefaultCodeCell($event)" class="insert-cell-indicator" ng-class="mouseOver && 'expanded'">Insert Cell
+    </div><div ng-click="moveMenu($event)" class="insert-cell-indicator shift-right" ng-class="mouseOver && 'expanded'">
+      <i class="fa fa-sort-down"></i>
     </div>
   </a>
   <ul class="dropdown-menu" role="menu">

--- a/core/src/main/web/app/mainapp/components/notebook/sectioncell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/sectioncell-directive.js
@@ -175,6 +175,9 @@
           },
           attachCell: function(newCell) {
             notebookCellOp.insertAfter($scope.cellmodel.id, newCell);
+          },
+          prevCell: function() {
+            return $scope.cellmodel;
           }
         };
       },

--- a/core/src/main/web/app/mainapp/services/notebookcellmodelmanager.js
+++ b/core/src/main/web/app/mainapp/services/notebookcellmodelmanager.js
@@ -198,9 +198,24 @@
         });
       },
       getAllCodeCells: function(id) {
+        if (!id) {
+          id = "root";
+        }
         return this.getAllDescendants(id).filter(function(cell) {
           return cell.type === "code";
         });
+      },
+      // find the first code cell starting with the startCell and scan
+      // using the direction, if the startCell is a code cell, it will be returned.
+      findCodeCell: function(startCellId, forward) {
+        var cell = this.getCell(startCellId);
+        while (cell) {
+          if (cell.type === "code") {
+            return cell;
+          }
+          cell = forward ? this.getNext(cell.id) : this.getPrev(cell.id);
+        }
+        return null;
       },
       insertBefore: function(id, cell) {
         var index = this.getIndex(id);

--- a/core/src/main/web/app/styles/cell-menus.scss
+++ b/core/src/main/web/app/styles/cell-menus.scss
@@ -25,12 +25,17 @@
     &:hover {
         .dropdown-toggle {
             opacity: 1;
-            text-decoration: none;
         }
     }
-    .shift-right {
-        margin-left: 1px;
-    }
+}
+
+bk-new-cell-menu {
+  .dropdown-toggle {
+    text-decoration: none;
+  }
+  .shift-right {
+    margin-left: 1px;
+  }
 }
 
 .dropdown-toggle {

--- a/core/src/main/web/app/styles/cell-menus.scss
+++ b/core/src/main/web/app/styles/cell-menus.scss
@@ -25,7 +25,11 @@
     &:hover {
         .dropdown-toggle {
             opacity: 1;
+            text-decoration: none;
         }
+    }
+    .shift-right {
+        margin-left: 1px;
     }
 }
 


### PR DESCRIPTION
After the change, the pop menu will only shows up when click on the down-pointing triangle on the right. If clicking on the left, text part `insert cell`, a code cell will be inserted. The evaluator for the new code cell is determined as commented in the code:
https://github.com/twosigma/beaker-notebook/commit/2add534995ebf2eaf02c3cbb839113ccef69ee69#diff-66bf8e92ebae0a71e23d29ea062a6675R94
