### PR TITLE
Fix Datatable glitch

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecelloutput-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecelloutput-directive.js
@@ -102,6 +102,7 @@
         $scope.toggleExpansion = function() {
           if ($scope.$parent.cellmodel.output.hidden) {
             delete $scope.$parent.cellmodel.output.hidden;
+            $scope.$broadcast('expand');
           } else {
             $scope.$parent.cellmodel.output.hidden = true;
           }

--- a/core/src/main/web/app/mainapp/components/notebook/codecelloutput-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecelloutput-directive.js
@@ -43,7 +43,7 @@
           $scope.applicableDisplays = bkOutputDisplayFactory.getApplicableDisplays(result);
           $scope.model.selectedType = $scope.applicableDisplays[0];
         });
-        
+
         // to be used in bkOutputDisplay
         $scope.outputDisplayModel = {
           getCellModel: function() {

--- a/core/src/main/web/app/mainapp/components/notebook/outputdisplay/outputdisplay-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/outputdisplay/outputdisplay-directive.js
@@ -17,7 +17,7 @@
   "use strict";
   var module = angular.module('bk.outputDisplay');
   module.directive('bkOutputDisplay', function(
-      $compile, $rootScope, bkOutputDisplayFactory, bkUtils) {
+      $compile, bkOutputDisplayFactory, bkUtils) {
     var getResultType = function(model) {
       if (model && model.getCellModel()) {
         if (_.isString(model.getCellModel())) {
@@ -40,7 +40,7 @@
           if (childScope) {
             childScope.$destroy();
           }
-          childScope = $rootScope.$new();
+          childScope = scope.$new();
           childScope.model = scope.model;
           var resultType = getResultType(scope.model);
           if (resultType) {

--- a/core/src/main/web/outputdisplay/bko-tabledisplay.js
+++ b/core/src/main/web/outputdisplay/bko-tabledisplay.js
@@ -64,7 +64,7 @@
                                   .withOption('searching', false);
         if (data.length > 25) {
           scope.dtOptions.withPaginationType('simple_numbers')
-          .withDisplayLength(25)           
+          .withDisplayLength(25)
           .withOption('lengthMenu', [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]]);
         } else {
           scope.dtOptions.withOption('paging', false);

--- a/core/src/main/web/outputdisplay/bko-tabledisplay.js
+++ b/core/src/main/web/outputdisplay/bko-tabledisplay.js
@@ -119,6 +119,10 @@
             scope.dtColumns.push(bkDatatables.DTColumnBuilder.newColumn(i).withTitle(columns[i]));
         }
 
+        scope.$on('expand', function() {
+          scope.dtOptions.dirty = true;
+        });
+
         scope.$watch('getDumpState()', function(result) {
           if (result !== undefined && result.tablestate === undefined) {
             scope.model.setDumpState({ tablestate : scope.state});


### PR DESCRIPTION
So this fixes the bug, but I had to make a pretty big architectural change (instantiating the output `childScope`s off of the current `scope` instead of the `$rootscope`), and I'm not sure how that might affect some of our edge cases.  Even so, the solution is basically to add a random attribute to our `dtOptions` object to trigger the angular-datatable's watcher in order to rerender, which is slightly janky.  I would have expected there to be a public method to rerender the table with the same approach that the directive controller takes, but it seems like there are only factory methods that expose services that re-render the components of the datatable itself.

I've opened an issue on the library, we might want to table this until it's either addressed or perhaps switch to a library that's less complex, more angular-friendly, and has better public interaction.  @samccone has had success using a library in the publications side of bunsen that might be worth considering.
