### PR TITLE
Allow users to enter an escaped $

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
@@ -43,6 +43,11 @@
     return out;
   };
 
+  bkRenderer.paragraph = function(text) {
+    // Allow users to write \$ to escape $
+    return marked.Renderer.prototype.paragraph.call(this, text.replace(/\\\$/g, '$'));
+  };
+
   var module = angular.module('bk.notebook');
   module.directive('bkMarkdownEditable', ['bkSessionManager', 'bkHelper', 'bkCoreManager', '$timeout', function(bkSessionManager, bkHelper, bkCoreManager, $timeout) {
     var notebookCellOp = bkSessionManager.getNotebookCellOp();

--- a/test/tests/beaker.po.js
+++ b/test/tests/beaker.po.js
@@ -25,6 +25,20 @@ var BeakerPageObject = function () {
     browser.actions().mouseDown().mouseUp().perform();
   };
 
+  this.createMarkdownCell = function(text) {
+    element(by.css('bk-new-cell-menu .dropdown-toggle'))
+    .click()
+    .then(function() {
+      return element(by.css('a[ng-click="newMarkdownCell()"]'));
+    })
+    .then(function(el) {
+      return el.click();
+    })
+    .then(function() {
+      return this.setCellInput(text);
+    }.bind(this));
+  }.bind(this);
+
   this.newEmptyNotebook = element(by.className('new-empty-notebook'));
 
   this.fileMenu = element(by.className('file-menu'));
@@ -49,6 +63,20 @@ var BeakerPageObject = function () {
       return deferred.promise;
     }.bind(this));
   };
+
+  this.readMarkdownCell = function() {
+    return element(by.css('body'))
+    .then(function(el) {
+      // click on the body to refocus editor
+      return el.click();
+    })
+    .then(function() {
+      return element(by.css('.markup p'))
+    })
+    .then(function(el) {
+      return el.getText();
+    });
+ }
 
   this.languageManager = element(by.className('plugin-manager'));
   this.languageManagerButtonKnown = function(language) {

--- a/test/tests/notebook.js
+++ b/test/tests/notebook.js
@@ -75,4 +75,18 @@ describe('notebook', function () {
     done();
   });
 
+  it('can handle escaping $ in markdown', function(done) {
+    beakerPO.newEmptyNotebook.click()
+    .then(function() {
+      return beakerPO.createMarkdownCell('hello world \\$');
+    })
+    .then(function() {
+      return beakerPO.readMarkdownCell();
+    }.bind(this))
+    .then(function(txt) {
+      expect(txt).toEqual('hello world $');
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Before this fix `\$` was shown as `\$` in the markdown output.
As part of the parsing step for marked we are now replacing instances of
`\$` with `$`. This step runs after the katex interpolation so there is
no need to be concerned with the `$` being interpolated into a new LateX
section.

Fixes #1428
