### PR TITLE
style: Fix extra whitespace on some output cells

### DIFF
--- a/core/src/main/web/app/styles/cell-outputs.scss
+++ b/core/src/main/web/app/styles/cell-outputs.scss
@@ -24,13 +24,6 @@ bk-code-cell-output {
   }
 }
 
-.advanced-mode bk-output-display[type="Html"] {
-  padding-top: 10px;
-  display: block;
-  margin-top: 8px;
-  position: relative;
-}
-
 .advanced-mode bk-output-display.bkr {
   min-height: 20px;
 }


### PR DESCRIPTION
Styles initially added here:
https://github.com/twosigma/beaker-notebook/issues/586

in 9574ddd224225020120ada0400a8ea8a482a0616

Refactored in

6a2bd6d246cdbb88895e2f1e5027134b125f8569

Which caused this breakage

Fixes #1566
