### PR TITLE
Avoid button overflow

### DIFF
--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -28,6 +28,7 @@
 
 .btn {
   overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .text-danger {

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -26,6 +26,10 @@
   }
 }
 
+.btn {
+  overflow-x: hidden;
+}
+
 .text-danger {
   color: #a94442 !important;
 }


### PR DESCRIPTION
Fixes #1824: Hide overflow when text doesn't fit in button.
