### PR TITLE
remove the R evaluator from a tut that does not use it

### DIFF
--- a/core/config/tutorials/d3.bkr
+++ b/core/config/tutorials/d3.bkr
@@ -41,15 +41,6 @@
                     "background": "#FFE0F0"
                 }
             }
-        },
-        {
-            "name": "R",
-            "plugin": "R",
-            "view": {
-                "cm": {
-                    "mode": "r"
-                }
-            }
         }
     ],
     "cells": [


### PR DESCRIPTION
fix Issue #790 
