### PR TITLE
Fix for 144: When loading a plugin from a cross-origin URL, show a dialog warning the user that it could be unsafe

### DIFF
--- a/core/src/main/web/app/helpers/evaluatepluginmanager.js
+++ b/core/src/main/web/app/helpers/evaluatepluginmanager.js
@@ -47,34 +47,46 @@
               name = "";
               url = nameOrUrl;
             }
-            loadingInProgressPlugins.push({
-              name: name,
-              url: url
-            });
-            bkUtils.loadModule(url, name).then(function(ex) {
-              if (!_.isEmpty(ex.name)) {
-                plugins[ex.name] = ex;
-              }
-              if (!_.isEmpty(name) && name !== ex.name) {
-                plugins[name] = ex;
-              }
-              ex.getEvaluatorFactory().then(function(shellCreator) {
-                deferred.resolve(shellCreator);
-              });
-            }, function(err) {
-              console.error(err);
-              if (_.isEmpty(name)) {
-                deferred.reject("failed to load plugin: " + url);
-              } else {
-                deferred.reject("failed to load plugin: " + name + " at " + url);
-              }
-            }).finally(function() {
-              loadingInProgressPlugins = _(loadingInProgressPlugins).filter(function(it) {
-                return it.url !== url;
-              });
-            });
+            var r = new RegExp('^(?:[a-z]+:)?//', 'i');
+            if (r.test(url))
+            {
+              console.error("THIS IS IT");
 
-            return deferred.promise;
+
+              deferred.reject("REJECTED: " + url);
+              return deferred.promise;
+            }
+            else
+            {
+              loadingInProgressPlugins.push({
+                name: name,
+                url: url
+              });
+              bkUtils.loadModule(url, name).then(function(ex) {
+                if (!_.isEmpty(ex.name)) {
+                  plugins[ex.name] = ex;
+                }
+                if (!_.isEmpty(name) && name !== ex.name) {
+                  plugins[name] = ex;
+                }
+                ex.getEvaluatorFactory().then(function(shellCreator) {
+                  deferred.resolve(shellCreator);
+                });
+                }, function(err) {
+                console.error(err);
+                if (_.isEmpty(name)) {
+                  deferred.reject("failed to load plugin: " + url);
+                } else {
+                  deferred.reject("failed to load plugin: " + name + " at " + url);
+                }
+              }).finally(function() {
+                loadingInProgressPlugins = _(loadingInProgressPlugins).filter(function(it) {
+                  return it.url !== url;
+                });
+              });
+
+              return deferred.promise;
+            }
           }
         },
         createEvaluatorThenExit: function(settings) {

--- a/core/src/main/web/app/helpers/evaluatepluginmanager.js
+++ b/core/src/main/web/app/helpers/evaluatepluginmanager.js
@@ -47,46 +47,33 @@
               name = "";
               url = nameOrUrl;
             }
