### PR TITLE
fix race condition in jetty plugin starts

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -380,6 +380,7 @@ public class PluginServiceLocatorRest {
       @QueryParam("startedIndicator") String startedIndicator,
       @QueryParam("startedIndicatorStream") @DefaultValue("stdout") String startedIndicatorStream,
       @QueryParam("recordOutput") @DefaultValue("false") boolean recordOutput,
+      @QueryParam("readyUrl") String readyUrl,
       @QueryParam("waitfor") String waitfor)
       throws InterruptedException, IOException {
       
@@ -475,12 +476,11 @@ public class PluginServiceLocatorRest {
     try {
       spinCheck(url, null);
 
-      if (!nginxRules.startsWith("ipython")) {
-        // check that jetty is really ready
-        String url2 = "http://127.0.0.1:" + pConfig.port + "/rest/ready/ready";
+      if (null != readyUrl) {
+        // confirm the backend is really ready
+        String url2 = "http://127.0.0.1:" + pConfig.port + readyUrl;
         String account = "beaker:" + pConfig.password;
         String auth = "Basic " + Base64.encodeBase64String(account.getBytes());
-        System.err.println("spin check " + url2 + " " + auth);
         spinCheck(url2, auth);
       }
 
@@ -529,6 +529,7 @@ public class PluginServiceLocatorRest {
     int totalTime = 0;
     
     while (totalTime < RESTART_ENSURE_RETRY_MAX_WAIT) {
+      System.err.println(url + " spinning... " + totalTime);
       Request get = Request.Get(url);
       if (null != auth) {
         get = get.addHeader("Authorization", auth);

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -473,10 +473,19 @@ public class PluginServiceLocatorRest {
     // check that nginx did actually restart
     String url = "http://127.0.0.1:" + this.restartPort + "/restart." + restartId + "/present.html";
     try {
-      spinCheck(url);
-      Thread.sleep(1000); // XXX unknown race condition
+      spinCheck(url, null);
+
+      if (!nginxRules.startsWith("ipython")) {
+        // check that jetty is really ready
+        String url2 = "http://127.0.0.1:" + pConfig.port + "/rest/ready/ready";
+        String account = "beaker:" + pConfig.password;
+        String auth = "Basic " + Base64.encodeBase64String(account.getBytes());
+        System.err.println("spin check " + url2 + " " + auth);
+        spinCheck(url2, auth);
+      }
+
     } catch (Throwable t) {
-      System.err.println("Nginx restart time out plugin =" + pluginId);
+      System.err.println("time out plugin =" + pluginId);
       this.plugins.remove(pluginId);
       if (windows()) {
         new WinProcess(proc).killRecursively();
@@ -484,7 +493,9 @@ public class PluginServiceLocatorRest {
         proc.destroy(); // send SIGTERM
       }
       throw new NginxRestartFailedException("nginx restart failed.\n" + "url=" + url + "\n" + "message=" + t.getMessage());
-    }   
+    }
+
+
 
     pConfig.setProcess(proc);
     System.out.println("Done starting " + pluginId);
@@ -510,7 +521,7 @@ public class PluginServiceLocatorRest {
         .build();
   }
 
-  private static boolean spinCheck(String url)
+  private static boolean spinCheck(String url, String auth)
       throws IOException, InterruptedException
   {
 
@@ -518,11 +529,11 @@ public class PluginServiceLocatorRest {
     int totalTime = 0;
     
     while (totalTime < RESTART_ENSURE_RETRY_MAX_WAIT) {
-      if (Request.Get(url)
-          .execute()
-          .returnResponse()
-          .getStatusLine()
-          .getStatusCode() == HttpStatus.SC_OK) {
+      Request get = Request.Get(url);
+      if (null != auth) {
+        get = get.addHeader("Authorization", auth);
+      }
+      if (get.execute().returnResponse().getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
         return true;
       }
       Thread.sleep(interval);
@@ -531,7 +542,7 @@ public class PluginServiceLocatorRest {
       if (interval > RESTART_ENSURE_RETRY_MAX_INTERVAL)
         interval = RESTART_ENSURE_RETRY_MAX_INTERVAL;
     }
-    throw new RuntimeException("Spin check timed out");
+    throw new RuntimeException("Spin check timed out: " + url);
   }
 
   private static class PluginServiceNotFoundException extends WebApplicationException {

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -495,8 +495,6 @@ public class PluginServiceLocatorRest {
       throw new NginxRestartFailedException("nginx restart failed.\n" + "url=" + url + "\n" + "message=" + t.getMessage());
     }
 
-
-
     pConfig.setProcess(proc);
     System.out.println("Done starting " + pluginId);
 

--- a/plugin/clojure/src/dist/clojure.js
+++ b/plugin/clojure/src/dist/clojure.js
@@ -155,7 +155,8 @@ define(function(require, exports, module) {
       command: COMMAND,
       startedIndicator: "Server started",
       waitfor: "Started SelectChannelConnector",
-      recordOutput: "true"
+      recordOutput: "true",
+      readyUrl: "/rest/ready/ready"
     }).success(function(ret) {
       serviceBase = ret;
       if (window.languageServiceBase == undefined) {

--- a/plugin/clojure/src/main/java/com/twosigma/beaker/clojure/module/URLConfigModule.java
+++ b/plugin/clojure/src/main/java/com/twosigma/beaker/clojure/module/URLConfigModule.java
@@ -18,6 +18,7 @@ package com.twosigma.beaker.clojure.module;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.twosigma.beaker.clojure.rest.ClojureShellRest;
+import com.twosigma.beaker.jvm.rest.ReadyRest;
 import com.twosigma.beaker.shared.servlet.GuiceCometdServlet;
 
 import java.util.HashMap;
@@ -49,5 +50,6 @@ public class URLConfigModule extends ServletModule {
 
     // REST binding
     bind(ClojureShellRest.class);
+    bind(ReadyRest.class);
   }
 }

--- a/plugin/groovy/src/dist/groovy.js
+++ b/plugin/groovy/src/dist/groovy.js
@@ -173,6 +173,7 @@ define(function(require, exports, module) {
       command: COMMAND,
       startedIndicator: "Server started",
       waitfor: "Started SelectChannelConnector",
+      readyUrl: "/rest/ready/ready",
       recordOutput: "true"
     }).success(function(ret) {
       serviceBase = ret;

--- a/plugin/groovy/src/main/java/com/twosigma/beaker/groovy/module/URLConfigModule.java
+++ b/plugin/groovy/src/main/java/com/twosigma/beaker/groovy/module/URLConfigModule.java
@@ -16,6 +16,7 @@
 package com.twosigma.beaker.groovy.module;
 
 import com.twosigma.beaker.groovy.rest.GroovyShellRest;
+import com.twosigma.beaker.jvm.rest.ReadyRest;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.twosigma.beaker.shared.servlet.GuiceCometdServlet;
@@ -47,5 +48,6 @@ public class URLConfigModule extends ServletModule {
 
     // REST binding
     bind(GroovyShellRest.class);
+    bind(ReadyRest.class);
   }
 }

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -397,8 +397,9 @@ define(function(require, exports, module) {
       bkHelper.locatePluginService(PLUGIN_NAME, {
         command: COMMAND,
         nginxRules: (ipyVersion == '1') ? "ipython1" : "ipython2",
-            startedIndicator: "NotebookApp] The IPython Notebook is running at: http://127.0.0.1:",
-            startedIndicatorStream: "stderr"
+        startedIndicator: "NotebookApp] The IPython Notebook is running at: http://127.0.0.1:",
+        startedIndicatorStream: "stderr",
+        readyUrl: "/api/sessions"
       }).success(function(ret) {
         serviceBase = ret;
         var IPythonShell = function(settings, doneCB) {

--- a/plugin/ipythonPlugins/src/dist/iruby/iruby.js
+++ b/plugin/ipythonPlugins/src/dist/iruby/iruby.js
@@ -357,7 +357,8 @@ define(function(require, exports, module) {
         command: COMMAND,
         nginxRules: (ipyVersion == '1') ? "ipython1" : "ipython2",
         startedIndicator: "NotebookApp] The IPython Notebook is running at: http://127.0.0.1:",
-        startedIndicatorStream: "stderr"
+        startedIndicatorStream: "stderr",
+        readyUrl: "/api/sessions"
       }).success(function(ret) {
         serviceBase = ret;
         var IRubyShell = function(settings, doneCB) {

--- a/plugin/ipythonPlugins/src/dist/julia/julia.js
+++ b/plugin/ipythonPlugins/src/dist/julia/julia.js
@@ -357,7 +357,8 @@ define(function(require, exports, module) {
         command: COMMAND,
         nginxRules: (ipyVersion == '1') ? "ipython1" : "ipython2",
         startedIndicator: "NotebookApp] The IPython Notebook is running at: http://127.0.0.1:",
-        startedIndicatorStream: "stderr"
+        startedIndicatorStream: "stderr",
+        readyUrl: "/api/sessions"
       }).success(function(ret) {
         serviceBase = ret;
         var JuliaShell = function(settings, doneCB) {

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -397,7 +397,8 @@ define(function(require, exports, module) {
         command: COMMAND,
         nginxRules: (ipyVersion == '1') ? "ipython1" : "ipython2",
         startedIndicator: "NotebookApp] The IPython Notebook is running at: http://127.0.0.1:",
-        startedIndicatorStream: "stderr"
+        startedIndicatorStream: "stderr",
+        readyUrl: "/api/sessions"
       }).success(function(ret) {
         serviceBase = ret;
         var Python3Shell = function(settings, doneCB) {

--- a/plugin/javash/src/dist/javash.js
+++ b/plugin/javash/src/dist/javash.js
@@ -172,7 +172,8 @@ define(function(require, exports, module) {
       command: COMMAND,
       startedIndicator: "Server started",
       waitfor: "Started SelectChannelConnector",
-      recordOutput: "true"
+      recordOutput: "true",
+      readyUrl: "/rest/ready/ready"
     }).success(function(ret) {
       serviceBase = ret;
       if (window.languageServiceBase == undefined) {

--- a/plugin/javash/src/main/java/com/twosigma/beaker/javash/module/URLConfigModule.java
+++ b/plugin/javash/src/main/java/com/twosigma/beaker/javash/module/URLConfigModule.java
@@ -18,6 +18,7 @@ package com.twosigma.beaker.javash.module;
 import com.twosigma.beaker.javash.rest.JavashShellRest;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.twosigma.beaker.jvm.rest.ReadyRest;
 import com.twosigma.beaker.shared.servlet.GuiceCometdServlet;
 import java.util.HashMap;
 import org.cometd.server.JacksonJSONContextServer;
@@ -47,5 +48,6 @@ public class URLConfigModule extends ServletModule {
 
     // REST binding
     bind(JavashShellRest.class);
+    bind(ReadyRest.class);
   }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/jvm/rest/ReadyRest.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/jvm/rest/ReadyRest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright 2014 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.twosigma.beaker.jvm.rest;
+
+import com.google.inject.Singleton;
+import java.io.IOException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("ready")
+@Produces(MediaType.APPLICATION_JSON)
+@Singleton
+public class ReadyRest {
+  
+  @GET
+  @Path("ready")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String ready() 
+  {
+    return "ok";
+  }
+
+}

--- a/plugin/kdb/src/dist/kdb.js
+++ b/plugin/kdb/src/dist/kdb.js
@@ -163,7 +163,8 @@ define(function(require, exports, module) {
         command: COMMAND,
         startedIndicator: "Server started",
         waitfor: "Started SelectChannelConnector",
-        recordOutput: "true"
+        recordOutput: "true",
+        readyUrl: "/rest/ready/ready"
     }).success(function(ret) {
       serviceBase = ret;
       if (window.languageServiceBase == undefined) {

--- a/plugin/kdb/src/main/java/com/twosigma/beaker/kdb/module/URLConfigModule.java
+++ b/plugin/kdb/src/main/java/com/twosigma/beaker/kdb/module/URLConfigModule.java
@@ -17,6 +17,7 @@ package com.twosigma.beaker.kdb.module;
 
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.twosigma.beaker.jvm.rest.ReadyRest;
 import com.twosigma.beaker.kdb.rest.KdbRest;
 import com.twosigma.beaker.shared.servlet.GuiceCometdServlet;
 import org.cometd.server.JacksonJSONContextServer;
@@ -40,5 +41,6 @@ public class URLConfigModule extends ServletModule {
 
     // REST binding
     bind(KdbRest.class);
+    bind(ReadyRest.class);
   }
 }

--- a/plugin/r/src/dist/r.js
+++ b/plugin/r/src/dist/r.js
@@ -164,7 +164,8 @@ define(function(require, exports, module) {
         command: COMMAND,
         startedIndicator: "Server started",
         waitfor: "Started SelectChannelConnector",
-        recordOutput: "true"
+        recordOutput: "true",
+        readyUrl: "/rest/ready/ready"
     }).success(function(ret) {
       serviceBase = ret;
       if (window.languageServiceBase == undefined) {

--- a/plugin/r/src/main/java/com/twosigma/beaker/r/module/URLConfigModule.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/module/URLConfigModule.java
@@ -16,6 +16,7 @@
 package com.twosigma.beaker.r.module;
 
 import com.twosigma.beaker.r.rest.RShellRest;
+import com.twosigma.beaker.jvm.rest.ReadyRest;
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import com.twosigma.beaker.shared.servlet.GuiceCometdServlet;
@@ -47,5 +48,6 @@ public class URLConfigModule extends ServletModule {
 
     // REST binding
     bind(RShellRest.class);
+    bind(ReadyRest.class);
   }
 }

--- a/plugin/scala/src/dist/scala.js
+++ b/plugin/scala/src/dist/scala.js
@@ -166,7 +166,8 @@ define(function(require, exports, module) {
       command: COMMAND,
       startedIndicator: "Server started",
       waitfor: "Started SelectChannelConnector",
-      recordOutput: "true"
+      recordOutput: "true",
+      readyUrl: "/rest/ready/ready"
     }).success(function(ret) {
       serviceBase = ret;
       if (window.languageServiceBase == undefined) {

--- a/plugin/scala/src/main/scala/com/twosigma/beaker/scala/module/URLConfigModule.java
+++ b/plugin/scala/src/main/scala/com/twosigma/beaker/scala/module/URLConfigModule.java
@@ -17,6 +17,7 @@ package com.twosigma.beaker.scala.module;
 
 import com.google.inject.servlet.ServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
+import com.twosigma.beaker.jvm.rest.ReadyRest;
 import com.twosigma.beaker.scala.rest.ScalaShellRest;
 import com.twosigma.beaker.shared.servlet.GuiceCometdServlet;
 
@@ -49,5 +50,6 @@ public class URLConfigModule extends ServletModule {
 
     // REST binding
     bind(ScalaShellRest.class);
+    bind(ReadyRest.class);
   }
 }


### PR DESCRIPTION
Fix Issue #1600 by polling until the backend is ready.
the URL to poll on is specified by the plugin JS.
our jetty plugins get a new endpoint to indicate when they are ready.
the ipython plugins use one of their existing endpoints.
node does not need one afaik but we can add it later if it does.
