### PR TITLE
Ensure initial input output cells are = height

### DIFF
--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -115,7 +115,6 @@ bk-section-cell {
         padding: $grid-row-height $grid-gutter-width;
         position: relative;
         border-top: solid 1px #CCC;
-        min-height: #{$line-height-base}em;
         box-sizing: content-box;
 
         .out_error {
@@ -150,6 +149,7 @@ bk-output-display pre {
     border:     none;
     margin:     0;
     padding:    0;
+    line-height: 1;
     background: transparent;
 }
 


### PR DESCRIPTION
#### Before

![screen shot 2015-05-07 at 2 38 14 pm](https://cloud.githubusercontent.com/assets/883126/7524719/f56b3b84-f4d1-11e4-8018-d9bfaff75f9b.png)
![screen shot 2015-05-07 at 2 38 18 pm](https://cloud.githubusercontent.com/assets/883126/7524721/f936e6c8-f4d1-11e4-8dff-cba6663b55eb.png)
#### After

![screen shot 2015-05-07 at 3 47 08 pm](https://cloud.githubusercontent.com/assets/883126/7524726/03142a5c-f4d2-11e4-963e-3168738b55e4.png)

![screen shot 2015-05-07 at 3 47 13 pm](https://cloud.githubusercontent.com/assets/883126/7524724/01173276-f4d2-11e4-8c05-c569f3a0d82a.png)

The root of this cause was a base line height rule being applied to
single outputs and to the entire body. Epic editor however overrides
line-height with a more specific CSS rule, thus the base body line-height
no longer applies, thus causing a difference in empty inline element
heights.

line-height initially changed in a50414819dbba547b4f8ef7ba639f95bc2bcb90d
For: https://github.com/twosigma/beaker-notebook/issues/1360

Fixes #1565
