### PR TITLE
Fix delayed spinner hide in advanced mode.

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/cell.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/cell.jst.html
@@ -29,11 +29,13 @@
     <div class="cell-menu-item delete-cell" ng-click="deleteCell()" title="delete cell"></div>
     <div class="cell-menu-item expand-contract" ng-if="cellmodel.type=='code'" ng-click="toggleCellInput()" ng-class="cellmodel.input.hidden && 'collapsed'" title="hide/show cell input"></div>
     <div class="dropdown dropdown-promoted advanced-only" ng-if="isCodeCell()" style="float: right;">
-      <div ng-if="cellmodel.type=='code' && !cellmodel.evaluatorReader" class="loading-spinner rotating bkr"></div>
-      <bk-code-cell-input-menu ng-if="cellmodel.type=='code' && cellmodel.evaluatorReader"></bk-code-cell-input-menu>
+      <div ng-if="!cellmodel.evaluatorReader">
+        <div class="loading-spinner rotating bkr"></div>
+      </div>
+      <bk-code-cell-input-menu ng-if="cellmodel.evaluatorReader"></bk-code-cell-input-menu>
     </div>
     <div class="cell-menu-item evaluate" ng-click="evaluate($event)" ng-if="isCodeCell()" title="run cell"></div>
-    <div class="cell-status-item loading-state advanced-hide" ng-if="cellmodel.type=='code' && !cellmodel.evaluatorReader">Initializing {{cellmodel.evaluator}}
+    <div class="cell-status-item loading-state advanced-hide" ng-if="isCodeCell() && !cellmodel.evaluatorReader">Initializing {{cellmodel.evaluator}}
       <div class="loading-spinner rotating"></div>
     </div>
   </div>

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -175,14 +175,12 @@
           return bkEvaluatorManager.getEvaluator($scope.cellmodel.evaluator);
         };
         $scope.updateUI = function(evaluator) {
+          $scope.cellmodel.evaluatorReader = Boolean(evaluator);
           if ($scope.cm && evaluator) {
             $scope.cm.setOption('mode', evaluator.cmMode);
             if (evaluator.indentSpaces) {
               $scope.cm.setOption('indentUnit', evaluator.indentSpaces);
             }
-            $timeout(function() {
-              $scope.cellmodel.evaluatorReader = true;
-            });
           }
         };
         $scope.$watch('getEvaluator()', function(newValue, oldValue) {


### PR DESCRIPTION
Angular prevents hiding an element while an animation is happening on
the element. In this case we were trying to hide an element that was
"spinning" and since it had a 2 second animation duration, the ng-if would only
act on the element after the animation cycle had completed.

By putting a containing div on the ng-if directive we work around this
limitation. In someways this is a hack.

Fixes #1771
