### PR TITLE
Remove unreachable code in markdowncell

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/markdowncell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/markdowncell-directive.js
@@ -27,11 +27,6 @@
         bkCoreManager,
         $timeout) {
 
-        var notebookCellOp = bkSessionManager.getNotebookCellOp();
-        var getBkNotebookWidget = function() {
-          return bkCoreManager.getBkApp().getBkNotebookWidget();
-        };
-
         return {
           restrict: 'E',
           template: JST['mainapp/components/notebook/markdowncell'](),


### PR DESCRIPTION
This code was refactored in 1112647a69a8e9d9e0c5b71ab8a733fcb53eeee0
and was never removed.
