### PR TITLE
Fix casting issue of scss units.

### DIFF
--- a/core/src/main/web/app/styles/cell-outputs.scss
+++ b/core/src/main/web/app/styles/cell-outputs.scss
@@ -29,7 +29,7 @@ bk-code-cell-output {
 }
 
 .markup {
-  min-height: $line-height-base + 0em;
+  min-height: unit($line-height-base) + 0em;
   & > :first-child {
     margin-top: 0;
   }


### PR DESCRIPTION
On windows, the scss compiler fails due to it being unable to handle
converting `px/px` units to `em`.

ref sass/sass#1743
