### PR TITLE
🐛 Menu closing bug fix

### DIFF
--- a/core/src/main/web/app/template/index_template.html
+++ b/core/src/main/web/app/template/index_template.html
@@ -94,7 +94,7 @@
   <script src="vendor/jquery.event.drag/jquery.event.drag.js"></script>
   <script src="vendor/jquery-ui/js/jquery-ui.custom.min.js"></script>
   <script src="vendor/bower_components/rAF/index.js"></script>
-  <script src="vendor/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"></script>
+  <script src="vendor/bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
   <script src="vendor/bower_components/bootstrap-sass/assets/javascripts/bootstrap.js"></script>
   <script src="vendor/bower_components/moment/min/moment-with-locales.min.js"></script>
   <script src="vendor/bower_components/moment-timezone/builds/moment-timezone-with-data.min.js"></script>

--- a/core/src/main/web/app/utils/basic/commonui.js
+++ b/core/src/main/web/app/utils/basic/commonui.js
@@ -97,7 +97,8 @@
 
         scope.$on('$destroy', function() {
           $(window).off('.' + scope.$id);
-          // Since the dropdown is external to the directive we need to make sure to clean it up when the directive goes away
+          // Since the dropdown is external to the directive we need
+          // to make sure to clean it up when the directive goes away
           dropdown.remove();
           element.off('click');
         });

