### PR TITLE
Fix z-index cell stacking bug.

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/cell.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/cell.jst.html
@@ -47,6 +47,6 @@
       <pre>{{cellmodel | json}}</pre>
     </div>
   </div>
-  <div ng-include="getTypeCellUrl()"></div>
+  <div ng-include="getTypeCellUrl()" class="cell-type"></div>
   <bk-new-cell-menu config="newCellMenuConfig" ng-class="isLarge && 'large'" is-large="isLarge" ng-if="newCellMenuConfig.isShow()"></bk-new-cell-menu>
 </div>

--- a/core/src/main/web/app/styles/cell-menus.scss
+++ b/core/src/main/web/app/styles/cell-menus.scss
@@ -54,7 +54,6 @@ bk-new-cell-menu {
 .toggle-menu {
     top: $grid-row-height - 5px;
     right: 1px;
-    z-index:    10;
     position:   absolute;
     background: rgba(255, 255, 255, 0.5);
     padding-right: $grid-gutter-width;

--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -86,8 +86,13 @@ bk-markdown-cell .markup
 
 .bkcell bk-code-cell-input-menu .dropdown {
     float:          left;
-    z-index:        99;
     position:       relative;
+}
+
+// Ensure that the cell type container is stacked below the cell menu in advanced mode since the two are overlapping elements.
+.advanced-mode bk-cell .cell-type {
+  z-index: -1;
+  position: relative;
 }
 
 bk-cell > .bkcell {


### PR DESCRIPTION
Fixes #1815

the z-index: 10 and node stacking lead to this bug, initially added in
https://github.com/twosigma/beaker-notebook/commit/eb17a7013701954ee03ad9544e82c147cfd8b647

But was a new "fix" from an earlier "fix" in #951

The origin of the issue, is simply in advanced mode, the editor is on
top (in the DOM) of the menu, and it needs to be z stacked below it.

This solution is only focued on the relationship between the menu and
the code-cell and nothing else.
