### PR TITLE
Fix: isLarge codecell assignment

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/cell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/cell-directive.js
@@ -45,7 +45,11 @@
         };
         var notebookCellOp = bkSessionManager.getNotebookCellOp();
 
-        $scope.isLarge = notebookCellOp.isLast($scope.cellmodel.id);
+        $scope.$watch(function() {
+          return notebookCellOp.isLast($scope.cellmodel.id);
+        }, function(newVal, oldVal) {
+          $scope.isLarge = newVal;
+        });
 
         $scope.cellview = {
           showDebugInfo: false,


### PR DESCRIPTION
The root of this issue, was the fact that `isLast` is a dynamic value that
changes over time. Before this fix, we were assigning the variable as a
"Static" value in the controller. By making the value dynamic with a watcher it is now updated on each digest loop, therein fixing the issue.

An interesting manifestation of this bug was that when you added a
section all of the cells were "magically" correct. This was because of
the fact that the directives were torn down and rebuilt when a new
section was added, thus fixing the bug.

Fixes #1545