--- a/core/src/main/web/app/utils/basic/commonui.js
+++ b/core/src/main/web/app/utils/basic/commonui.js
@@ -64,6 +64,7 @@
       restrict: 'C',
       link: function(scope, element, attrs) {
         $(window).on('click.' + scope.$id, hideDropdown);
+        $(document).on('hide.bs.dropdown', hideDropdown);
 
         var dropdown = element.find('.dropdown-menu').first();
         var toggle = element.find('.dropdown-toggle').first();
@@ -96,6 +97,7 @@
         function hideDropdown() { dropdown.hide();}
 
         scope.$on('$destroy', function() {
+          $(document).off('hide.bs.dropdown', hideDropdown);
           $(window).off('.' + scope.$id);
           // Since the dropdown is external to the directive we need
           // to make sure to clean it up when the directive goes away

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
-    "protractor": "1.6.0",
+    "protractor": "2.1.0",
     "underscore": "^1.7.0"
   }
 }

--- a/test/tests/beaker.po.js
+++ b/test/tests/beaker.po.js
@@ -30,10 +30,7 @@ var BeakerPageObject = function() {
 
   this.toggleLanguageCellMenu = function(opts) {
     return element.all(by.css('.dropdown-toggle bk-language-logo'))
-    .get(opts.cellIndex)
-    .then(function(elm) {
-      return elm.click();
-    });
+    .get(opts.cellIndex).click();
   };
 
   this.isLanguageCellMenuOpen = function() {
@@ -43,9 +40,7 @@ var BeakerPageObject = function() {
   this.toggleCellMenu = function(opts) {
     return element.all(by.css('.bkcell .dropdown-promoted'))
     .get(opts.cellIndex)
-    .then(function(elm) {
-      return elm.click();
-    });
+    .click();
   };
 
   this.toggleAdvancedMode = function() {
@@ -57,11 +52,9 @@ var BeakerPageObject = function() {
   this.isCellMenuOpen = function(opts) {
     return element.all(by.css('.bkcell .open.toggle-menu.bkr'))
     .get(opts.cellIndex)
-    .then(function(elm) {
-      return elm.isDisplayed()
-      .then(function() {
-        return true;
-      });
+    .isDisplayed()
+    .then(function() {
+      return true;
     })
     .thenCatch(function() {
       return false;
@@ -117,17 +110,9 @@ var BeakerPageObject = function() {
   };
 
   this.readMarkdownCell = function() {
-    return element(by.css('body'))
-    .then(function(el) {
-      // click on the body to refocus editor
-      return el.click();
-    })
-    .then(function() {
-      return element(by.css('.markup p'));
-    })
-    .then(function(el) {
-      return el.getText();
-    });
+    element(by.css('body')).click();
+
+    return element(by.css('.markup p')).getText();
   };
 
   this.activateLanguageInManager = function(language) {
@@ -169,7 +154,6 @@ var BeakerPageObject = function() {
   this.setCellInput = function(code) {
     browser.executeScript('$(".CodeMirror")[0].CodeMirror.setValue("' + code + '")');
   };
-
 
   this.evaluateCell = function() {
     var self = this;

--- a/test/tests/beaker.po.js
+++ b/test/tests/beaker.po.js
@@ -169,6 +169,11 @@ var BeakerPageObject = function() {
     }, 5000);
   };
 
+  this.insertNewCell = function() {
+    element(by.css('bk-new-cell-menu')).click();
+    return this.insertCellButton.click();
+  };
+
   this.getCellOutput = function() {
     return element(by.css('bk-output-display > div'));
   };

--- a/test/tests/notebook.js
+++ b/test/tests/notebook.js
@@ -198,41 +198,55 @@ describe('notebook', function() {
     .then(done);
   });
 
-  it('can close a cell menu by clicking off', function(done) {
-    beakerPO.newEmptyNotebook.click()
-    .then(beakerPO.insertCellButton.click)
-    .then(beakerPO.toggleCellMenu.bind(this, {cellIndex: 0}))
-    .then(element(by.css('body')).click)
-    .then(beakerPO.isCellMenuOpen.bind(this, {cellIndex: 0}))
-    .then(function(isOpen) {
-      expect(isOpen).toEqual(false);
-    })
-    .then(beakerPO.closeNotebook)
-    .then(done);
-  });
+  describe('menu', function() {
+    beforeEach(function(done) {
+      beakerPO.newEmptyNotebook.click();
+      beakerPO.insertNewCell()
+      .then(done);
+    });
 
-  it('can open the menu', function(done) {
-    beakerPO.newEmptyNotebook.click()
-    .then(beakerPO.insertCellButton.click)
-    .then(beakerPO.toggleCellMenu.bind(this, {cellIndex: 0}))
-    .then(beakerPO.isCellMenuOpen.bind(this, {cellIndex: 0}))
-    .then(function(isOpen) {
-      expect(isOpen).toEqual(true);
-    })
-    .then(beakerPO.closeNotebook)
-    .then(done);
-  });
+    afterEach(function(done) {
+      beakerPO.closeNotebook()
+      .then(done);
+    });
 
-  it('can close the menu', function(done) {
-    beakerPO.newEmptyNotebook.click()
-    .then(beakerPO.insertCellButton.click)
-    .then(beakerPO.toggleCellMenu.bind(this, {cellIndex: 0}))
-    .then(beakerPO.toggleCellMenu.bind(this, {cellIndex: 0}))
-    .then(beakerPO.isCellMenuOpen.bind(this, {cellIndex: 0}))
-    .then(function(isOpen) {
-      expect(isOpen).toEqual(false);
-    })
-    .then(beakerPO.closeNotebook)
-    .then(done);
+    it('closes a menu when when another menu is opened', function(done) {
+      beakerPO.insertNewCell();
+      beakerPO.toggleCellMenu({cellIndex: 0});
+      beakerPO.toggleCellMenu({cellIndex: 2})
+      .then(done);
+    });
+
+    it('closes a menu by clicking off', function(done) {
+      beakerPO.toggleCellMenu({cellIndex: 0});
+      element(by.css('body')).click();
+
+      beakerPO.isCellMenuOpen({cellIndex: 0})
+      .then(function(isOpen) {
+        expect(isOpen).toEqual(false);
+        done();
+      });
+    });
+
+    it('can be opened', function(done) {
+      beakerPO.toggleCellMenu({cellIndex: 0});
+
+      beakerPO.isCellMenuOpen({cellIndex: 0})
+      .then(function(isOpen) {
+        expect(isOpen).toEqual(true);
+        done();
+      });
+    });
+
+    it('can be closed', function(done) {
+      beakerPO.toggleCellMenu({cellIndex: 0});
+      beakerPO.toggleCellMenu({cellIndex: 0});
+
+      beakerPO.isCellMenuOpen({cellIndex: 0})
+      .then(function(isOpen) {
+        expect(isOpen).toEqual(false);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
By listening to the custom event that is emitted by bootstrap when a
dropdown is opened we can then close all of the open bootstrap dropdown
menus.

The reason we have to manually listen for this is because since we are
promoting the dropdown outside of the dropdown toggle button parent the
bootstrap plugin is unable to find the menu to close.

Fixes #1842

---

Also added tests for this feature and upgraded our protractor version :dancer: 
