### PR TITLE
Lazily instantiate codemirror instances

### DIFF
--- a/core/bower.json
+++ b/core/bower.json
@@ -23,6 +23,7 @@
     "marked": "~0.3.3",
     "acorn": "0.3.1",
     "katex-build": "~0.3.0",
-    "scrollin": "~0.1.4"
+    "scrollin": "~0.1.4",
+    "rAF": "https://gist.githubusercontent.com/paulirish/1579671/raw/3d42a3a76ed09890434a07be2212f376959e616f/rAF.js"
   }
 }

--- a/core/bower.json
+++ b/core/bower.json
@@ -22,6 +22,7 @@
     "big.js": "~2.5.1",
     "marked": "~0.3.3",
     "acorn": "0.3.1",
-    "katex-build": "~0.3.0"
+    "katex-build": "~0.3.0",
+    "scrollin": "~0.1.4"
   }
 }

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -56,7 +56,7 @@
         $scope.isError = function() {
           //jscs:disable
           if ($scope.cellmodel === undefined || $scope.cellmodel.output === undefined || $scope.cellmodel.output.result === undefined) {
-          //jscs:enable
+            //jscs:enable
             return false;
           }
 
@@ -342,11 +342,14 @@
           }
         });
 
-        scope.cm = CodeMirror.fromTextArea(element.find('textarea')[0], codeMirrorOptions);
+        Scrollin.track(element[0], {handler: function() {
+          scope.cm = CodeMirror.fromTextArea(element.find('textarea')[0], codeMirrorOptions);
+          scope.bkNotebook.registerCM(scope.cellmodel.id, scope.cm);
+          scope.cm.on('change', changeHandler);
+        }});
 
         scope.updateUI(scope.getEvaluator());
         scope.bkNotebook.registerFocusable(scope.cellmodel.id, scope);
-        scope.bkNotebook.registerCM(scope.cellmodel.id, scope.cm);
 
         // cellmodel.body --> CodeMirror
         scope.$watch('cellmodel.input.body', function(newVal, oldVal) {
@@ -369,8 +372,6 @@
             }
           }
         };
-
-        scope.cm.on('change', changeHandler);
 
         var inputMenuDiv = element.find('.bkcell').first();
         scope.popupMenu = function(event) {
@@ -417,6 +418,7 @@
         });
 
         scope.$on('$destroy', function() {
+          Scrollin.untrack(element[0]);
           CodeMirror.off(window, 'resize', resizeHandler);
           CodeMirror.off('change', changeHandler);
           scope.bkNotebook.unregisterFocusable(scope.cellmodel.id);

--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -22,6 +22,14 @@
     background: transparent;
 }
 
+.bkcelltextarea {
+    border: none;
+    resize: none;
+    font-family: monospace;
+    padding-top: 19px;
+    padding-left: 29px;
+}
+
 .mini-cell-stats {
     top: 22px;
     left: 20px;

--- a/core/src/main/web/app/template/index_template.html
+++ b/core/src/main/web/app/template/index_template.html
@@ -93,6 +93,7 @@
   <script src="vendor/cometd/jquery/jquery.cometd.js"></script>
   <script src="vendor/jquery.event.drag/jquery.event.drag.js"></script>
   <script src="vendor/jquery-ui/js/jquery-ui.custom.min.js"></script>
+  <script src="vendor/bower_components/rAF/index.js"></script>
   <script src="vendor/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
   <script src="vendor/bower_components/bootstrap-sass/assets/javascripts/bootstrap.js"></script>
   <script src="vendor/moment/moment-with-locales.min.js"></script>

--- a/core/src/main/web/app/template/index_template.html
+++ b/core/src/main/web/app/template/index_template.html
@@ -86,6 +86,7 @@
   <script src="vendor/bower_components/codemirror/keymap/emacs.js"></script>
   <script src="vendor/bower_components/acorn/acorn.js"></script>
   <script src="vendor/bower_components/q/q.js"></script>
+  <script src="vendor/bower_components/scrollin/dist/index.js"></script>
   <script src="vendor/bower_components/underscore.string/lib/underscore.string.js"></script>
   <script src="vendor/angular-ui/ui-utils.min.js"></script>
   <script src="vendor/cometd/cometd.js"></script>


### PR DESCRIPTION
By taking advantage of the fact that a user can not interact
with a codemirror instance until the editor is in the viewport, we can be
smart and only set the codemirror editors up once a user scrolls them into view.

For small notebooks this change has a limited impact, however for large
notebooks with 100s of code cells this change results in a significant
performance boost to the application, especially in the initial time to
render metric for notebooks.

---

**Tested With http://nbviewer.ipython.org/url/norvig.com/ipython/TSPv3.ipynb**
##### Initial setup work
- Download the ipython notebook
- Convert to a beaker notebook
- Save to filesystem
#### Testing Process
- Start the profiler
- Open the bkr notebook 
- Once the initial map paints, stop the profiler

![screen shot 2015-05-14 at 2 31 40 pm](https://cloud.githubusercontent.com/assets/883126/7638882/f71f0982-fa45-11e4-90d3-b26bdf6fcce0.png)

![screen shot 2015-05-14 at 2 31 57 pm](https://cloud.githubusercontent.com/assets/883126/7638889/0069c0f4-fa46-11e4-82c1-a9f0ab1ae81f.png)

_[Source analysis](https://docs.google.com/spreadsheets/d/1QQ9uWVikhvgqPdwvO03B5WnJkac3507uiBWPAwBDpl4/edit#gid=0)_

---

**Ref** #1546
**Fixes** #178
