### PR TITLE
allow removing plugins from notebook, plus other bug fixes

### DIFF
--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -38,6 +38,7 @@
         $scope.evalTabOp = {
           newPluginNameOrUrl: "",
 	  showURL: false,
+	  showWarning: false,
           getAllEvaluators: function() {
             return bkEvaluatorManager.getAllEvaluators();
           },
@@ -104,11 +105,13 @@
               // you would really want to be able to delete them.
               // other states we should support: failed and exiting.
               console.log("remove plugin");
-              if (true/*bkSessionManager.evaluatorUnused(plugin)*/) {
+              if (bkSessionManager.evaluatorUnused(plugin)) {
+		console.log("removing!!");
                 bkSessionManager.removeEvaluator(plugin);
                 bkCoreManager.getBkApp().removeEvaluator(plugin);
               } else {
                 console.log("show warning pane");
+		  $scope.evalTabOp.showWarning = true;
               }
             }
           }

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -83,14 +83,12 @@
             this.newPluginNameOrUrl = pluginNameOrUrl;
           },
           togglePlugin: function(name) {
-            console.log("togglePlugin: " + name);
             var plugin = this.newPluginNameOrUrl;
 	    $scope.evalTabOp.showURL = false;
 	    if (name) {
 		plugin = name;
 	    }
             var status = this.getKnownEvaluatePlugins()[plugin];
-            console.log("status: " + status);
             if (status == "known") {
               var newEvaluatorObj = {
                 name: "",
@@ -104,14 +102,11 @@
               // to try to load and fail, and get stuck loading.  then
               // you would really want to be able to delete them.
               // other states we should support: failed and exiting.
-              console.log("remove plugin");
               if (bkSessionManager.evaluatorUnused(plugin)) {
-		console.log("removing!!");
                 bkSessionManager.removeEvaluator(plugin);
                 bkCoreManager.getBkApp().removeEvaluator(plugin);
               } else {
-                console.log("show warning pane");
-		  $scope.evalTabOp.showWarning = true;
+		$scope.evalTabOp.showWarning = true;
               }
             }
           }

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -81,18 +81,36 @@
           setNewPluginNameOrUrl: function(pluginNameOrUrl) {
             this.newPluginNameOrUrl = pluginNameOrUrl;
           },
-          addPlugin: function(name) {
+          togglePlugin: function(name) {
+            console.log("togglePlugin: " + name);
             var plugin = this.newPluginNameOrUrl;
 	    $scope.evalTabOp.showURL = false;
 	    if (name) {
 		plugin = name;
 	    }
-            var newEvaluatorObj = {
-              name: "",
-              plugin: plugin
-            };
-            bkSessionManager.addEvaluator(newEvaluatorObj);
-            bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
+            var status = this.getKnownEvaluatePlugins()[plugin];
+            console.log("status: " + status);
+            if (status == "known") {
+              var newEvaluatorObj = {
+                name: "",
+                plugin: plugin
+              };
+              bkSessionManager.addEvaluator(newEvaluatorObj);
+              bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
+            } else {
+              // what happens if you remove a plugin that is loading?
+              // could just ignore, unless it's possible for plugins
+              // to try to load and fail, and get stuck loading.  then
+              // you would really want to be able to delete them.
+              // other states we should support: failed and exiting.
+              console.log("remove plugin");
+              if (true/*bkSessionManager.evaluatorUnused(plugin)*/) {
+                bkSessionManager.removeEvaluator(plugin);
+                bkCoreManager.getBkApp().removeEvaluator(plugin);
+              } else {
+                console.log("show warning pane");
+              }
+            }
           }
         };
 

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
@@ -18,7 +18,7 @@
     <h3>Plugin Manager</h3>
   </div>
   <div class="modal-body modal-large">
-    <button class="beaker-btn" ng-click="evalTabOp.addPlugin(pluginName)" ng-disabled="pluginStatus!='known'" ng-repeat="(pluginName, pluginStatus) in evalTabOp.getKnownEvaluatePlugins()">
+    <button class="beaker-btn" ng-click="evalTabOp.togglePlugin(pluginName)" ng-repeat="(pluginName, pluginStatus) in evalTabOp.getKnownEvaluatePlugins()">
       <span ng-show="pluginStatus=='active'" class="plugin-active plugin-status">&#x25cf;</span>
       <span ng-show="pluginStatus=='loading'" class="plugin-loading plugin-status">&#x25cf;</span>
       <span ng-show="pluginStatus=='known'" class="plugin-known plugin-status">&#x25cf;</span>
@@ -28,8 +28,8 @@
     </button>
     <p><br/></p>
     <div ng-show="evalTabOp.showURL" class="input-append addeval">
-      <input type="text" bk-enter='evalTabOp.addPlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
-      <button class="btn" ng-click='evalTabOp.addPlugin()'>Add Plugin from URL</button>
+      <input type="text" bk-enter='evalTabOp.togglePlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
+      <button class="btn" ng-click='evalTabOp.togglePlugin()'>Add Plugin from URL</button>
     </div>
     <tabs>
       <pane ng-repeat="(evaluatorName, evaluator) in evalTabOp.getEvaluatorsWithSpec()" heading="{{evaluatorName}}">

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
@@ -31,6 +31,14 @@
       <input type="text" bk-enter='evalTabOp.togglePlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
       <button class="btn" ng-click='evalTabOp.togglePlugin()'>Add Plugin from URL</button>
     </div>
+    <div ng-show="evalTabOp.showWarning">
+      <div class="modal-body error-title body-box">
+	<p>Cannot remove plugin currently used by a code cell in the notebook.<br/>
+	  Delete those cells and try again.</p>
+	<button class="btn right" ng-click='evalTabOp.showWarning = false'>OK</button>
+      </div>
+      <p><br/></p>
+    </div>
     <tabs>
       <pane ng-repeat="(evaluatorName, evaluator) in evalTabOp.getEvaluatorsWithSpec()" heading="{{evaluatorName}}">
         <bk-plugin-manager-evaluator-settings>

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -450,7 +450,9 @@
             },
             removeEvaluator: function(plugin) {
               bkEvaluatorManager.removeEvaluator(plugin);
-              // remove from evaluatorMenuItems too
+	      evaluatorMenuItems = _.reject(evaluatorMenuItems, function(item) {
+		      return item.name == plugin;
+		});
             },
             getEvaluatorMenuItems: function() {
               return evaluatorMenuItems;

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -91,10 +91,12 @@
                       });
                     }
                   });
