### PR TITLE
[bunsen] Allow Beaker client to reconnect after disconnecting from the server

### DIFF
--- a/core/src/main/web/app/utils/cometdutils.js
+++ b/core/src/main/web/app/utils/cometdutils.js
@@ -22,7 +22,8 @@
   var module = angular.module('bk.cometdUtils', []);
   module.factory('cometdUtils', function () {
     $.cometd.unregisterTransport("websocket");
-    $.cometd.init("cometd");
+    $.cometd.configure({url: "cometd", maxBackoff: 5000});
+    $.cometd.handshake();
     var _statusListener;
     return {
       addConnectedStatusListener: function (cb) {


### PR DESCRIPTION
There are two possible scenarios for a disconnect to happen:

1) Client was disconnected due to networking issues, in this case it will reconnect and maintain proper notebook sessions
2) Client was disconnected due to Beaker server restart, in this case it will reconnect and allow to continue working/saving notebooks, but notebook sessions maintained by the client will become invalid

The second scenario isn't addressed in this commit but ideally we should also reset the client state so it stays inline with the server.
