### PR TITLE
Fix #486, handle connection status properly when recover from sleep

### DIFF
--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -603,7 +603,7 @@
               $timeout.cancel(reconnectTimeout);
               reconnectTimeout = undefined;
             }
-            window.removeEventListener('keypress', indicateReconnectFailed);
+            window.removeEventListener('keypress', indicateReconnectFailed, true);
           };
 
           return {

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -559,16 +559,16 @@
                 "Save current notebook as a file?",
                 "Disconnected",
                 function() {
-                  // "Not now", hijack all keypress events to prompt again
-                  window.addEventListener('keypress', $scope.promptToSave, true);
-                },
-                function() {
                   // "Save", save the notebook as a file on the client side
                   bkUtils.saveAsClientFile(
                       bkSessionManager.getSaveData().notebookModelAsString,
                       "notebook.bkr");
                 },
-                "Not now", "Save", "", "btn-primary"
+                function() {
+                  // "Not now", hijack all keypress events to prompt again
+                  window.addEventListener('keypress', $scope.promptToSave, true);
+                },
+                "Save", "Not now", "btn-primary", ""
             ).then(function() {
               prompted = false;
             });

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -45,6 +45,7 @@
   module.directive('bkMainApp', function(
       $route,
       $routeParams,
+      $timeout,
       bkUtils,
       bkCoreManager,
       bkSession,
@@ -574,19 +575,80 @@
           };
         })();
 
-        bkUtils.addConnectedStatusListener(function(msg) {
-          if (msg.successful !== !$scope.disconnected) {
-            var disconnected = !msg.successful;
-            $scope.$digest();
-            if (disconnected) {
-              $scope.disconnected = true;
-              $scope.promptToSave();
-            } else {
-              // we don't handle reconnect right now
+        var connectionManager = (function() {
+          var RECONNECT_TIMEOUT = 5000; // 5 seconds
+          var OFFLINE_MESSAGE = "offline";
+          var CONNECTING_MESSAGE = "reconnecting";
+          var reconnectTimeout = undefined;
+          var statusMessage = OFFLINE_MESSAGE;
+          var disconnected = false;
+          var indicateReconnectFailed = function() {
+            stopWaitingReconnect();
+            statusMessage = OFFLINE_MESSAGE;
+            bkUtils.disconnect(); // prevent further attempting to reconnect
+            $scope.promptToSave();
+          };
+          var waitReconnect = function() {
+            statusMessage = CONNECTING_MESSAGE;
+
+            // wait for 5 sceonds, if reconnect didn't happen, prompt to save
+            if (!reconnectTimeout) {
+              reconnectTimeout = $timeout(indicateReconnectFailed, RECONNECT_TIMEOUT);
             }
+            // if user attempts to interact within 5 second, also prompt to save
+            window.addEventListener('keypress', indicateReconnectFailed, true);
+          };
+          var stopWaitingReconnect = function() {
+            if (reconnectTimeout) {
+              $timeout.cancel(reconnectTimeout);
+              reconnectTimeout = undefined;
+            }
+            window.removeEventListener('keypress', indicateReconnectFailed);
+          };
+
+          return {
+            onDisconnected: function() {
+              disconnected = true;
+              waitReconnect();
+            },
+            onReconnected: function() {
+              bkSessionManager.isSessionValid().then(function(isValid) {
+                if (isValid) {
+                  stopWaitingReconnect();
+                  disconnected = false;
+                } else {
+                  indicateReconnectFailed();
+                }
+              });
+            },
+            getStatusMessage: function() {
+              return statusMessage;
+            },
+            isDisconnected: function() {
+              return disconnected;
+            }
+          };
+        })();
+
+        $scope.getOffineMessage = function() {
+          return connectionManager.getStatusMessage();
+        };
+        $scope.isDisconnected = function() {
+          return connectionManager.isDisconnected();
+        };
+
+        bkUtils.addConnectedStatusListener(function(msg) {
+          if (msg.successful !== !$scope.isDisconnected()) {
+            var disconnected = !msg.successful;
+            if (disconnected) {
+              connectionManager.onDisconnected();
+            } else {
+              connectionManager.onReconnected();
+            }
+            $scope.$digest();
           }
         });
-        $scope.$watch('disconnected', function(disconnected) {
+        $scope.$watch('isDisconnected()', function(disconnected) {
           if (disconnected) {
             stopAutoBackup();
           } else {

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -160,6 +160,7 @@
         _sessionId = sessionId;
 
         bkNotebookNamespaceModelManager.init(sessionId, notebookModel);
+        bkSession.backup(_sessionId, generateBackupData());
       },
       clear: function() {
         bkEvaluatorManager.reset();

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -221,6 +221,15 @@
       getSessionId: function() {
         return _sessionId;
       },
+      isSessionValid: function() {
+        if (!_sessionId) {
+          return bkUtils.newPromise("false");
+        } else {
+          return bkSession.getSessions().then(function(sessions) {
+            return _(sessions).chain().keys().contains(_sessionId).value();
+          });
+        }
+      },
       // TODO, move the following impl to a dedicated notebook model manager
       // but still expose it here
       setNotebookModelEdited: function(edited) {

--- a/core/src/main/web/app/template/mainapp/mainapp.jst.html
+++ b/core/src/main/web/app/template/mainapp/mainapp.jst.html
@@ -35,7 +35,7 @@
             ""}}</font></span>
         </li>
         <li class="pull-right" style="padding: 10px 54px; cursor: default;">
-          <span ng-show="disconnected" class="offline-label" ng-click="promptToSave()" eat-click>offline</span>
+          <span ng-show="isDisconnected()" class="offline-label" ng-click="promptToSave()" eat-click>{{getOffineMessage()}}</span>
         </li>
       </ul>
     </div>

--- a/core/src/main/web/app/utils/cometdutils.js
+++ b/core/src/main/web/app/utils/cometdutils.js
@@ -39,6 +39,9 @@
         return function() {
           $.cometd.removeListener(listener);
         };
+      },
+      disconnect: function() {
+        return $.cometd.disconnect();
       }
     };
   });

--- a/core/src/main/web/app/utils/utils.js
+++ b/core/src/main/web/app/utils/utils.js
@@ -193,6 +193,9 @@
       removeConnectedStatusListener: function() {
         return cometdUtils.removeConnectedStatusListener();
       },
+      disconnect: function() {
+        return cometdUtils.disconnect();
+      },
 
       // wrapper around requireJS
       moduleMap: {},


### PR DESCRIPTION
In this change, when beaker get a disconnect change (from cometd), it
will wait for 5 seconds. If within 5 seconds, there is a connect event,
it will try to ditinguish the connect event coming from a valid
reconnect(same session is still availble) from an invalid connect that
can for example come from server crash or user stopping the server
intentionally. If there is no connect event, again within 5 sec of
the disconnect event, and there is a key press event, as well as timeout
after 5 secs, beaker will treat the situation as server is permanently
gone and stop further reconnect attempt and pops up the dialog for
saving the notebook model as a client file (#353)
