### PR TITLE
Spot/883 implement exit method on ipython and python3 plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ Plugin specifications: [Evaluator plugins](https://github.com/twosigma/beaker-no
 ##Open source
 Beaker's full source code and documentation is available under the Apache 2.0 license.  Beaker's sharing feature uses a server with its own [repository](https://github.com/twosigma/beaker-sharing-server).
 
+

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -92,6 +92,9 @@ public class PluginServiceLocatorRest {
     "}\n";
 
   private static final String IPYTHON1_RULES =
+    "location %(base_url)s/kernels/kill/ {\n" +
+    "  proxy_pass http://127.0.0.1:%(port)s/kernels/;\n" +
+    "}\n" +
     "location %(base_url)s/kernels/ {\n" +
     "  proxy_pass http://127.0.0.1:%(port)s/kernels;\n" +
     "}\n" +
@@ -99,6 +102,9 @@ public class PluginServiceLocatorRest {
     IPYTHON_RULES_BASE;
 
   private static final String IPYTHON2_RULES =
+    "location %(base_url)s/api/kernels/kill/ {\n" +
+    "  proxy_pass http://127.0.0.1:%(port)s/api/kernels/;\n" +
+    "}\n" +
     "location %(base_url)s/api/kernels/ {\n" +
     "  proxy_pass http://127.0.0.1:%(port)s/api/kernels;\n" +
     "}\n" +

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -255,6 +255,11 @@ define(function(require, exports, module) {
 	});
       }
     },
+    exit: function(cb) {
+      console.log("ipython exit");
+      var kernel = kernels[this.settings.shellID];
+      kernel.kill();
+    },
     interrupt: function() {
       this.cancelExecution();
     },

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -254,6 +254,11 @@ define(function(require, exports, module) {
 	});
       }
     },
+    exit: function(cb) {
+      console.log("ipython exit");
+      var kernel = kernels[this.settings.shellID];
+      kernel.kill();
+    },
     interrupt: function() {
       this.cancelExecution();
     },

--- a/plugin/ipythonPlugins/src/dist/vendor/ipython/kernel.js
+++ b/plugin/ipythonPlugins/src/dist/vendor/ipython/kernel.js
@@ -371,7 +371,12 @@ var IPython1 = (function (IPython1) {
                 cache : false,
                 type : "DELETE"
             };
-            $.ajax(this.kernel_url, settings);
+            var url = this.kernel_url;
+            var slash = url.lastIndexOf("/");
+            if (slash >= 0) {
+              url = url.substring(0, slash + 1) + "kill/" + url.substring(slash + 1, url.length);
+            }
+            $.ajax(url, settings);
         };
     };
 

--- a/plugin/ipythonPlugins/src/dist/vendor/ipython2/kernel.js
+++ b/plugin/ipythonPlugins/src/dist/vendor/ipython2/kernel.js
@@ -399,7 +399,12 @@ var IPython = (function (IPython) {
                 cache : false,
                 type : "DELETE"
             };
-            $.ajax(utils.url_join_encode(this.kernel_url), settings);
+            var url = utils.url_join_encode(this.kernel_url);
+            var slash = url.lastIndexOf("/");
+            if (slash >= 0) {
+              url = url.substring(0, slash + 1) + "kill/" + url.substring(slash + 1, url.length);
+            }
+            $.ajax(url, settings);
         }
     };
 


### PR DESCRIPTION
this fixes a memory leak as old as the plugin: https://github.com/twosigma/beaker-notebook/issues/883

strangely, in order for the new ipython kernel API call to get through nginx i had to add a rule for it.
IMO there are too many nginx rules for ipython and that code should be cleaned up.

todo: update the other ipython based plugins (which they already need anyway)
