### PR TITLE
style: Fix markdown output overlap with menu.

### DIFF
--- a/core/src/main/web/app/styles/cell-outputs.scss
+++ b/core/src/main/web/app/styles/cell-outputs.scss
@@ -56,6 +56,14 @@ bk-code-cell-output {
   .bk-section-title & {
     min-height: 1em;
   }
+
+  p:before {
+    content: ' ';
+    display: block;
+    float: right;
+    height: 10px;
+    width: 79px;
+  }
 }
 
 .modal.output-table-options {


### PR DESCRIPTION
The issue, was the fact that we have horizontal menu of cell actions
that are absolutely positioned on top of the output cell. Due to the
positioning the menu, the markdown cell output did not flow around the menu
element, thus causing a visual overlap. The CSS2 spec did introduce the
concept of a `::first-line` pseudo selector, however the rules that can be
applied are limited to a small subset of css rules [1]. None of which
can limit the width of the first line. The solution that I opted for
instead was to take advantage of a CSS3 pseudo selector `:before` to
insert a "fake" element that takes up the same size as the menu that is
out of the flow. into the output element to cause the output text
to reflow around

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/::first-line

Fixes #1532

---
#### Visualizing the pseudo element

![screen shot 2015-05-06 at 9 34 52 am](https://cloud.githubusercontent.com/assets/883126/7495135/05862f90-f3da-11e4-8806-c3f8e4336eb8.png)
#### Applied

![screen shot 2015-05-06 at 9 53 12 am](https://cloud.githubusercontent.com/assets/883126/7495145/12dc4f76-f3da-11e4-90b4-f8402e9cc0ea.png)
