### PR TITLE
Import fonts in embedded beaker globally

### DIFF
--- a/core/beaker-sandbox.scss
+++ b/core/beaker-sandbox.scss
@@ -1,3 +1,9 @@
+// Declare fonts globally
+@import "src/main/web/app/styles/variables";
+@import "src/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "src/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
+@import "src/vendor/bower_components/font-awesome/css/font-awesome";
+
 .beaker-sandbox {
   @import "src/main/web/app/temp/namespacedCss/beakerApp";
   @import "src/main/web/app/temp/namespacedCss/beakerOutputDisplay";

--- a/core/package.json
+++ b/core/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "gulp": "^3.8.2",
     "yargs" : "",
-    "gulp-sass": "^1.2.4",
+    "gulp-sass": "^2.0.1",
     "gulp-minify-css": "0.3.5",
     "gulp-uglify": "",
     "gulp-template-compile": "^0.2.0",


### PR DESCRIPTION
Don't namespace in .beaker-sandbox, because @font-face declarations
inside selectors don't work.
