### PR TITLE
Fix Issue #44 Make R evaluation interruptible

### DIFF
--- a/plugin/r/src/dist/r.js
+++ b/plugin/r/src/dist/r.js
@@ -160,6 +160,16 @@ define(function(require, exports, module) {
         data: { shellID: self.settings.shellID }
       });
     },
+    cancelExecution: function() {
+      // XXX duplicate of interrupt.
+      var self = this;
+      $.ajax({
+        type: "POST",
+        datatype: "json",
+        url: serviceBase + "/rest/rsh/interrupt",
+        data: { shellID: self.settings.shellID }
+      });
+    },
     spec: {
       interrupt: {type: "action", action: "interrupt", name: "Interrupt"}
     },

--- a/plugin/r/src/dist/r.js
+++ b/plugin/r/src/dist/r.js
@@ -151,7 +151,17 @@ define(function(require, exports, module) {
         data: { shellID: self.settings.shellID }
       }).done(cb);
     },
+    interrupt: function() {
+      var self = this;
+      $.ajax({
+        type: "POST",
+        datatype: "json",
+        url: serviceBase + "/rest/rsh/interrupt",
+        data: { shellID: self.settings.shellID }
+      });
+    },
     spec: {
+      interrupt: {type: "action", action: "interrupt", name: "Interrupt"}
     },
     cometdUtil: cometdUtil
   };

