### PR TITLE
Fix CI test runs.

### DIFF
--- a/core/config/builds/dev/build.gradle
+++ b/core/config/builds/dev/build.gradle
@@ -106,6 +106,7 @@ check.dependsOn(":core:build")
 check.dependsOn(":core:installApp")
 check.dependsOn(writeVersion)
 check.dependsOn(installPlugins)
+check.dependsOn(":core:copyVendorStuff")
 check.dependsOn(":test:check")
 updatePackages.dependsOn(":core:updatePackages")
 


### PR DESCRIPTION
The tests on CI started to fail after
https://github.com/twosigma/beaker-notebook/commit/ef482e0f407aa5df208692d72d8116a3564ee22b
was merged. The real issue was the fact that requirejs was moved inside
of the bower_components vendor/ folder. Because of that change, it then
needed to be copied over during test runs. By copying it over via the
`copyVendorStuff` as part of the parent `check` gradle task, CI is now fixed.

Fixes #1533
