### PR TITLE
Fix code-mirror line highlight

### DIFF
--- a/core/src/main/web/app/styles/vendor_overrides.scss
+++ b/core/src/main/web/app/styles/vendor_overrides.scss
@@ -28,6 +28,10 @@
   z-index: initial;
 }
 
+.CodeMirror-lines div[style="position: relative; z-index: 1;"] {
+  z-index: 0 !important;
+}
+
 .CodeMirror-fullscreen {
   display: block;
   position: fixed;


### PR DESCRIPTION
https://github.com/twosigma/beaker-notebook/pull/1837/files#diff-2314905bb6a414a883c230a7a0e9934fR28

codemirror inlines a z-index which is causing problems:
codemirror/CodeMirror@e1727ac

Fixes #1884