-                  evaluatorMenuItems.push({
-                    name: evaluator.pluginName,//TODO, this should be evaluator.settings.name
-                    items: actionItems
-                  });
+                  if (actionItems.length > 0) {
+                    evaluatorMenuItems.push({
+                      name: evaluator.pluginName, // TODO, this should be evaluator.settings.name
+                      items: actionItems
+                    });
+                  }
                 }
               });
         };
@@ -445,6 +447,10 @@
             },
             addEvaluator: function(settings) {
               addEvaluator(settings, true);
+            },
+            removeEvaluator: function(plugin) {
+              bkEvaluatorManager.removeEvaluator(plugin);
+              // remove from evaluatorMenuItems too
             },
             getEvaluatorMenuItems: function() {
               return evaluatorMenuItems;

--- a/core/src/main/web/app/mainapp/services/evaluatormanager.js
+++ b/core/src/main/web/app/mainapp/services/evaluatormanager.js
@@ -27,11 +27,24 @@
       reset: function() {
         evaluators = {};
       },
+      removeEvaluator: function(plugin) {
+        console.log("bkEvaluatorManager.removeEvaluator");
+        console.log(evaluators);
+        for (var key in evaluators) {
+          var e = evaluators[key];
+          if (e.pluginName == plugin) {
+            if (_.isFunction(e.exit)) {
+              e.exit();
+            }
+            delete evaluators[key];
+          }
+        }
+      },
       newEvaluator: function(evaluatorSettings) {
         loadingInProgressEvaluators.push(evaluatorSettings);
         return bkEvaluatePluginManager.getEvaluatorFactory(evaluatorSettings.plugin)
-            .then(function(facotry) {
-              return facotry.create(evaluatorSettings);
+            .then(function(factory) {
+              return factory.create(evaluatorSettings);
             })
             .then(function(evaluator) {
               if (_.isEmpty(evaluatorSettings.name)) {
@@ -69,7 +82,7 @@
       },
       exitAndRemoveAllEvaluators: function() {
         _.each(evaluators, function(ev) {
-          if (ev && _.isFinite(ev.exit)) {
+          if (ev && _.isFunction(ev.exit)) {
             ev.exit();
           }
         });

--- a/core/src/main/web/app/mainapp/services/evaluatormanager.js
+++ b/core/src/main/web/app/mainapp/services/evaluatormanager.js
@@ -28,8 +28,6 @@
         evaluators = {};
       },
       removeEvaluator: function(plugin) {
-        console.log("bkEvaluatorManager.removeEvaluator");
-        console.log(evaluators);
         for (var key in evaluators) {
           var e = evaluators[key];
           if (e.pluginName == plugin) {

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -256,6 +256,13 @@
         _notebookModel.get().evaluators.push(evaluator);
         _edited = true;
       },
+      removeEvaluator: function(plugin) {
+        var model = _notebookModel.get();
+        model.evaluators = _.reject(model.evaluators, function(e) {
+          return e.plugin == plugin;
+        });
+        _edited = true;
+      },
       getNotebookCellOp: function() {
         return bkNotebookCellModelManager;
       },

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -253,12 +253,9 @@
         }
       },
       evaluatorUnused: function(plugin) {
-	console.log("finding: " + plugin);
 	var n = _.find(_notebookModel.get().cells, function (c) {
-	    console.log("c.type=" + c.type + " c.evaluator=" + c.evaluator);
 	    return c.type == "code" && c.evaluator == plugin;
 	});
-          console.log("n=" + n + " !n=" + !n);
 	return !n;
       },
       addEvaluator: function(evaluator) {

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -252,6 +252,15 @@
           _edited = true;
         }
       },
+      evaluatorUnused: function(plugin) {
+	console.log("finding: " + plugin);
+	var n = _.find(_notebookModel.get().cells, function (c) {
+	    console.log("c.type=" + c.type + " c.evaluator=" + c.evaluator);
+	    return c.type == "code" && c.evaluator == plugin;
+	});
+          console.log("n=" + n + " !n=" + !n);
+	return !n;
+      },
       addEvaluator: function(evaluator) {
         _notebookModel.get().evaluators.push(evaluator);
         _edited = true;

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -92,3 +92,7 @@
   font-size: 150%;
   vertical-align: -2px;
 }
+
+.body-box {
+  border: solid 1px $cell-border;
+}


### PR DESCRIPTION
Fix Issue #77 by making clicking on an active plugin in the plugin manager remove that plugin if possible (ie it is unused).

Also fix Issue #568 , by just checking the item before adding it.

Also fix a longstanding unknown bug where the exit method was not called on plugins when the notebook was closed.
