### PR TITLE
[bunsen] Reconnect evaluators after Beaker client has reconnected to the server

### DIFF
--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -613,6 +613,7 @@
               disconnected = true;
             },
             onReconnected: function() {
+              bkSessionManager.reconnectEvaluators();
               disconnected = false;
             },
             getStatusMessage: function() {

--- a/core/src/main/web/app/mainapp/services/evaluatormanager.js
+++ b/core/src/main/web/app/mainapp/services/evaluatormanager.js
@@ -78,6 +78,13 @@
       getLoadingEvaluators: function() {
         return loadingInProgressEvaluators;
       },
+      reconnectEvaluators: function() {
+        _.each(evaluators, function(ev) {
+          if (ev && _.isFunction(ev.reconnect)) {
+            ev.reconnect();
+          }
+        });
+      },
       exitAndRemoveAllEvaluators: function() {
         _.each(evaluators, function(ev) {
           if (ev && _.isFunction(ev.exit)) {

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -269,6 +269,9 @@
         });
         _edited = true;
       },
+      reconnectEvaluators: function() {
+        return bkEvaluatorManager.reconnectEvaluators();
+      },
       getNotebookCellOp: function() {
         return bkNotebookCellModelManager;
       },

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -259,6 +259,10 @@ define(function(require, exports, module) {
       var kernel = kernels[this.settings.shellID];
       kernel.kill();
     },
+    reconnect: function() {
+      var kernel = kernels[this.settings.shellID];
+      kernel.restart();
+    },
     interrupt: function() {
       this.cancelExecution();
     },


### PR DESCRIPTION
Steps to reproduce the reconnection issue in Bunsen:
- Open a notebook and create a python cell.
- Execute the cell and the correct response comes back.
- Turn off your WiFi.
- Wait about 30 sec-1 min until "reconnecting" is displayed at the top of the notebook.
- Turn on your WiFi.
- Wait until the "reconnecting" message disappears.
- Execute the single cell.
- A result is never returned -- the cell execution counter keeps counting.

This fix is implemented on the Bunsen branch but if it turns out to be correct it should also make sense to cherry-pick it to master.

The issue was that upon client disconnect iPython evaluators were being disconnected from the shell/stdin channels due to:
- https://github.com/twosigma/beaker-notebook/blob/bunsen/plugin/ipythonPlugins/src/dist/vendor/ipython2/kernel.js#L186
- https://github.com/twosigma/beaker-notebook/blob/bunsen/plugin/ipythonPlugins/src/dist/vendor/ipython2/kernel.js#L192 

but never reconnected back.
Note, I haven't tested other evaluators yet.

@scottdraves @anglee Could you please have a look at the fix? Thanks.
