### PR TITLE
support for loading classes defined in default package

### DIFF
--- a/plugin/jvm/src/main/java/com/twosigma/beaker/jvm/classloader/JarClassLoader.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/jvm/classloader/JarClassLoader.java
@@ -286,7 +286,12 @@ public class JarClassLoader extends AbstractClassLoader {
             if (result.getPackage() == null) {
                 int lastDotIndex = className.lastIndexOf( '.' );
                 String packageName = (lastDotIndex >= 0) ? className.substring( 0, lastDotIndex) : "";
-                definePackage( packageName, null, null, null, null, null, null, null );
+
+                // Groovy scripts are sometimes defined in the default package. If these get included, 
+                // the package name is empty, but this causes an IllegalArgumentException,
+                // so skip defining the package in this case
+                if(!packageName.isEmpty())
+                    definePackage( packageName, null, null, null, null, null, null, null );
             }
 
             if (resolveIt)


### PR DESCRIPTION
I had a problem when using Groovy support if I include a JAR file that has classes defined in the default package. Although this is considered bad form in Java (and arguably in general) it's not too uncommon in Groovy when it is used as a scripting language, to end up with some classes defined in the default package. The error would be that definePackage() would throw an IllegalArgumentException because of the blank package name. This change just adds a single if() statement to prevent defining a package when the package name is blank.
