### PR TITLE
add scss source maps

### DIFF
--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -36,6 +36,7 @@ var plugins = require('gulp-load-plugins');
 var htmlbuild = require('gulp-htmlbuild');
 var es = require('event-stream');
 var fs = require('fs');
+var sourcemaps = require('gulp-sourcemaps');
 
 var srcPath  = Path.join(__dirname, "/src/main/web/");
 var vendorPath  = Path.join(__dirname, "/src/");
@@ -130,10 +131,12 @@ gulp.task("buildSingleOutDispJs", function() {
 
 gulp.task("compileBeakerScss", function() {
   return gulp.src(Path.join(rootPath, "**.scss"))
+  .pipe(sourcemaps.init())
   .pipe(sass().on('error', handleError))
   .pipe(importCss())
   .pipe(stripCssComments())
-  .pipe(gulp.dest(tempPath))
+  .pipe(sourcemaps.write())
+  .pipe(gulp.dest(tempPath));
 });
 
 gulp.task('prepareCssForNamespacing', function(){

--- a/core/package.json
+++ b/core/package.json
@@ -29,6 +29,7 @@
     "gulp-rename": "",
     "gulp-replace": "",
     "run-sequence": "",
+    "gulp-sourcemaps": "^1.5.2",
     "html-classer-gulp": "0.0.2",
     "gulp-load-plugins" : "",
     "event-stream" : "",


### PR DESCRIPTION
Styles are sometimes very hard to debug

![screen shot 2015-05-11 at 1 55 55 pm](https://cloud.githubusercontent.com/assets/883126/7571547/43bdd3c0-f7e6-11e4-9dbb-4d7cead2488f.png)

source maps makes the origin scss easy to find
