### PR TITLE
Import fonts in embedded beaker globally

### DIFF
--- a/core/beaker-sandbox.scss
+++ b/core/beaker-sandbox.scss
@@ -1,3 +1,9 @@
+// Declare fonts globally
+@import "src/main/web/app/styles/variables";
+@import "src/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "src/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
+@import "src/vendor/bower_components/font-awesome/css/font-awesome.css";
+
 .beaker-sandbox {
   @import "src/main/web/app/temp/namespacedCss/beakerApp";
   @import "src/main/web/app/temp/namespacedCss/beakerOutputDisplay";


### PR DESCRIPTION
Don't namespace in .beaker-sandbox, because @font-face declarations
inside selectors don't work.