--- a/plugin/r/src/dist/r.js
+++ b/plugin/r/src/dist/r.js
@@ -152,23 +152,10 @@ define(function(require, exports, module) {
       }).done(cb);
     },
     interrupt: function() {
-      var self = this;
-      $.ajax({
-        type: "POST",
-        datatype: "json",
-        url: serviceBase + "/rest/rsh/interrupt",
-        data: { shellID: self.settings.shellID }
-      });
+      this.cancelExecution();
     },
     cancelExecution: function() {
-      // XXX duplicate of interrupt.
-      var self = this;
-      $.ajax({
-        type: "POST",
-        datatype: "json",
-        url: serviceBase + "/rest/rsh/interrupt",
-        data: { shellID: self.settings.shellID }
-      });
+      bkHelper.httpPost(serviceBase + "/rest/rsh/interrupt", {shellID: this.settings.shellID});
     },
     spec: {
       interrupt: {type: "action", action: "interrupt", name: "Interrupt"}

--- a/plugin/r/src/main/java/com/twosigma/beaker/r/module/ErrorGobbler.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/module/ErrorGobbler.java
@@ -26,9 +26,18 @@ import java.io.InputStreamReader;
 public class ErrorGobbler extends Thread {
 
   private final InputStream inputStream;
+  private boolean expectingExtraLine;
 
   public ErrorGobbler(InputStream is) {
     inputStream = is;
+    expectingExtraLine = false;
+  }
+
+  // R has a very weird behavior: when a session process is
+  // interrupted the master issues an empty line to stderr.  No idea
+  // why or how to stop it, seems like a bug.  Use this to hide it.
+  public void expectExtraLine() {
+    expectingExtraLine = true;
   }
 
   @Override
@@ -38,6 +47,10 @@ public class ErrorGobbler extends Thread {
       BufferedReader br = new BufferedReader(isr);
       String line = null;
       while ((line = br.readLine()) != null) {
+        if (expectingExtraLine && line.length() == 0) {
+          expectingExtraLine = false;
+          continue;
+        }
         System.err.println(line);
       }
     } catch (IOException ioe) {

--- a/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
@@ -125,7 +125,7 @@ public class RShellRest {
   }
 
   private RServer startRserve()
-    throws IOException, RserveException
+    throws IOException, RserveException, REXPMismatchException
   {
     int port = getPortFromCore();
     String pluginInstallDir = System.getProperty("user.dir");
@@ -164,7 +164,8 @@ public class RShellRest {
 
     RConnection rconn = new RConnection("127.0.0.1", port);
     rconn.login("beaker", password);
-    return new RServer(rconn, handler, port, password, rServe);
+    int pid = rconn.eval("Sys.getpid()").asInteger();
+    return new RServer(rconn, handler, port, password, pid);
   }
 
   // set the port used for communication with the Core server
@@ -177,7 +178,8 @@ public class RShellRest {
   @POST
   @Path("getShell")
   public String getShell(@FormParam("shellid") String shellId)
-                         throws InterruptedException, RserveException, IOException {
+    throws InterruptedException, RserveException, IOException, REXPMismatchException
+  {
     // if the shell doesnot already exist, create a new shell
     if (shellId.isEmpty() || !this.shells.containsKey(shellId)) {
       shellId = UUID.randomUUID().toString();
@@ -198,7 +200,6 @@ public class RShellRest {
       @FormParam("code") String code) throws InterruptedException, REXPMismatchException, IOException {
 
     boolean gotMismatch = false;
-    // System.out.println("evaluating, shellID = " + shellID + ", code = " + code);
     SimpleEvaluationObject obj = new SimpleEvaluationObject(code);
     obj.started();
     RServer server = getEvaluator(shellID);
@@ -281,13 +282,15 @@ public class RShellRest {
 
   @POST
   @Path("interrupt")
-  public void interrupt(@FormParam("shellID") String shellID) {
+  public void interrupt(@FormParam("shellID") String shellID)
+    throws IOException
+  {
     RServer server = getEvaluator(shellID);
-                        System.out.println("XXX R interrupt");
+    Runtime.getRuntime().exec("kill -SIGINT " + server.pid);
   }
 
   private void newEvaluator(String id)
-          throws RserveException, IOException
+    throws RserveException, IOException, REXPMismatchException
   {
     RServer newRs;
     if (useMultipleRservers) {
@@ -298,8 +301,10 @@ public class RShellRest {
       }
       RConnection rconn = new RConnection("127.0.0.1", rServer.port);
       rconn.login("beaker", rServer.password);
-      newRs = new RServer(rconn, rServer.outputHandler, rServer.port, rServer.password, rServer.process);
+      int pid = rconn.eval("Sys.getpid()").asInteger();
+      newRs = new RServer(rconn, rServer.outputHandler, rServer.port, rServer.password, pid);
     }
+    
     this.shells.put(id, newRs);
   }
 
@@ -402,13 +407,13 @@ public class RShellRest {
     ROutputHandler outputHandler;
     int port;
     String password;
-    Process process;
-    public RServer(RConnection con, ROutputHandler handler, int port, String password, Process process) {
+    int pid;
+    public RServer(RConnection con, ROutputHandler handler, int port, String password, int pid) {
       this.connection = con;
       this.outputHandler = handler;
       this.port = port;
       this.password = password;
-      this.process = process;
+      this.pid = pid;
     }
   }
 }

--- a/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
@@ -164,7 +164,7 @@ public class RShellRest {
 
     RConnection rconn = new RConnection("127.0.0.1", port);
     rconn.login("beaker", password);
-    return new RServer(rconn, handler, port, password);
+    return new RServer(rconn, handler, port, password, rServe);
   }
 
   // set the port used for communication with the Core server
@@ -279,6 +279,13 @@ public class RShellRest {
   public void exit(@FormParam("shellID") String shellID) {
   }
 
+  @POST
+  @Path("interrupt")
+  public void interrupt(@FormParam("shellID") String shellID) {
+    RServer server = getEvaluator(shellID);
+                        System.out.println("XXX R interrupt");
+  }
+
   private void newEvaluator(String id)
           throws RserveException, IOException
   {
@@ -291,7 +298,7 @@ public class RShellRest {
       }
       RConnection rconn = new RConnection("127.0.0.1", rServer.port);
       rconn.login("beaker", rServer.password);
-      newRs = new RServer(rconn, rServer.outputHandler, rServer.port, rServer.password);
+      newRs = new RServer(rconn, rServer.outputHandler, rServer.port, rServer.password, rServer.process);
     }
     this.shells.put(id, newRs);
   }
@@ -395,11 +402,13 @@ public class RShellRest {
     ROutputHandler outputHandler;
     int port;
     String password;
-    public RServer(RConnection con, ROutputHandler handler, int port, String password) {
+    Process process;
+    public RServer(RConnection con, ROutputHandler handler, int port, String password, Process process) {
       this.connection = con;
       this.outputHandler = handler;
       this.port = port;
       this.password = password;
+      this.process = process;
     }
   }
 }

--- a/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
@@ -289,6 +289,9 @@ public class RShellRest {
   public void interrupt(@FormParam("shellID") String shellID)
     throws IOException
   {
+    if (windows()) {
+      return;
+    }
     RServer server = getEvaluator(shellID);
     server.errorGobbler.expectExtraLine();
     Runtime.getRuntime().exec("kill -SIGINT " + server.pid);

--- a/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/rest/RShellRest.java
@@ -244,7 +244,11 @@ public class RShellRest {
         con.eval("print(\"" + END_MAGIC + "\")");
       }
     } catch (RserveException e) {
-      obj.error(e.getMessage());
+      if (127 == e.getRequestReturnCode()) {
+        obj.error("Interrupted");
+      } else {
+        obj.error(e.getMessage());
+      }
     } catch (REXPMismatchException e) {
       gotMismatch = true;
     }


### PR DESCRIPTION
This is not easy and it does not always work because not all R operations can be interrupted.
But presumably R users are used to this and it's the best we can do.
The way it works is, when R starts a new session we ask it for its unix PID.
Then, we interrupt it by sending a SIGINT.
The weird part is someone (Rserve?) is printing an extra empty line which must be suppressed lest our output tray pop up.

This will not work on windows, will need more work there.
