### PR TITLE
bunsen:  backup session whenever an evaluator comes online.

### DIFF
--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -100,6 +100,9 @@
                     });
                   }
                 }
+                // ensure that if page is refreshed now,
+                // the evaluator process is not leaked.
+                bkSessionManager.backup();
               });
         };
 


### PR DESCRIPTION
This ensures that plugin processes won't leak if the page is closed
between when the evaluator is connected and when the next scheduled
backup occurs.
