### PR TITLE
Fix Issue #1600.  Unable to repro with this change, but we should kee…

### DIFF
--- a/core/nginx/nginx.conf.template
+++ b/core/nginx/nginx.conf.template
@@ -1,4 +1,4 @@
-worker_processes  4;
+worker_processes  1;
 daemon off;
 error_log  "%(nginx_dir)s/logs/nginx.log" error;
 pid nginx.pid;


### PR DESCRIPTION
…p an eye on this one.  I believe the problem is that even though we query nginx to confirm that it has updated its configuration, if there are multiple worker threads then it is possible the test query is satisfied by one, but another worker has yet to reload when it gets the getShell REST call.  I do not see a convenient way to confirm reload is complete, and i am not aware of a substantial benefit to multiple workers so seems just going back to one worker is the best solution.
