### PR TITLE
Fix vertical jump on single line headlines.

### DIFF
--- a/core/src/main/web/app/styles/hierarchy.scss
+++ b/core/src/main/web/app/styles/hierarchy.scss
@@ -46,6 +46,7 @@
   }
 
   .depth-indicator {
+    vertical-align: top;
     display: inline-block;
   }
 
@@ -58,6 +59,7 @@
   .bk-section-title {
     top: 5px;
     position: relative;
+    vertical-align: top;
     display: inline-block;
   }
 }


### PR DESCRIPTION
By enforcing that the content is aligned to the top of the inline-block
container there is no shift between the output mode and edit mode for
single lines of content.
