### PR TITLE
Fix focusing of new cells.

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -349,6 +349,12 @@
           scope.bkNotebook.registerCM(scope.cellmodel.id, scope.cm);
           scope.cm.on('change', changeHandler);
           scope.updateUI(scope.getEvaluator());
+          // Since the instantiation of codemirror instances is now lazy,
+          // we need to track and handle focusing on an async cell add
+          if (scope._shouldFocusCodeMirror) {
+            delete scope._shouldFocusCodeMirror;
+            return scope.cm.focus();
+          }
         }});
 
         scope.bkNotebook.registerFocusable(scope.cellmodel.id, scope);
@@ -407,7 +413,11 @@
 
         scope.$on('beaker.cell.added', function(e, cellmodel) {
           if (cellmodel === scope.cellmodel) {
-            scope.cm && scope.cm.focus();
+            if (scope.cm) {
+              return scope.cm.focus();
+            }
+
+            scope._shouldFocusCodeMirror = true;
           }
         });
 


### PR DESCRIPTION
This bug was introduced in 632880f4bce4af8cb14817e1fb68d632fb193525.

The reason why this happened was because since we lazily instantiate
each codemirror instance we can not focus it right away (since it is
not yet created).

By setting some intermediate state on the codecell scope, we can then
hook into it when the cell enters the viewport and is created.

---

Fixes #1680
