### PR TITLE
tests: remove R setup for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
 before_script:
   - sudo add-apt-repository --yes ppa:nginx/stable
   - sudo add-apt-repository --yes ppa:chris-lea/zeromq
-  - sudo add-apt-repository --yes ppa:marutter/rrutter
   - sudo apt-get update -q
   - sudo apt-get install nginx
   - sudo apt-get install libzmq3-dbg libzmq3-dev libzmq3
@@ -15,9 +14,3 @@ before_script:
   - sudo pip install ipython jinja2 tornado
   - sudo pip install pyzmq
   - sudo apt-get install python-matplotlib python-scipy python-pandas
-  - sudo apt-get install r-base r-base-dev
-  - sudo Rscript -e "install.packages('Rserve',,'http://cran.us.r-project.org')"
-  - sudo Rscript -e "install.packages('ggplot2',,'http://cran.us.r-project.org')"
-  - sudo Rscript -e "install.packages('devtools',,'http://cran.us.r-project.org')"
-  - sudo Rscript -e "install.packages('RJSONIO',,'http://cran.us.r-project.org')"
-  - sudo Rscript -e "install.packages('RCurl',,'http://cran.us.r-project.org')"


### PR DESCRIPTION
Currently we have no R tests in place, so this can be removed for now
since it causes a significant slowdown
