### PR TITLE
Fix y axis overflow scrollbar on output

### DIFF
--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -157,6 +157,7 @@ bk-output-display pre {
     border:     none;
     margin:     0;
     padding:    0;
+    overflow:   visible;
     line-height: 1;
     background: transparent;
 }


### PR DESCRIPTION
This was caused by a discrepancy between the line height of the pre and
the line height of the containing element. Due to this, there was an
overflow that defaulted to auto, instead we just set it to visible to
prevent scrollbars.
