### PR TITLE
Created user folder at ~/.beaker/v1/web

### DIFF
--- a/core/nginx/nginx.conf.template
+++ b/core/nginx/nginx.conf.template
@@ -67,6 +67,11 @@ http {
       return 301 %(start_page)s;
     }
 
+    # user directory
+    location /user {
+      alias "%(user_folder)s";
+    }
+
     # this is the main beaker index page - auto generated via rest call
     location = /beaker/ {
       %(auth_cookie_rule)s

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
@@ -73,6 +73,11 @@ public interface BeakerConfig {
    */
   public String getNginxExtraRules();
   /**
+   * folder the user can use for storage
+   * @return
+   */
+  public String getUserFolder();
+  /**
    * optional/extra/override nginx plugin rules
    * @return
    */

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -51,6 +51,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
   private final String nginxStaticDir;
   private final String nginxServDir;
   private final String nginxExtraRules;
+  private final String userFolder;
   private final Map<String, String> nginxPluginRules;
   private final Boolean useKerberos;
   private final Boolean publicServer;
@@ -131,7 +132,10 @@ public class DefaultBeakerConfig implements BeakerConfig {
     else
         this.sharing_server = "http://sharing.beakernotebook.com/gist/anonymous";
     this.prefs = obj;
-    
+
+    this.userFolder = this.dotDir + "/web";
+    utils.ensureDirectoryExists(userFolder); 
+
     final String prefDefaultNotebookUrl = pref.getDefaultNotebookUrl();
     final String mainDefaultNotebookPath = this.dotDir + "/config/default.bkr";
     final String defaultDefaultNotebookPath = this.installDir + "/config/default.bkr";
@@ -235,6 +239,11 @@ public class DefaultBeakerConfig implements BeakerConfig {
   @Override
   public String getNginxExtraRules() {
     return this.nginxExtraRules;
+  }
+
+  @Override
+  public String getUserFolder() {
+    return this.userFolder;
   }
 
   @Override

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -127,6 +127,7 @@ public class PluginServiceLocatorRest {
   private final String nginxStaticDir;
   private final String nginxServDir;
   private final String nginxExtraRules;
+  private final String userFolder;
   private final Map<String, String> nginxPluginRules;
   private final String pluginDir;
   private final String [] nginxCommand;
@@ -174,6 +175,7 @@ public class PluginServiceLocatorRest {
     this.nginxStaticDir = bkConfig.getNginxStaticDirectory();
     this.nginxServDir = bkConfig.getNginxServDirectory();
     this.nginxExtraRules = bkConfig.getNginxExtraRules();
+    this.userFolder = bkConfig.getUserFolder();
     this.nginxPluginRules = bkConfig.getNginxPluginRules();
     this.pluginDir = bkConfig.getPluginDirectory();
     this.publicServer = bkConfig.getPublicServer();
@@ -713,6 +715,7 @@ public class PluginServiceLocatorRest {
     }
     nginxConfig = nginxConfig.replace("%(plugin_section)s", pluginSection.toString());
     nginxConfig = nginxConfig.replace("%(extra_rules)s", this.nginxExtraRules);
+    nginxConfig = nginxConfig.replace("%(user_folder)s", this.userFolder);
     nginxConfig = nginxConfig.replace("%(host)s", hostName);
     nginxConfig = nginxConfig.replace("%(port_main)s", Integer.toString(this.portBase));
     nginxConfig = nginxConfig.replace("%(port_beaker)s", Integer.toString(this.corePort));


### PR DESCRIPTION
Partly addresses #430, providing a user-controlled directory that is served by nginx and accessible through '/user/' (i.e. you can do src="/user/beaker.jpg" in an img tag to show ~/.beaker/v1/web/beaker.jpg)
