### PR TITLE
Fix windows build

### DIFF
--- a/core/bower.json
+++ b/core/bower.json
@@ -15,7 +15,7 @@
     "codemirror": "5.2.0",
     "q": "0.9.7",
     "angular-bootstrap": "0.12.0",
-    "bootstrap-sass": "3.2.0",
+    "bootstrap-sass": "3.3.5",
     "jquery-file-upload": "9.9.2",
     "ngstorage": "0.3.0",
     "font-awesome": "4.0.3",

--- a/core/config/builds/dev/build.gradle
+++ b/core/config/builds/dev/build.gradle
@@ -31,7 +31,11 @@ task copyVendorStuff
 
 task run (type: Exec) {
   workingDir coreDir
-  commandLine './beaker.command'
+  if (windows()) {
+    commandLine 'cmd', '/beaker.command.bat'
+  } else {
+    commandLine './beaker.command'
+  }
 }
 task runOnly (type: Exec) {
   workingDir coreDir

--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -191,7 +191,7 @@ gulp.task("compileBeakerTemplates", function() {
 });
 
 function getFilePathArrayFromList(basePath, listPath) {
-  return fs.readFileSync(basePath + listPath)
+  return fs.readFileSync(Path.join(basePath, listPath))
   .toString().split('\n')
   .filter(function(n) {
     return n !== undefined && n.trim() !== ''
@@ -199,7 +199,7 @@ function getFilePathArrayFromList(basePath, listPath) {
 }
 
 gulp.task('buildOutputDisplayTemplate', function () {
-  var thePath = pluginPath + 'template/';
+  var thePath = Path.join(pluginPath, 'template');
 
   if (argv.outdisp) {
     thePath = argv.outdisp + '/';

--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -38,12 +38,12 @@ var es = require('event-stream');
 var fs = require('fs');
 var sourcemaps = require('gulp-sourcemaps');
 
-var srcPath  = Path.join(__dirname, "/src/main/web/");
-var pluginPath  = Path.join(__dirname, "/src/main/web/plugin/");
-var rootPath  = Path.join(__dirname, "/src/main/web/app/");
-var root2Path  = Path.join(__dirname, "/src/main/web/outputdisplay/");
-var buildPath = Path.join(__dirname, "/src/main/web/app/dist/");
-var tempPath = Path.join(__dirname, "/src/main/web/app/temp/");
+var srcPath  = Path.join(__dirname, "src", "main", "web");
+var pluginPath  = Path.join(__dirname, "src", "main", "web", "plugin");
+var rootPath  = Path.join(__dirname, "src", "main", "web", "app");
+var root2Path  = Path.join(__dirname, "src", "main", "web", "outputdisplay");
+var buildPath = Path.join(__dirname, "src", "main", "web", "app", "dist");
+var tempPath = Path.join(__dirname, "src", "main", "web", "app", "temp");
 
 var banner = ['/*',
               ' *  Copyright 2014 TWO SIGMA OPEN SOURCE, LLC',

--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -232,7 +232,7 @@ gulp.task('buildOutputDisplayTemplate', function () {
     gulp.src(jsarray.map(function(v) {
       return Path.join(srcPath, v);
     }))
-    .pipe(stripJsComments())
+//    .pipe(stripJsComments())
     .pipe(concat('beakerOutputDisplay.js'))
     .pipe(header(banner))
     .pipe(gulp.dest(buildPath));
@@ -292,7 +292,7 @@ gulp.task('buildIndexTemplate', function () {
         } else {
           block.pipe(gulpSrc())
             .pipe(sourcemaps.init({loadMaps: true}))
-            .pipe(stripJsComments())
+//            .pipe(stripJsComments())
             .pipe(concat('beakerApp.js'))
             .pipe(header(banner ))
             .pipe(sourcemaps.write())

--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -38,12 +38,12 @@ var es = require('event-stream');
 var fs = require('fs');
 var sourcemaps = require('gulp-sourcemaps');
 
-var srcPath  = Path.join(__dirname, "src", "main", "web");
-var pluginPath  = Path.join(__dirname, "src", "main", "web", "plugin");
-var rootPath  = Path.join(__dirname, "src", "main", "web", "app");
-var root2Path  = Path.join(__dirname, "src", "main", "web", "outputdisplay");
-var buildPath = Path.join(__dirname, "src", "main", "web", "app", "dist");
-var tempPath = Path.join(__dirname, "src", "main", "web", "app", "temp");
+var srcPath  = Path.join(__dirname, "/src/main/web/");
+var pluginPath  = Path.join(__dirname, "/src/main/web/plugin/");
+var rootPath  = Path.join(__dirname, "/src/main/web/app/");
+var root2Path  = Path.join(__dirname, "/src/main/web/outputdisplay/");
+var buildPath = Path.join(__dirname, "/src/main/web/app/dist/");
+var tempPath = Path.join(__dirname, "/src/main/web/app/temp/");
 
 var banner = ['/*',
               ' *  Copyright 2014 TWO SIGMA OPEN SOURCE, LLC',
@@ -128,15 +128,8 @@ gulp.task("buildSingleOutDispJs", function() {
   .pipe(gulp.dest(buildPath));
 });
 
-gulp.task("compileVendorScss", function() {
-  return gulp.src(Path.join(rootPath, "vendor.scss"))
-  .pipe(sass().on('error', handleError))
-  .pipe(importCss())
-  .pipe(gulp.dest(tempPath));
-});
-
 gulp.task("compileBeakerScss", function() {
-  return gulp.src(Path.join(rootPath, "app.scss"))
+  return gulp.src(Path.join(rootPath, "**.scss"))
   .pipe(sourcemaps.init())
   .pipe(sass().on('error', handleError))
   .pipe(importCss())
@@ -191,7 +184,7 @@ gulp.task("compileBeakerTemplates", function() {
 });
 
 function getFilePathArrayFromList(basePath, listPath) {
-  return fs.readFileSync(Path.join(basePath, listPath))
+  return fs.readFileSync(basePath + listPath)
   .toString().split('\n')
   .filter(function(n) {
     return n !== undefined && n.trim() !== ''
@@ -199,7 +192,7 @@ function getFilePathArrayFromList(basePath, listPath) {
 }
 
 gulp.task('buildOutputDisplayTemplate', function () {
-  var thePath = Path.join(pluginPath, 'template');
+  var thePath = pluginPath + 'template/';
 
   if (argv.outdisp) {
     thePath = argv.outdisp + '/';
@@ -359,7 +352,7 @@ gulp.task("namespaceCss", function(cb) {
 });
 
 gulp.task("compile", function(cb) {
-  var seq = ["compileBeakerScss", "compileVendorScss", "compileBeakerTemplates"];
+  var seq = ["compileBeakerScss", "compileBeakerTemplates"];
   if (argv.embed) {
     seq.push("namespaceCss");
   }

--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -128,8 +128,15 @@ gulp.task("buildSingleOutDispJs", function() {
   .pipe(gulp.dest(buildPath));
 });
 
+gulp.task("compileVendorScss", function() {
+  return gulp.src(Path.join(rootPath, "vendor.scss"))
+  .pipe(sass().on('error', handleError))
+  .pipe(importCss())
+  .pipe(gulp.dest(tempPath));
+});
+
 gulp.task("compileBeakerScss", function() {
-  return gulp.src(Path.join(rootPath, "**.scss"))
+  return gulp.src(Path.join(rootPath, "app.scss"))
   .pipe(sourcemaps.init())
   .pipe(sass().on('error', handleError))
   .pipe(importCss())
@@ -352,7 +359,7 @@ gulp.task("namespaceCss", function(cb) {
 });
 
 gulp.task("compile", function(cb) {
-  var seq = ["compileBeakerScss", "compileBeakerTemplates"];
+  var seq = ["compileBeakerScss", "compileVendorScss", "compileBeakerTemplates"];
   if (argv.embed) {
     seq.push("namespaceCss");
   }

--- a/core/src/main/web/app/controlpanel/controlpanel.jst.html
+++ b/core/src/main/web/app/controlpanel/controlpanel.jst.html
@@ -17,6 +17,8 @@
   <div class="navbar navbar-inverse">
     <a class="navbar-brand" href="/beaker/#/control" ng-click="gotoControlPanel($event)" eat-click>
       <img src="app/images/beaker_icon@2x.png" />
+    </a>
+    <a class="navbar-left" href="/beaker/#/control" ng-click="gotoControlPanel($event)" eat-click>
       Beaker
     </a>
   </div>

--- a/core/src/main/web/app/styles/header.scss
+++ b/core/src/main/web/app/styles/header.scss
@@ -30,15 +30,28 @@ header {
     margin-bottom: 0;
   }
 
-  .navbar-brand {
+  .navbar-left {
     color: #fff !important;
     font-size: 20px;
+    padding-top: 5px;
+  }
+  a:hover.navbar-left {
+    text-decoration: none;
+  }
+  
+  .navbar-brand {
+    color: #fff !important;
     padding-top: 10px;
-    padding-bottom: 7px;
 
     img {
       height: 22px;
       margin-top: -7px;
     }
+  }
+  
+  .navbar-text {
+    margin-top: 10px;
+    margin-bottom: 0px;
+    color: #bdbdad !important;
   }
 }

--- a/core/src/main/web/app/styles/variables.scss
+++ b/core/src/main/web/app/styles/variables.scss
@@ -40,7 +40,7 @@ $border-radius-base: 0;
 $border-radius-large: 0;
 $border-radius-small: 0;
 
-$navbar-height: 38px;
+$navbar-height: 30px;
 $navbar-inverse-bg: #3f5264;
 $navbar-default-bg: #eff2f8;
 $navbar-default-link-color: #3f5264;

--- a/core/src/main/web/app/template/mainapp/mainapp.jst.html
+++ b/core/src/main/web/app/template/mainapp/mainapp.jst.html
@@ -17,6 +17,8 @@
   <div class="navbar navbar-inverse">
     <a class="navbar-brand" href="/beaker/#/control" ng-click="gotoControlPanel($event)" eat-click>
       <img src="app/images/beaker_icon@2x.png" />
+    </a>
+    <a class="navbar-left" href="/beaker/#/control" ng-click="gotoControlPanel($event)" eat-click>
       Beaker
     </a>
     <p class="navbar-text">{{filename()}}</p>


### PR DESCRIPTION
the important fix here is to move from bootstrap-sass 3.2.0 to 3.3.5.
this removes some syntax errors that were causing gulp to exit without reporting any error.
but this introduced a problem with the navbar, which i fixed and then i made the navbar
a bit shorter and increased the contrast of its text.

Fix https://github.com/twosigma/beaker-notebook/issues/1786 and https://github.com/twosigma/beaker-notebook/issues/1759
