### PR TITLE
get plugin paths and options from prefs

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/Main.java
+++ b/core/src/main/java/com/twosigma/beaker/core/Main.java
@@ -35,8 +35,10 @@ import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.cli.GnuParser;
@@ -112,15 +114,22 @@ public class Main {
     }
   }
 
-  private static Map<String, String> getPluginOptions(CommandLine options) {
-    Map<String, String> result = new HashMap<>();
+  private static Map<String, List<String>> getPluginOptions(CommandLine options) {
+    Map<String, List<String>> result = new HashMap<>();
     if (options.hasOption("plugin-option")) {
       for (String param: options.getOptionValues("plugin-option")) {
         int x = param.indexOf(':');
         if (x < 0) {
           throw new RuntimeException("plugin option requires colon (':')");
         }
-        result.put(param.substring(0, x), param.substring(x + 1, param.length()));
+        String key = param.substring(0, x);
+        String val = param.substring(x + 1, param.length());
+        List<String> current = result.get(key);
+        if (null == current) {
+          current = new ArrayList<>();
+          result.put(key, current);
+        } 
+        current.add(val);
       }
     }
     return result;
@@ -209,7 +218,7 @@ public class Main {
       final Boolean noPasswordAllowed,
       final Integer portBase,
       final String defaultNotebookUrl,
-      final Map<String, String> pluginOptions) {
+      final Map<String, List<String>> pluginOptions) {
     return new BeakerConfigPref() {
 
       @Override
@@ -238,7 +247,7 @@ public class Main {
       }
 
       @Override
-      public Map<String, String> getPluginOptions() {
+      public Map<String, List<String>> getPluginOptions() {
         return pluginOptions;
       }
     };

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
@@ -16,6 +16,7 @@
 
 package com.twosigma.beaker.core.module.config;
 
+import java.util.List;
 import java.util.Map;
 import java.net.UnknownHostException;
 import org.json.simple.JSONObject;
@@ -154,7 +155,7 @@ public interface BeakerConfig {
    * Additional options to use when starting a plugin
    * @return
    */
-  public Map<String, String> getPluginOptions();
+  public Map<String, List<String>> getPluginOptions();
   /**
    * optional alternative environment variables a plugin should be started with
    * @return

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
@@ -18,6 +18,7 @@ package com.twosigma.beaker.core.module.config;
 
 import java.util.Map;
 import java.net.UnknownHostException;
+import org.json.simple.JSONObject;
 
 /**
  * BeakerConfig
@@ -202,4 +203,5 @@ public interface BeakerConfig {
   public String getPluginPath(String plugin);
 
   public Object getPluginPrefs();
+  public void setPluginPrefs(JSONObject prefs);
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
@@ -201,4 +201,5 @@ public interface BeakerConfig {
    */
   public String getPluginPath(String plugin);
 
+  public Object getPluginPrefs();
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
@@ -195,4 +195,10 @@ public interface BeakerConfig {
    */
   public String getSharingServerUrl();
 
+  /**
+   * Path to find a backend.
+   * @return
+   */
+  public String getPluginPath(String plugin);
+
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfigPref.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfigPref.java
@@ -16,6 +16,7 @@
 
 package com.twosigma.beaker.core.module.config;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -47,5 +48,5 @@ public interface BeakerConfigPref {
    * Gets a map of plugin starting options
    * @return
    */
-  public Map<String, String> getPluginOptions();
+  public Map<String, List<String>> getPluginOptions();
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -78,7 +78,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
   private final String hash;
   private final String gist_server;
   private final String sharing_server;
-  private final JSONObject prefs;
+  private JSONObject prefs;
 
   private String hash(String password) {
     return DigestUtils.sha512Hex(password + getPasswordSalt());
@@ -390,6 +390,10 @@ public class DefaultBeakerConfig implements BeakerConfig {
 
   public Object getPluginPrefs() {
     return this.prefs.get("plugins");
+  }
+
+  public void setPluginPrefs(JSONObject newPrefs) {
+    this.prefs = newPrefs;
   }
 
   private void augmentPluginOptions() {

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -157,6 +157,8 @@ public class DefaultBeakerConfig implements BeakerConfig {
     this.pluginOptions = pref.getPluginOptions();
     this.pluginEnvps = new HashMap<>();
 
+    augmentPluginOptions();
+
     this.publicServer = pref.getPublicServer();
     this.noPasswordAllowed = pref.getNoPasswordAllowed();
     this.authCookie = RandomStringUtils.random(40, true, true);
@@ -384,5 +386,17 @@ public class DefaultBeakerConfig implements BeakerConfig {
       // ignore
     }
     return result;
+  }
+
+  private void augmentPluginOptions() {
+    try {
+      Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("plugins");
+      for (Map.Entry<String, JSONObject> entry: plugins.entrySet()) {
+        String options = (String) entry.getValue().get("options");
+        this.pluginOptions.put(entry.getKey(), options);
+      }
+    } catch (Exception e) {
+      // ignore
+    }
   }
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -401,7 +401,9 @@ public class DefaultBeakerConfig implements BeakerConfig {
       Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("plugins");
       for (Map.Entry<String, JSONObject> entry: plugins.entrySet()) {
         String options = (String) entry.getValue().get("options");
-        this.pluginOptions.put(entry.getKey(), options);
+        if (options != null) {
+          this.pluginOptions.put(entry.getKey(), options);
+        }
       }
     } catch (Exception e) {
       // ignore

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -29,6 +29,7 @@ import java.lang.Exception;
 import java.net.UnknownHostException;
 import java.net.InetAddress;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
@@ -72,7 +73,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
   private final String recentNotebooksFileUrl;
   private final String sessionBackupDir;
   private final Map<String, String> pluginLocations;
-  private final Map<String, String> pluginOptions;
+  private final Map<String, List<String>> pluginOptions;
   private final Map<String, String[]> pluginEnvps;
   private final String version;
   private final String buildTime;
@@ -297,7 +298,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
   }
 
   @Override
-  public Map<String, String> getPluginOptions() {
+  public Map<String, List<String>> getPluginOptions() {
     return this.pluginOptions;
   }
 
@@ -397,17 +398,27 @@ public class DefaultBeakerConfig implements BeakerConfig {
     this.prefs = newPrefs;
   }
 
+  private void addOption(String plugin, String option) {
+    List<String> current = this.pluginOptions.get(plugin);
+    if (null == current) {
+      current = new ArrayList<>();
+      this.pluginOptions.put(plugin, current);
+    } 
+    current.add(option);
+  }
+
   private void augmentPluginOptions() {
     try {
       Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("plugins");
       for (Map.Entry<String, JSONObject> entry: plugins.entrySet()) {
         Object options = entry.getValue().get("options");
+        String key = entry.getKey();
         if (options != null) {
           if (options instanceof String) {
-            this.pluginOptions.put(entry.getKey(), (String) options);
+            addOption(key, (String) options);
           } else {
             for (String o : (List<String>) options) {
-              this.pluginOptions.put(entry.getKey(), o);
+              addOption(key, o);
             }
           }
         }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.lang.Exception;
 import java.net.UnknownHostException;
 import java.net.InetAddress;
 import java.nio.file.Paths;
@@ -77,6 +78,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
   private final String hash;
   private final String gist_server;
   private final String sharing_server;
+  private final JSONObject prefs;
 
   private String hash(String password) {
     return DigestUtils.sha512Hex(password + getPasswordSalt());
@@ -130,6 +132,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
         this.sharing_server = (String)obj.get("sharing_server");
     else
         this.sharing_server = "http://sharing.beakernotebook.com/gist/anonymous";
+    this.prefs = obj;
     
     final String prefDefaultNotebookUrl = pref.getDefaultNotebookUrl();
     final String mainDefaultNotebookPath = this.dotDir + "/config/default.bkr";
@@ -368,5 +371,18 @@ public class DefaultBeakerConfig implements BeakerConfig {
   @Override
   public String getSharingServerUrl() {
     return this.sharing_server;      
+  }
+
+  @Override
+  public String getPluginPath(String plugin) {
+    String result = null;
+    try {
+      JSONObject plugins = (JSONObject) this.prefs.get("plugins");
+      JSONObject pprefs = (JSONObject) plugins.get(plugin);
+      result = (String) pprefs.get("path");
+    } catch (Exception e) {
+      // ignore
+    }
+    return result;
   }
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -388,6 +388,10 @@ public class DefaultBeakerConfig implements BeakerConfig {
     return result;
   }
 
+  public Object getPluginPrefs() {
+    return this.prefs.get("plugins");
+  }
+
   private void augmentPluginOptions() {
     try {
       Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("plugins");

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -31,6 +31,7 @@ import java.net.InetAddress;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -400,9 +401,15 @@ public class DefaultBeakerConfig implements BeakerConfig {
     try {
       Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("plugins");
       for (Map.Entry<String, JSONObject> entry: plugins.entrySet()) {
-        String options = (String) entry.getValue().get("options");
+        Object options = entry.getValue().get("options");
         if (options != null) {
-          this.pluginOptions.put(entry.getKey(), options);
+          if (options instanceof String) {
+            this.pluginOptions.put(entry.getKey(), (String) options);
+          } else {
+            for (String o : (List<String>) options) {
+              this.pluginOptions.put(entry.getKey(), o);
+            }
+          }
         }
       }
     } catch (Exception e) {

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -325,7 +325,6 @@ public class PluginServiceLocatorRest {
         String path = "PATH=";
         if (envList.get(i).startsWith(path)) {
           envList.set(i, path + plugPath + ":" + envList.get(i).substring(path.length()));
-          System.out.println("XXX prepended path: " + envList.get(i));
         }
       }
     }

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -212,8 +212,10 @@ public class PluginServiceLocatorRest {
     this.corePassword = webServerConfig.getPassword();
 
     // record plugin options from cli and to pass through to individual plugins
-    for (Map.Entry<String, String> e: bkConfig.getPluginOptions().entrySet()) {
-      addPluginArgs(e.getKey(), e.getValue());
+    for (Map.Entry<String, List<String>> e: bkConfig.getPluginOptions().entrySet()) {
+      for (String arg : e.getValue()) {
+        addPluginArg(e.getKey(), arg);
+      }
     }
 
     // Add shutdown hook
@@ -529,7 +531,7 @@ public class PluginServiceLocatorRest {
     }
   }
 
-  private void addPluginArgs(String plugin, String arg) {
+  private void addPluginArg(String plugin, String arg) {
     List<String> args = this.pluginArgs.get(plugin);
     if (args == null) {
       args = new ArrayList<>();

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -595,7 +595,7 @@ public class PluginServiceLocatorRest {
     cmd.add("--profile");
     cmd.add(this.nginxServDir);
     cmd.add(pluginId);
-    Runtime.getRuntime().exec(listToArray(cmd)).waitFor();
+    Runtime.getRuntime().exec(listToArray(cmd), buildEnv(pluginId, null)).waitFor();
     String hash = hashIPythonPassword(password, pluginId, command);
     String config = this.ipythonTemplate;
     config = config.replace("%(port)s", Integer.toString(port));

--- a/core/src/main/java/com/twosigma/beaker/core/rest/UtilRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/UtilRest.java
@@ -407,4 +407,11 @@ public class UtilRest {
     return bkConfig.getPluginPrefs();
   }
 
+  @POST
+  @Path("setPluginPrefs")
+  public void setPluginPrefs(JSONObject pluginPrefs) {
+    // Merge pluginPrefs into prefs, and save the file, like the above methods do.
+    bkConfig.setPluginPrefs(pluginPrefs);
+  }
+
 }

--- a/core/src/main/java/com/twosigma/beaker/core/rest/UtilRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/UtilRest.java
@@ -400,4 +400,11 @@ public class UtilRest {
     return data;
   }
 
+  @GET
+  @Path("getPluginPrefs")
+  @Produces(MediaType.APPLICATION_JSON)
+  public Object getPluginPrefs() {
+    return bkConfig.getPluginPrefs();
+  }
+
 }

--- a/plugin/ipythonPlugins/src/dist/ipython/ipythonPlugin
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipythonPlugin
@@ -18,17 +18,6 @@ import os
 import sys
 import subprocess
 
-if sys.platform != 'win32':
-    backend = '' # XXX or whatever you gave to 'conda create'
-    backend = backend.strip()
-    if backend == '':
-        backend = "deactivate"
-    else:
-        backend = "activate " + backend
-    p = subprocess.Popen(["sh", "-c", "source " + backend + ' ; echo $PATH'], stdout=subprocess.PIPE)
-    out, err = p.communicate()
-    os.environ["PATH"] = out.strip()
-
 if len(sys.argv) > 1:
     arg1 = sys.argv[1]
     if arg1 == "--version":
@@ -42,7 +31,7 @@ if len(sys.argv) > 1:
 
 port = sys.argv.pop()
 
-# set pythonpath to include this directory so we can import beaker.py
+# set pythonpath to include this directory so we can import beaker_runtime.py
 plugin_dir = os.path.dirname(sys.argv.pop(0))
 if "PYTHONPATH" in os.environ:
     old_path = ':' + os.environ["PYTHONPATH"]

--- a/plugin/ipythonPlugins/src/dist/python3/python3Plugin
+++ b/plugin/ipythonPlugins/src/dist/python3/python3Plugin
@@ -18,18 +18,6 @@ import os
 import sys
 import subprocess
 
-#backend = '' # XXX or whatever you gave to 'conda create'
-#backend = backend.strip()
-#if backend == '':
-#    backend = "deactivate"
-#else:
-#    backend = "activate " + backend
-
-#p = subprocess.Popen(["sh", "-c", "source " + backend + ' ; echo $PATH'], stdout=subprocess.PIPE)
-#out, err = p.communicate()
-
-#os.environ["PATH"] = out.strip()
-
 if len(sys.argv) > 1:
     arg1 = sys.argv[1]
     if arg1 == "--version":
@@ -43,7 +31,7 @@ if len(sys.argv) > 1:
 
 port = sys.argv.pop()
 
-# set pythonpath to include this directory so we can import beaker.py
+# set pythonpath to include this directory so we can import beaker_runtime.py
 plugin_dir = os.path.dirname(sys.argv.pop(0))
 if "PYTHONPATH" in os.environ:
     old_path = ':' + os.environ["PYTHONPATH"]


### PR DESCRIPTION
includes adding support for multiple options per plugin, merging options from command line and prefs file, and rest endpoint for reading the prefs (and an incomplete rest endpoint for writing them).

Also strips out the hacks left in when i put in support for simultaneous python2&3, selection of the python virtual env is now done through the plugin path.

this closes Issue #1166 and several other issues, though it still needs the GUI.
