### PR TITLE
🔨 Fix broken dashboard save

### DIFF
--- a/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
+++ b/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
@@ -75,7 +75,7 @@
                             });
                           } else {
                             var fileSaver = bkCoreManager.getFileSaver(pathInfo.uriType);
-                            fileSaver.save(pathInfo.uri, notebookModelAsString).then(function () {
+                            fileSaver.save(pathInfo.uri, notebookModelAsString).then(function() {
                               bkRecentMenu.recordRecentDocument(angular.toJson({
                                 uri: pathInfo.uri,
                                 type: pathInfo.uriType,
@@ -83,7 +83,7 @@
                                 format: _.isEmpty(format) ? '' : format
                               }));
                               deferred.resolve();
-                            }, function (error) {
+                            }, function(error) {
                               deferred.reject({
                                 cause: 'error saving to file',
                                 error: error

--- a/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
+++ b/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
@@ -47,7 +47,7 @@
             });
 
           };
-          bkUtils.httpGet("rest/session-backup/getEdited", {
+          bkUtils.httpGet('rest/session-backup/getEdited', {
             sessionid: session.id
           }).then(function(response) {
             var edited = response.data.edited;
@@ -57,8 +57,8 @@
             } else {
               // ask if user want to save first
               bkHelper.show3ButtonModal(
-                  "Do you want to save [" + $scope.getCaption(session) + "]?",
-                  "Confirm close",
+                  'Do you want to save [' + $scope.getCaption(session) + ']?',
+                  'Confirm close',
                   function() { // yes
                     // save session
                     var saveSession = function() {
@@ -71,7 +71,7 @@
                         bkCoreManager.showDefaultSavingFileChooser().then(function(pathInfo) {
                           if (!pathInfo.uri) {
                             deferred.reject({
-                              cause: "Save cancelled"
+                              cause: 'Save cancelled'
                             });
                           } else {
                             var fileSaver = bkCoreManager.getFileSaver(pathInfo.uriType);
@@ -80,12 +80,12 @@
                                 uri: pathInfo.uri,
                                 type: pathInfo.uriType,
                                 readOnly: false,
-                                format: _.isEmpty(format) ? "" : format
+                                format: _.isEmpty(format) ? '' : format
                               }));
                               deferred.resolve();
                             }, function (error) {
                               deferred.reject({
-                                cause: "error saving to file",
+                                cause: 'error saving to file',
                                 error: error
                               });
                             });
@@ -95,8 +95,8 @@
                       }
                     };
                     var savingFailedHandler = function(info) {
-                      if (info.cause === "Save cancelled") {
-                        console.log("File saving cancelled");
+                      if (info.cause === 'Save cancelled') {
+                        console.log('File saving cancelled');
                       } else {
                         bkHelper.show1ButtonModal(info.error, info.cause);
                       }
@@ -109,8 +109,8 @@
                   function() { // cancel
                     // no-op
                   },
-                  "Save",
-                  "Don't Save"
+                  'Save',
+                  'Don\'t Save'
               );
             }
           });
@@ -119,9 +119,9 @@
         $scope.getCaption = function(session) {
           var url = session.notebookUri;
           if (!url) {
-            return "New Notebook";
+            return 'New Notebook';
           }
-          if (url[url.length - 1] === "/") {
+          if (url[url.length - 1] === '/') {
             url = url.substring(0, url.length - 1);
           }
           return url.replace(/^.*[\\\/]/, '');

--- a/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
+++ b/core/src/main/web/app/controlpanel/controlpanelsessionitem-directive.js
@@ -66,33 +66,34 @@
                       if (!_.isEmpty(session.notebookUri) && !session.readOnly) {
                         var fileSaver = bkCoreManager.getFileSaver(session.uriType);
                         return fileSaver.save(session.notebookUri, notebookModelAsString, true);
-                      } else {
-                        var deferred = bkUtils.newDeferred();
-                        bkCoreManager.showDefaultSavingFileChooser().then(function(pathInfo) {
-                          if (!pathInfo.uri) {
-                            deferred.reject({
-                              cause: 'Save cancelled'
-                            });
-                          } else {
-                            var fileSaver = bkCoreManager.getFileSaver(pathInfo.uriType);
-                            fileSaver.save(pathInfo.uri, notebookModelAsString).then(function() {
-                              bkRecentMenu.recordRecentDocument(angular.toJson({
-                                uri: pathInfo.uri,
-                                type: pathInfo.uriType,
-                                readOnly: false,
-                                format: _.isEmpty(format) ? '' : format
-                              }));
-                              deferred.resolve();
-                            }, function(error) {
-                              deferred.reject({
-                                cause: 'error saving to file',
-                                error: error
-                              });
-                            });
-                          }
-                        });
-                        return deferred.promise;
                       }
+
+                      var deferred = bkUtils.newDeferred();
+                      bkCoreManager.showDefaultSavingFileChooser().then(function(pathInfo) {
+                        if (!pathInfo.uri) {
+                          return deferred.reject({
+                            cause: 'Save cancelled'
+                          });
+                        }
+
+                        var fileSaver = bkCoreManager.getFileSaver(pathInfo.uriType);
+                        fileSaver.save(pathInfo.uri, notebookModelAsString).then(function() {
+                          bkRecentMenu.recordRecentDocument(angular.toJson({
+                            uri: pathInfo.uri,
+                            type: pathInfo.uriType,
+                            readOnly: false,
+                            format: _.isEmpty(format) ? '' : format
+                          }));
+                          deferred.resolve();
+                        }, function(error) {
+                          deferred.reject({
+                            cause: 'error saving to file',
+                            error: error
+                          });
+                        });
+                      });
+
+                      return deferred.promise;
                     };
                     var savingFailedHandler = function(info) {
                       if (info.cause === 'Save cancelled') {

--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -418,7 +418,7 @@
     var _sessionId = null;
     var _edited = false;
     var _needsBackup = false;
-    var _saveDir = bkUtils.getHomeDirectory(); 
+    var _saveDir = bkUtils.getHomeDirectory();
 
     var BeakerObject = function(nbmodel) {
       this.knownBeakerVars = { };
@@ -977,6 +977,10 @@
       setNotebookModelEdited: function(edited) {
         _needsBackup = edited;
         _edited = edited;
+        if (edited === true) {
+          this.backup();
+        }
+
         bkUtils.httpPost("rest/session-backup/setEdited", {
           sessionid: _sessionId,
           edited: edited


### PR DESCRIPTION
When a user had multiple windows open, if they were to save from the dashboard it was possible to save an old version of the notebook.

This change makes it so a save from the dashboard will always use the latest backup.

---

Using the latest backup did raise an interesting problem however. Since we used to only update the backup on a poll we could reach a condition where we were backing up an old version. To fix this I now backup the notebook on edit state change

---

Fixes #1909

---

**Implementation notes**

As @DiegoAlbertoTorres pointed out there is a cost in calling backup eagerly for large notebooks. A solution that we can implement ontop of this PR would be to do what is outlined here #1975
