### PR TITLE
Fix broken datatable sorting

### DIFF
--- a/core/src/main/web/outputdisplay/bko-tabledisplay/bko-tabledisplay.js
+++ b/core/src/main/web/outputdisplay/bko-tabledisplay/bko-tabledisplay.js
@@ -28,7 +28,7 @@
             if ( d === '' || d === null ) {
                 return 'moment-'+format;
             }
-            return moment(d.timestamp).isValid() ?
+            return (d.timestamp !== undefined && moment(d.timestamp).isValid()) ?
                 'moment-'+format :
                 null;
         } );


### PR DESCRIPTION
There was an assumption that undefined would not be a valid moment
object, however it is. Because of that all the column sorting broke.

`moment(undefined).isValid() === true`

---

Bug introduced in c586f602a8debd64ec5d2adfe97d6ae36c8ca895

Fixes #1745
