### PR TITLE
Fix Issue #165 by removing --pylab from our ipython command line.  Its f...

### DIFF
--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -292,7 +292,17 @@ define(function(require, exports, module) {
             self.settings = settings;
             var finish = function () {
               if (bkHelper.hasSessionId()) {
-		  var initCode = ("try:\n"+
+		  var initCode = ("%matplotlib inline\n" +
+                                  "import numpy\n" +
+                                  "import matplotlib\n" +
+                                  "from matplotlib import pylab, mlab, pyplot\n" +
+                                  "np = numpy\n" +
+                                  "plt = pyplot\n" +
+                                  "from IPython.display import display\n" +
+                                  "from IPython.core.pylabtools import figsize, getfigs\n" +
+                                  "from pylab import *\n" +
+                                  "from numpy import *\n" +
+                                  "try:\n"+
 				  "    import beaker_runtime3 as beaker_runtime\n" +
 				  "except ImportError:\n" +
 				  "    import beaker_runtime as beaker_runtime\n" +

--- a/plugin/ipythonPlugins/src/dist/ipython/ipythonPlugin
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipythonPlugin
@@ -40,5 +40,4 @@ os.environ["PYTHONPATH"] = plugin_dir + old_path
 
 os.execlp("ipython", "ipython", "notebook",
           "--ipython-dir=" + os.environ["beaker_tmp_dir"],
-          "--profile", "beaker_backend_IPython",
-          "--pylab", "inline")
+          "--profile", "beaker_backend_IPython")


### PR DESCRIPTION
...unctionality is replaced with some initCode, both matplotlib magic to get inline graphics, plus all the imports.  We should make the initCode (at least this the optional parts of it) a plugin setting so people can change it.  IPython does not recommend using all these imports: http://stackoverflow.com/questions/20525459/ipython-pylab-vs-ipython
