### PR TITLE
Fix Advanced mode height jumps

### DIFF
--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -137,7 +137,7 @@ bk-section-cell {
     min-height: 20px;
 
     .advanced-mode & {
-      min-height: 17px;
+      min-height: 18px;
       padding: 8px $grid-gutter-width;
     }
 

--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -120,7 +120,7 @@ bk-section-cell {
       padding: 8px $grid-gutter-width;
 
       &.input-hidden {
-        padding-top: $grid-row-height*2;
+        padding-top: 26px;
       }
     }
 


### PR DESCRIPTION
The input cell would jump by 10px when you hid the input

<img width="659" alt="screen shot 2015-07-27 at 4 41 17 pm" src="https://cloud.githubusercontent.com/assets/883126/8917267/0a3d0140-347f-11e5-8682-97914286ead4.png">
<img width="615" alt="screen shot 2015-07-27 at 4 38 52 pm" src="https://cloud.githubusercontent.com/assets/883126/8917266/0a3be86e-347f-11e5-95c2-2be7856be200.png">

the output cell would jump by 1px when you hid the output
