### PR TITLE
Fixed issue #1689: Used correct target URL for command-click on brand…

### DIFF
--- a/core/nginx/nginx.conf.template
+++ b/core/nginx/nginx.conf.template
@@ -74,6 +74,7 @@ http {
       proxy_set_header Authorization "Basic %(auth)s";
     }
     location = /%(urlhash)s/beaker/ {
+      autoindex off;
       return 301 %(start_page)s;
     }
 

--- a/core/nginx/nginx.conf.template
+++ b/core/nginx/nginx.conf.template
@@ -74,7 +74,6 @@ http {
       proxy_set_header Authorization "Basic %(auth)s";
     }
     location = /%(urlhash)s/beaker/ {
-      autoindex off;
       return 301 %(start_page)s;
     }
 

--- a/core/src/main/web/app/controlpanel/controlpanel-directive.js
+++ b/core/src/main/web/app/controlpanel/controlpanel-directive.js
@@ -36,7 +36,7 @@
 
         $scope.gotoControlPanel = function(event) {
           if (bkUtils.isMiddleClick(event)) {
-            window.open("./");
+            window.open("../../");
           } else {
             location.reload();
           }

--- a/core/src/main/web/app/controlpanel/controlpanel-directive.js
+++ b/core/src/main/web/app/controlpanel/controlpanel-directive.js
@@ -19,7 +19,7 @@
   var module = angular.module('bk.controlPanel');
 
   module.directive('bkControlPanel', function(
-      bkUtils, bkCoreManager, bkSession, bkMenuPluginManager, bkTrack) {
+      bkUtils, bkCoreManager, bkSession, bkMenuPluginManager, bkTrack, $location) {
     return {
       restrict: 'E',
       template: JST["controlpanel/controlpanel"](),
@@ -36,7 +36,7 @@
 
         $scope.gotoControlPanel = function(event) {
           if (bkUtils.isMiddleClick(event)) {
-            window.open("../../");
+            window.open($location.absUrl() + '/beaker');
           } else {
             location.reload();
           }

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -1044,7 +1044,7 @@
         startAutoBackup();
         $scope.gotoControlPanel = function(event) {
           if (bkUtils.isMiddleClick(event)) {
-            window.open("./");
+	    window.open($location.absUrl() + '/beaker');
           } else {
             bkCoreManager.gotoControlPanel();
           }

--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -1044,7 +1044,7 @@
         startAutoBackup();
         $scope.gotoControlPanel = function(event) {
           if (bkUtils.isMiddleClick(event)) {
-	    window.open($location.absUrl() + '/beaker');
+            window.open($location.absUrl() + '/beaker');
           } else {
             bkCoreManager.gotoControlPanel();
           }


### PR DESCRIPTION
… logo. Turned off 'autoindex' (directory listing) on nginx at (urlhash)s/beaker. Not sure why this was necessary, since 'autoindex' was already off at the root of the config file.
