### PR TITLE
Fix safari broken evaluating.

### DIFF
--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -56,7 +56,7 @@ define(function(require, exports, module) {
 
         var theCookies = document.cookie.split(';');
         for (var i = 0 ; i < theCookies.length; i++) {
-          if (theCookies[i].startsWith(' username-127-0-0-1-')) {            
+          if (theCookies[i].indexOf(' username-127-0-0-1-') === 0) {
             var theCookie = theCookies[i].split('=');
             document.cookie = theCookie[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/";
           }

--- a/plugin/ipythonPlugins/src/dist/iruby/iruby.js
+++ b/plugin/ipythonPlugins/src/dist/iruby/iruby.js
@@ -55,7 +55,7 @@ define(function(require, exports, module) {
 
         var theCookies = document.cookie.split(';');
         for (var i = 0 ; i < theCookies.length; i++) {
-          if (theCookies[i].startsWith(' username-127-0-0-1-')) {            
+          if (theCookies[i].indexOf(' username-127-0-0-1-') === 0) {
             var theCookie = theCookies[i].split('=');
             document.cookie = theCookie[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/";
           }

--- a/plugin/ipythonPlugins/src/dist/julia/julia.js
+++ b/plugin/ipythonPlugins/src/dist/julia/julia.js
@@ -56,7 +56,7 @@ define(function(require, exports, module) {
 
         var theCookies = document.cookie.split(';');
         for (var i = 0 ; i < theCookies.length; i++) {
-          if (theCookies[i].startsWith(' username-127-0-0-1-')) {            
+          if (theCookies[i].indexOf(' username-127-0-0-1-') === 0) {
             var theCookie = theCookies[i].split('=');
             document.cookie = theCookie[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/";
           }

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -56,7 +56,7 @@ define(function(require, exports, module) {
 
         var theCookies = document.cookie.split(';');
         for (var i = 0 ; i < theCookies.length; i++) {
-          if (theCookies[i].startsWith(' username-127-0-0-1-')) {            
+          if (theCookies[i].indexOf(' username-127-0-0-1-') === 0) {
             var theCookie = theCookies[i].split('=');
             document.cookie = theCookie[0] + "=; expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/";
           }


### PR DESCRIPTION
Introduced in 1a1c909b, safari and some browsers do not implement
`.startsWith` yet because it is part of the ES6 spec
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith

Fixes #1955
