### PR TITLE
Memory Leak Fixes

### DIFF
--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -442,7 +442,6 @@
           };
 
           if (cm.getOption('mode') === 'htmlmixed' || cm.getOption('mode') === 'javascript') {
-            console.log("using code mirror");
             cm.execCommand("autocomplete");
           } else {
             var options = {

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -429,6 +429,7 @@
           Scrollin.untrack(element[0]);
           CodeMirror.off(window, 'resize', resizeHandler);
           CodeMirror.off('change', changeHandler);
+          scope.cm && scope.cm.off();
           scope.bkNotebook.unregisterFocusable(scope.cellmodel.id);
           scope.bkNotebook.unregisterCM(scope.cellmodel.id);
           scope.bkNotebook = null;

--- a/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
@@ -159,6 +159,12 @@
             bkSessionManager.setNotebookModelEdited(true);
           }
         });
+
+        scope.$on('$destroy', function() {
+          scope.bkNotebook.unregisterFocusable(scope.cellmodel.id, scope);
+          scope.bkNotebook.unregisterCM(scope.cellmodel.id, scope.cm);
+          scope.cm.off();
+        });
       }
     };
   }]);


### PR DESCRIPTION
This PR contains two memory leak fixes that quickly get out of hand on large notebooks. 

---
### Leak 1

> codecell directive codemirror binding leak :fountain: 
##### Steps to reproduce:
- Start a profiler with an empty notebook
-  create a html cell and delete it (**3 times**)
- force a GC 
- check the number of nodes and event listeners still in memory
##### Before

![screen shot 2015-06-05 at 9 39 26 am](https://cloud.githubusercontent.com/assets/883126/8011241/14c863fc-0b85-11e5-9cfa-b36160b8f991.png)

Note how the yellow and green lines (denoting event listeners and DOM nodes never goes down) 

At this point I figured we were leaking something, so I took a look at the codecell directive and found what I was looking for:

``` js
scope.cm.on('change', changeHandler);
```

We were watching for the change event on the codemirror instance and calling a function inside of our directive, thus making the codemirror instance impossible to GC since it was always in the graph.

This was a simple fix that just required us to explicitly unregister for the `change` event on `$scope.$destroy` of the directive. 
##### After

![screen shot 2015-06-05 at 9 57 35 am](https://cloud.githubusercontent.com/assets/883126/8011402/70145350-0b86-11e5-8979-bdc9016ba309.png)

Awesome one leak down!

---
### Leak 2

> markdown editable directive leaks :fountain: 

After using the app for a while I had noticed that typing in section cells can get quite slow. I hypothesized that perhaps section cells were bleeding memory and were not being cleaned up correctly. So from that initial itch I proceeded. 
##### Steps to reproduce:
- Start a profiler with an empty notebook
- add a new section
  - click off of the section area to unfocus the editor
  - delete the section
- (repeat above 3x)
- force a GC and stop the profiler
##### Before

![screen shot 2015-06-05 at 11 28 56 am](https://cloud.githubusercontent.com/assets/883126/8011546/83333fa4-0b87-11e5-8dc2-6aa860c21ed0.png)

Owch ok, (I know there is no scale here, but this was leaking over ~1000 DOM nodes per new section cell)

From this I started digging down into the directive tree of section cell to markdown editable cell.
After reading over the markdown editable source code I fairly quickly was able to identify some issues in the source code. There was a combination of listening directly to the codemirror instance as in leak 1 as well as a new kind of leak caused by the way that we were registering codemirror instances back up to the notebook.

:warning: 

``` js
scope.cm.on("blur", function(){
  scope.$apply(function() {
    syncContentAndPreview();
  });
});
```

:warning: :warning:  :fire: :skull: 

```
scope.bkNotebook.registerFocusable(scope.cellmodel.id, scope);
scope.bkNotebook.registerCM(scope.cellmodel.id, scope.cm);
```

The fix here was straightforward, we just needed to listen to `$scope.$destroy` and unregister our events to disconnect this content from the memory graph.
##### After

![screen shot 2015-06-05 at 12 03 17 pm](https://cloud.githubusercontent.com/assets/883126/8011560/a786f148-0b87-11e5-8bd2-0f45f4672edd.png)

:dancer: fixed!

---
##### Process takeaways

In the devtools resources they recommend to use the heap snapshots and heap timelines to identify and find leaking items (and be able to match the leaking objects to objects created in your app). Unfortunately past their "simple" examples that they have put together in the documentation I find this method of debugging to be incredibly difficult. On a complex application with many objects moving in and out of memory, these unrelated objects cloud the snapshots so much that identifying the object(s) that are leaking becomes basically impossible. 

It may just be me, however after spending quite a bit of time digging through these dumps, I had no good takeaways:

![screen shot 2015-06-05 at 1 52 33 pm](https://cloud.githubusercontent.com/assets/883126/8011811/2ea02058-0b8a-11e5-8483-de07c9d7e419.png)
![screen shot 2015-06-05 at 1 52 14 pm](https://cloud.githubusercontent.com/assets/883126/8011812/2ea18c4a-0b8a-11e5-9640-418938c64df1.png)
![screen shot 2015-06-05 at 1 51 47 pm](https://cloud.githubusercontent.com/assets/883126/8011813/2ea2984c-0b8a-11e5-8164-2a550a01893a.png)

The heap timeline does show me that something is leaking, but past that I need to dig into the source code (of my application) to actually learn more. 

---

**In summary**

The most powerful process that I have found so far is to follow these steps. 
- Draw a hypotheses based on your application domain experience.
- Figure out a testing methodology that is easily repeatable
- Use the timeline profile and forced GCs to then execute your test. 
