### PR TITLE
sessions:  Allow session ID's to be controlled externally.

### DIFF
--- a/core/src/main/web/app/beaker.js
+++ b/core/src/main/web/app/beaker.js
@@ -119,6 +119,9 @@
           return '/session/' + newSessionId;
         };
       };
+      var makeSessionUrl = function(sessionId) {
+        return '/session/' + sessionId + "?" + window.location.href.split("?")[1];
+      };
       $routeProvider
           .when('/session/new', {
             redirectTo: makeNewProvider("new")
@@ -139,7 +142,18 @@
               sessionRouteResolve.target = function() {
                 return search;
               };
-              return '/session/' + newSessionId + "?" + window.location.href.split("?")[1];
+	      return makeSessionUrl(newSessionId);
+            }
+          })
+          .when('/edit/:notebookId', {
+            redirectTo: function(routeParams, path, search) {
+              sessionRouteResolve.editingById = function() {
+                return routeParams.notebookId;
+              };
+              sessionRouteResolve.target = function() {
+                return search;
+              };
+              return makeSessionUrl(routeParams.notebookId);
             }
           })
           .when('/control', {

--- a/core/src/main/web/app/helpers/bunsenhelper.js
+++ b/core/src/main/web/app/helpers/bunsenhelper.js
@@ -33,6 +33,7 @@
   module.factory('bkBunsenHelper', function(bkCoreManager, bkShare, $dialog, $routeParams, $window, $timeout, bkSessionManager) {
 
     var bunsenSave = function(notebook, operation) {
+      bkSessionManager.backup();
       $window.top.postMessage({projectId: $routeParams.projectId,
                                notebook: notebook,
                                operation: operation},
@@ -58,7 +59,7 @@
       setNotebookEdited: function(edited) {
         $window.top.postMessage(
           {
-            notebookId: $routeParams.notebookId,
+            notebookId: $routeParams.sessionId,
             operation: 'edited',
             value: bkSessionManager.isNotebookModelEdited()
           },
@@ -71,7 +72,7 @@
         var action = 'update';
         var serializedNotebook = {
           data: saveData,
-          id: $routeParams.notebookId
+          id: $routeParams.sessionId
         };
         if (newName) {
           action = 'create';


### PR DESCRIPTION
Introduces editById as a main entrypoint (parallel to
"session" or "open"), which, given a notebook location and ID,
opens a new session to edit the notebook, or if there's already an
open session with that ID, re-uses the existing one.

This makes it so that a user can never have more than one session
open for the same notebook, which is what we want for Bunsen.
