### PR TITLE
Should work now even if homebrew is installed in non-standard location

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,7 +70,8 @@ task (compileCss, type: Exec) {
 
 task (copyNginx, type: Exec) {
   if (mac()) {
-    commandLine 'cp -f /usr/local/lib/libpcre.1.dylib /usr/local/bin/nginx /usr/local/etc/nginx/mime.types nginx/bin'.split()
+    def brewLocation = 'which brew'.execute().text.split(/bin.brew$/)[0].trim()
+    commandLine 'cp', '-f', brewLocation + 'lib/libpcre.1.dylib', brewLocation + 'bin/nginx', brewLocation + 'etc/nginx/mime.types', 'nginx/bin'
   } else if (windows()) {
     def nginxLocation = 'cmd /c where nginx'.execute().text.trim()
     commandLine 'cmd', '/c', 'xcopy', '/Y', '/Q', nginxLocation, 'nginx\\bin', '&', 'xcopy', '/Y', '/Q', nginxLocation + '\\..\\conf\\mime.types', 'nginx\\bin'


### PR DESCRIPTION
I am the sort of [insert negative word here] who installs his homebrew into a non-standard location.  The gradle files for beaker notebook assume that everything installed via homebrew is in the normal /usr/local location.  This patch is an attempt to fix this.  It works on my machine.

Caveat : I have never written any Groovy or Gradle before.
