### PR TITLE
Close Issue #1084 as follows: do the session backup first thing in onbef...

### DIFF
--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -1016,13 +1016,17 @@
 
         $scope.$on("$destroy", onDestroy);
         window.onbeforeunload = function(e) {
+          bkSessionManager.backup();
+          if (bkSessionManager.isNotebookModelEdited()) {
+            return "Your notebook has been edited but not saved, if you close the page your changes may be lost";
+          }
           if (bkEvaluateJobManager.isAnyInProgress()) {
             return "Some cells are still running. Leaving the page now will cause cancelling and result be lost";
           }
-        };
-        window.unload = function() {
-          bkEvaluateJobManager.cancel();
           onDestroy();
+        };
+        window.onunload = function() {
+          bkEvaluateJobManager.cancel();
         };
         startAutoBackup();
         $scope.gotoControlPanel = function(event) {


### PR DESCRIPTION
...oreunload, IDK but it does not work if you do it later.  To be nicer to users, if there are unsaved edits, ask them if they really want to close (even if they say no, we still do the backup).  Fix the typo window.unload -> window.onunload for canceling jobs.
