### PR TITLE
Fix output overlap

### DIFF
--- a/core/src/main/web/app/styles/cell-outputs.scss
+++ b/core/src/main/web/app/styles/cell-outputs.scss
@@ -20,10 +20,6 @@ bk-code-cell-output {
   }
 }
 
-.advanced-mode bk-output-display.bkr {
-  min-height: 20px;
-}
-
 .markup, .dataTables_scrollBody {
   box-sizing: content-box;
 }

--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -134,6 +134,7 @@ bk-section-cell {
         position: relative;
         border-top: solid 1px #CCC;
         box-sizing: content-box;
+        min-height: 20px;
 
         .out_error {
             padding-bottom: 0;


### PR DESCRIPTION
Since bk-output-display uses ng-show the element is `display:none` when the
output is hidden, thus causing the min-height to no longer be applied.

Fixes #1853
#### Output showing

<img width="819" alt="screen shot 2015-07-06 at 12 06 10 pm" src="https://cloud.githubusercontent.com/assets/883126/8526909/7e46a842-23d7-11e5-8c2a-51fc11d014d6.png">
#### Output hidden

<img width="827" alt="screen shot 2015-07-06 at 12 06 15 pm" src="https://cloud.githubusercontent.com/assets/883126/8526910/7e472c7c-23d7-11e5-9128-2b56b7999dba.png">
