### PR TITLE
Fix for issue 702

### DIFF
--- a/core/nginx/nginx.conf.template
+++ b/core/nginx/nginx.conf.template
@@ -61,6 +61,12 @@ http {
       return 301 %(start_page)s;
     }
 
+    location /beaker {
+      proxy_pass http://127.0.0.1:%(port_beaker)s/;
+      proxy_set_header Authorization "Basic %(auth)s";
+      %(auth_cookie_rule)s
+    }
+
     location /beaker/ {
       proxy_pass http://127.0.0.1:%(port_beaker)s/;
       proxy_set_header Authorization "Basic %(auth)s";


### PR DESCRIPTION
The issue is created by nginx that is trying to redirect the /beaker
URI into /beaker/ since in the configuration file there's no match for
/beaker without a slash. URI rewrite will not work. The solution is to
add a second location block that matches /beaker URI and proxy passes
them.
