### PR TITLE
fix session backup/checkpoint when reloading page

### DIFF
--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -1019,10 +1019,10 @@
           if (bkEvaluateJobManager.isAnyInProgress()) {
             return "Some cells are still running. Leaving the page now will cause cancelling and result be lost";
           }
-        };
-        window.unload = function() {
-          bkEvaluateJobManager.cancel();
           onDestroy();
+        };
+        window.onunload = function() {
+          bkEvaluateJobManager.cancel();
         };
         startAutoBackup();
         $scope.gotoControlPanel = function(event) {


### PR DESCRIPTION
move onDestroy back to onbeforeunload, unclear why but initiating the session backup from onunload does not work.  also fix the typo and window.unload to window.onunload though so bkEvaluateJobManager.cancel gets called.  this closes Issue #1084
