### PR TITLE
Fix padding application on language picker.

### DIFF
--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -20,6 +20,11 @@
 
 .bkcell .CodeMirror {
     background: transparent;
+    padding-top: $grid-row-height;
+}
+
+.advanced-mode .bkcell .CodeMirror {
+  padding-top: 0;
 }
 
 .bkcelltextarea {
@@ -79,7 +84,6 @@ bk-markdown-cell .markup
     float:          left;
     z-index:        99;
     position:       relative;
-    padding-bottom: $grid-row-height;
 }
 
 bk-cell > .bkcell {


### PR DESCRIPTION
Prior to this change, we were using the language picker to apply padding
to the code editor. This choice lead to a css bug with the right menu in
advanced mode (the height being too large).

The fix in this case was to change the padding rule to be on the editor
node as compared to a node that happens to be near to it.

Made visible in 5d8677459665703a59992cb199164d2f174561ea

Code initally added in dba4979368193a37886420117ca77e45d17f114f

---
##### Before

![screen shot 2015-06-01 at 9 24 35 am](https://cloud.githubusercontent.com/assets/883126/7914612/20b9cc9c-0846-11e5-9eb8-021c8744395b.png)
##### After

![screen shot 2015-06-01 at 9 24 39 am](https://cloud.githubusercontent.com/assets/883126/7914614/24049c1a-0846-11e5-9f9b-2929cf60dd15.png)

Fixes #1682