-            var r = new RegExp('^(?:[a-z]+:)?//', 'i');
-            if (r.test(url))
-            {
-              console.error("THIS IS IT");
-
-
-              deferred.reject("REJECTED: " + url);
-              return deferred.promise;
-            }
-            else
-            {
-              loadingInProgressPlugins.push({
-                name: name,
-                url: url
+            loadingInProgressPlugins.push({
+              name: name,
+              url: url
+            });
+            bkUtils.loadModule(url, name).then(function(ex) {
+              if (!_.isEmpty(ex.name)) {
+                plugins[ex.name] = ex;
+              }
+              if (!_.isEmpty(name) && name !== ex.name) {
+                plugins[name] = ex;
+              }
+              ex.getEvaluatorFactory().then(function(shellCreator) {
+                deferred.resolve(shellCreator);
               });
-              bkUtils.loadModule(url, name).then(function(ex) {
-                if (!_.isEmpty(ex.name)) {
-                  plugins[ex.name] = ex;
-                }
-                if (!_.isEmpty(name) && name !== ex.name) {
-                  plugins[name] = ex;
-                }
-                ex.getEvaluatorFactory().then(function(shellCreator) {
-                  deferred.resolve(shellCreator);
-                });
-                }, function(err) {
-                console.error(err);
-                if (_.isEmpty(name)) {
-                  deferred.reject("failed to load plugin: " + url);
-                } else {
-                  deferred.reject("failed to load plugin: " + name + " at " + url);
-                }
-              }).finally(function() {
-                loadingInProgressPlugins = _(loadingInProgressPlugins).filter(function(it) {
-                  return it.url !== url;
-                });
+              }, function(err) {
+              //console.error(err);
+              if (_.isEmpty(name)) {
+                deferred.reject("failed to load plugin: " + url);
+              } else {
+                deferred.reject("failed to load plugin: " + name + " at " + url);
+              }
+            }).finally(function() {
+              loadingInProgressPlugins = _(loadingInProgressPlugins).filter(function(it) {
+                return it.url !== url;
               });
-
-              return deferred.promise;
-            }
+            });
+            return deferred.promise;
           }
         },
         createEvaluatorThenExit: function(settings) {

--- a/core/src/main/web/app/helpers/evaluatepluginmanager.js
+++ b/core/src/main/web/app/helpers/evaluatepluginmanager.js
@@ -62,7 +62,7 @@
                 deferred.resolve(shellCreator);
               });
               }, function(err) {
-              //console.error(err);
+              console.error(err);
               if (_.isEmpty(name)) {
                 deferred.reject("failed to load plugin: " + url);
               } else {

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -107,16 +107,15 @@
               bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
             } if(fromUrl) {
                 var r = new RegExp('^(?:[a-z]+:)?//', 'i');
-                if (!r.test(plugin) || $scope.evalTabOp.forceLoad)
-                {
-                    var newEvaluatorObj = {
-                      name: "",
-                      plugin: plugin
-                    };
-                    $scope.evalTabOp.forceLoad = false;
-                    $scope.evalTabOp.newPluginNameOrUrl = "";
-                    bkSessionManager.addEvaluator(newEvaluatorObj);
-                    bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
+                if (!r.test(plugin) || $scope.evalTabOp.forceLoad) {
+                  var newEvaluatorObj = {
+                    name: "",
+                    plugin: plugin
+                  };
+                  $scope.evalTabOp.forceLoad = false;
+                  $scope.evalTabOp.newPluginNameOrUrl = "";
+                  bkSessionManager.addEvaluator(newEvaluatorObj);
+                  bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
                 } else {
                   $scope.evalTabOp.showSecurityWarning = true;
                 }

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager-directive.js
@@ -33,12 +33,19 @@
           return bkCoreManager.getBkApp().getBkNotebookWidget().getViewModel().isHideEvaluators();
         };
         $scope.hideEvaluators = function() {
+          $scope.evalTabOp.showURL = false;
+          $scope.evalTabOp.showWarning = false;
+          $scope.evalTabOp.showSecurityWarning = false;
+          $scope.evalTabOp.forceLoad = false;
+          $scope.evalTabOp.newPluginNameOrUrl = "";
           return bkCoreManager.getBkApp().getBkNotebookWidget().getViewModel().hideEvaluators();
         };
         $scope.evalTabOp = {
           newPluginNameOrUrl: "",
 	  showURL: false,
 	  showWarning: false,
+          showSecurityWarning: false,
+          forceLoad: false,
           getAllEvaluators: function() {
             return bkEvaluatorManager.getAllEvaluators();
           },
@@ -91,13 +98,28 @@
               fromUrl = false;
 	    }
             var status = this.getKnownEvaluatePlugins()[plugin];
-            if (status == "known" || fromUrl) {
+            if (status == "known") {
               var newEvaluatorObj = {
                 name: "",
                 plugin: plugin
               };
               bkSessionManager.addEvaluator(newEvaluatorObj);
               bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
+            } if(fromUrl) {
+                var r = new RegExp('^(?:[a-z]+:)?//', 'i');
+                if (!r.test(plugin) || $scope.evalTabOp.forceLoad)
+                {
+                    var newEvaluatorObj = {
+                      name: "",
+                      plugin: plugin
+                    };
+                    $scope.evalTabOp.forceLoad = false;
+                    $scope.evalTabOp.newPluginNameOrUrl = "";
+                    bkSessionManager.addEvaluator(newEvaluatorObj);
+                    bkCoreManager.getBkApp().addEvaluator(newEvaluatorObj);
+                } else {
+                  $scope.evalTabOp.showSecurityWarning = true;
+                }
             } else {
               // what happens if you remove a plugin that is loading?
               // could just ignore, unless it's possible for plugins

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
@@ -33,7 +33,7 @@
     </div>
     <div ng-show="evalTabOp.showSecurityWarning">
       <div class="modal-body error-title body-box">
-	<p>Warning: loading a plugin from an external URL is insecure.. do you want to continue?</p>
+	<p>Are you sure you want to load this plugin from an external URL?</p>
 	<button class="btn right" ng-click='evalTabOp.showSecurityWarning = false; evalTabOp.showURL=false; evalTabOp.newPluginNameOrUrl=""'>Cancel</button>
 	<button class="btn right" ng-click='evalTabOp.showSecurityWarning = false; evalTabOp.forceLoad = true; evalTabOp.togglePlugin()'>OK</button>
       </div>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager.jst.html
@@ -31,6 +31,14 @@
       <input type="text" bk-enter='evalTabOp.togglePlugin()' ng-model="evalTabOp.newPluginNameOrUrl"></input>
       <button class="btn" ng-click='evalTabOp.togglePlugin()'>Add Plugin from URL</button>
     </div>
+    <div ng-show="evalTabOp.showSecurityWarning">
+      <div class="modal-body error-title body-box">
+	<p>Warning: loading a plugin from an external URL is insecure.. do you want to continue?</p>
+	<button class="btn right" ng-click='evalTabOp.showSecurityWarning = false; evalTabOp.showURL=false; evalTabOp.newPluginNameOrUrl=""'>Cancel</button>
+	<button class="btn right" ng-click='evalTabOp.showSecurityWarning = false; evalTabOp.forceLoad = true; evalTabOp.togglePlugin()'>OK</button>
+      </div>
+      <p><br/></p>
+    </div>
     <div ng-show="evalTabOp.showWarning">
       <div class="modal-body error-title body-box">
 	<p>Cannot remove plugin currently used by a code cell in the notebook.<br/>

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -121,6 +121,41 @@
           var loadNotebookModelAndResetSession = function(
               notebookUri, uriType, readOnly, format, notebookModel, edited, sessionId,
               isExistingSession) {
+            // check if the notebook has to load plugins from an external source
+            var r = new RegExp('^(?:[a-z]+:)?//', 'i');
+            if (notebookModel && notebookModel.evaluators) {
+              for (var i = 0; i < notebookModel.evaluators.length; ++i) {
+                if (r.test(notebookModel.evaluators[i].plugin)) {
+                  promptIfInsecure().then(function() {
+                    // user accepted risk... do the loading
+                    _loadNotebookModelAndResetSession(notebookUri, uriType, readOnly, format, notebookModel, edited, sessionId, isExistingSession);
+                  }, function() {
+                    console.log("press fail");
+                    _loadNotebookModelAndResetSession(notebookUri, uriType, readOnly, format, notebookModel, edited, sessionId, isExistingSession);
+                  });
+                  return;
+                }
+              }
+            }
+            // no unsafe operation detected... do the loading
+            _loadNotebookModelAndResetSession(notebookUri, uriType, readOnly, format, notebookModel, edited, sessionId, isExistingSession);
+          };
+          var promptIfInsecure = function() {
+            var deferred = bkUtils.newDeferred();
+            bkCoreManager.show2ButtonModal(
+                "WARNING: this notebook references external plugins. Loading these plugin is an unsafe operation.",
+                "Do you want to continue?",
+                function() {
+                  deferred.reject();
+                },
+                function() {
+                  deferred.resolve();
+                }, "No, Cancel!", "Continue", "", "btn-danger");
+            return deferred.promise;
+          };
+          var _loadNotebookModelAndResetSession = function(
+              notebookUri, uriType, readOnly, format, notebookModel, edited, sessionId,
+              isExistingSession) {
             $scope.loading = true;
             addScrollingHack();
             bkSessionManager.reset(

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -156,14 +156,15 @@
           var promptIfInsecure = function(urlList) {
             var deferred = bkUtils.newDeferred();
             bkCoreManager.show2ButtonModal(
-                "WARNING: this notebook is asking to load the following plugins from external servers:<br/>" + urlList+ " <br/>",
-                "Do you want to continue?",
+                "This notebook is asking to load the following plugins from external servers:<br/>" + urlList+
+                    " <br/>How do you want to handle these external plugins?",
+                "Warning: external plugins detected",
                 function() {
                   deferred.reject();
                 },
                 function() {
                   deferred.resolve();
-                }, "No, Cancel!", "Continue", "", "btn-danger");
+                }, "Disable", "Load", "", "btn-danger");
             return deferred.promise;
           };
           var _loadNotebookModelAndResetSession = function(


### PR DESCRIPTION
Fix for bug [144](https://github.com/twosigma/beaker-notebook/issues/144).
In the plugin manager if the user inserts an URL as a source of the plugin, a dialog is shown to ask for confirmation.
At notebook load, if any evaluator is referencing an external URL, a dialog is shown to ask for confirmation. If the user denies the notebook is loaded without the URL-based evaluators.
