### PR TITLE
Allow location of Beaker server to be specified at runtime.

### DIFF
--- a/core/src/main/web/app/helpers/helper.js
+++ b/core/src/main/web/app/helpers/helper.js
@@ -296,6 +296,9 @@
       generateId: function(length) {
         return bkUtils.generateId(length);
       },
+      serverUrl: function(path) {
+        return bkUtils.serverUrl(path);
+      },
       httpGet: function(url, data) {
         return bkUtils.httpGet(url, data);
       },
@@ -381,7 +384,7 @@
 
       // eval utils
       locatePluginService: function(id, locator) {
-        return bkUtils.httpGet("../beaker/rest/plugin-services/" + id,
+        return bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/plugin-services/" + id),
             locator);
       },
       getEvaluatorFactory: function(shellConstructorPromise) {

--- a/core/src/main/web/app/mainapp/components/notebook/notebook-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/notebook-directive.js
@@ -145,7 +145,7 @@
           $.ajax({
             type: "GET",
             datatype: "json",
-            url: "../beaker/rest/outputlog/clear",
+            url: bkUtils.serverUrl("beaker/rest/outputlog/clear"),
             data: {}});
           $scope.outputLog = [];
         };
@@ -276,7 +276,7 @@
           shareMenu
         ];
 
-        bkUtils.httpGet("../beaker/rest/util/isUseAdvancedMode").success(function(isAdvanced) {
+        bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/util/isUseAdvancedMode")).success(function(isAdvanced) {
           if (_impl._viewModel.isAdvancedMode() != (isAdvanced === "true")) {
             _impl._viewModel.toggleAdvancedMode();
           }

--- a/core/src/main/web/app/utils/outputlog.js
+++ b/core/src/main/web/app/utils/outputlog.js
@@ -19,11 +19,11 @@
  */
 (function() {
   'use strict';
-  var module = angular.module('bk.outputLog', ['bk.angularUtils', 'bk.cometdUtils']);
-  module.factory('bkOutputLog', function (angularUtils, cometdUtils) {
+  var module = angular.module('bk.outputLog', ['bk.utils', 'bk.cometdUtils']);
+  module.factory('bkOutputLog', function (bkUtils, cometdUtils) {
     return {
       getLog: function (cb) {
-        angularUtils.httpGet("../beaker/rest/outputlog/get", {})
+        bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/outputlog/get"), {})
             .success(cb)
             .error(function () {
               console.log("failed to get output log");

--- a/core/src/main/web/app/utils/session.js
+++ b/core/src/main/web/app/utils/session.js
@@ -20,16 +20,16 @@
  */
 (function() {
   'use strict';
-  var module = angular.module('bk.session', ['bk.angularUtils']);
+  var module = angular.module('bk.session', ['bk.utils']);
   /**
    * bkSession
    * - talks to beaker server (/beaker/rest/session)
    * - bkSessionManager should depend on it to update/backup the session model
    */
-  module.factory('bkSession', function(angularUtils) {
+  module.factory('bkSession', function(bkUtils) {
     var backupSession = function(sessionId, sessionData) {
-      var deferred = angularUtils.newDeferred();
-      angularUtils.httpPost("../beaker/rest/session-backup/backup/" + sessionId, sessionData)
+      var deferred = bkUtils.newDeferred();
+      bkUtils.httpPost(bkUtils.serverUrl("beaker/rest/session-backup/backup/" + sessionId), sessionData)
           .success(function(data) {
             deferred.resolve();
           })
@@ -40,8 +40,8 @@
       return deferred.promise;
     };
     var getSessions = function() {
-      var deferred = angularUtils.newDeferred();
-      angularUtils.httpGet("../beaker/rest/session-backup/getExistingSessions")
+      var deferred = bkUtils.newDeferred();
+      bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/session-backup/getExistingSessions"))
           .success(function(sessions) {
             deferred.resolve(sessions);
           })
@@ -51,8 +51,8 @@
       return deferred.promise;
     };
     var loadSession = function(sessionId) {
-      var deferred = angularUtils.newDeferred();
-      angularUtils.httpGet("../beaker/rest/session-backup/load", {sessionid: sessionId})
+      var deferred = bkUtils.newDeferred();
+      bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/session-backup/load"), {sessionid: sessionId})
           .success(function(session, status) {
             deferred.resolve(session);
           })
@@ -62,8 +62,8 @@
       return deferred.promise;
     };
     var closeSession = function(sessionId) {
-      var deferred = angularUtils.newDeferred();
-      angularUtils.httpPost("../beaker/rest/session-backup/close", {sessionid: sessionId})
+      var deferred = bkUtils.newDeferred();
+      bkUtils.httpPost(bkUtils.serverUrl("beaker/rest/session-backup/close"), {sessionid: sessionId})
           .success(function(ret) {
             deferred.resolve(sessionId);
           })
@@ -73,8 +73,8 @@
       return deferred.promise;
     };
     var recordLoadedPlugin = function(pluginName, pluginUrl) {
-      angularUtils.httpPost(
-          "../beaker/rest/session-backup/addPlugin",
+      bkUtils.httpPost(
+          bkUtils.serverUrl("beaker/rest/session-backup/addPlugin"),
           {pluginname: pluginName, pluginurl: pluginUrl})
           .success(function(ret) {
             //console.log("recordLoadedPlugin");
@@ -84,8 +84,8 @@
           });
     };
     var getPlugins = function() {
-      var deferred = angularUtils.newDeferred();
-      angularUtils.httpGet("../beaker/rest/session-backup/getExistingPlugins", {})
+      var deferred = bkUtils.newDeferred();
+      bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/session-backup/getExistingPlugins"), {})
           .success(function(plugins) {
             deferred.resolve(plugins);
           })

--- a/core/src/main/web/app/utils/utils.js
+++ b/core/src/main/web/app/utils/utils.js
@@ -33,7 +33,14 @@
    */
   module.factory('bkUtils', function(commonUtils, angularUtils, bkTrack, cometdUtils) {
 
+    var serverRoot = "../";
+    function serverUrl(path) {
+      return serverRoot + path;
+    }
+
     var bkUtils = {
+      serverUrl: serverUrl,
+
       // wrap trackingService
       log: function(event, obj) {
         bkTrack.log(event, obj);
@@ -105,32 +112,35 @@
       cancelTimeout: function(promise) {
         return angularUtils.cancelTimeout(promise);  
       },
-      
+      setServerRoot: function(url) {
+        serverRoot = url;
+      },
+
       // beaker server involved utils
       getHomeDirectory: function() {
         var deferred = angularUtils.newDeferred();
-        this.httpGet("../beaker/rest/file-io/getHomeDirectory")
+        this.httpGet(serverUrl("beaker/rest/file-io/getHomeDirectory"))
             .success(deferred.resolve)
             .error(deferred.reject);
         return deferred.promise;
       },
       getVersionInfo: function() {
         var deferred = angularUtils.newDeferred();
-        this.httpGet("../beaker/rest/util/getVersionInfo")
+        this.httpGet(serverUrl("beaker/rest/util/getVersionInfo"))
             .success(deferred.resolve)
             .error(deferred.reject);
         return deferred.promise;
       },
       getStartUpDirectory: function() {
         var deferred = angularUtils.newDeferred();
-        this.httpGet("../beaker/rest/file-io/getStartUpDirectory")
+        this.httpGet(serverUrl("beaker/rest/file-io/getStartUpDirectory"))
             .success(deferred.resolve)
             .error(deferred.reject);
         return deferred.promise;
       },
       getDefaultNotebook: function() {
         var deferred = angularUtils.newDeferred();
-        angularUtils.httpGet("../beaker/rest/util/getDefaultNotebook").
+        angularUtils.httpGet(serverUrl("beaker/rest/util/getDefaultNotebook")).
             success(function(data) {
               deferred.resolve(angular.fromJson(data));
             }).
@@ -148,7 +158,7 @@
       },
       loadFile: function(path) {
         var deferred = angularUtils.newDeferred();
-        angularUtils.httpGet("../beaker/rest/file-io/load", {path: path})
+        angularUtils.httpGet(serverUrl("beaker/rest/file-io/load"), {path: path})
             .success(function(content) {
               if (!_.isString(content)) {
                 // angular $http auto-detects JSON response and deserialize it using a JSON parser
@@ -160,9 +170,10 @@
             .error(deferred.reject);
         return deferred.promise;
       },
+
       loadHttp: function(url) {
         var deferred = angularUtils.newDeferred();
-        angularUtils.httpGet("../beaker/rest/http-proxy/load", {url: url})
+        angularUtils.httpGet(serverUrl("beaker/rest/http-proxy/load"), {url: url})
             .success(function(content) {
               if (!_.isString(content)) {
                 // angular $http auto-detects JSON response and deserialize it using a JSON parser
@@ -177,11 +188,11 @@
       saveFile: function(path, contentAsJson, overwrite) {
         var deferred = angularUtils.newDeferred();
         if (overwrite) {
-          angularUtils.httpPost("../beaker/rest/file-io/save", {path: path, content: contentAsJson})
+          angularUtils.httpPost(serverUrl("beaker/rest/file-io/save"), {path: path, content: contentAsJson})
               .success(deferred.resolve)
               .error(deferred.reject);
         } else {
-          angularUtils.httpPost("../beaker/rest/file-io/saveIfNotExists", {path: path, content: contentAsJson})
+          angularUtils.httpPost(serverUrl("beaker/rest/file-io/saveIfNotExists"), {path: path, content: contentAsJson})
               .success(deferred.resolve)
               .error(function(data, status, header, config) {
                 if (status === 409) {

--- a/embeddable_assets/beakerApp.js
+++ b/embeddable_assets/beakerApp.js
@@ -7036,7 +7036,7 @@ return __p
           $.ajax({
             type: "GET",
             datatype: "json",
-            url: "../beaker/rest/outputlog/clear",
+            url: bkUtils.serverUrl("beaker/rest/outputlog/clear"),
             data: {}});
           $scope.outputLog = [];
         };
@@ -7163,7 +7163,7 @@ return __p
           shareMenu
         ];
 
-        bkUtils.httpGet("../beaker/rest/util/isUseAdvancedMode").success(function(isAdvanced) {
+        bkUtils.httpGet(bkUtils.serverUrl("beaker/rest/util/isUseAdvancedMode")).success(function(isAdvanced) {
           if (_impl._viewModel.isAdvancedMode() != (isAdvanced === "true")) {
             _impl._viewModel.toggleAdvancedMode();
           }


### PR DESCRIPTION
In cases where Beaker is embedded in an application where the user
is provisioned a server after having already logged in, this lets us
at any point control where beaker server requests are sent, without
impacting other Ajax requests made by the embedding application.
