### PR TITLE
chart with one point crashes (#1452)

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotpoint.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotpoint.js
@@ -79,6 +79,14 @@
         range.yl = Math.min(range.yl, ele.y);
         range.yr = Math.max(range.yr, ele.y);
       }
+      if(range.xl == range.xr){
+        range.xl = range.xl - 0.1;
+        range.xr = range.xr + 0.1;
+      }
+      if(range.yl == range.yr){
+        range.yl = range.yl - 0.1;
+        range.yr = range.yr + 0.1;
+      }
       return range;
     };
 

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotpoint.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotpoint.js
@@ -79,11 +79,11 @@
         range.yl = Math.min(range.yl, ele.y);
         range.yr = Math.max(range.yr, ele.y);
       }
-      if(range.xl == range.xr){
+      if(range.xl === range.xr){
         range.xl = range.xl - 0.1;
         range.xr = range.xr + 0.1;
       }
-      if(range.yl == range.yr){
+      if(range.yl === range.yr){
         range.yl = range.yl - 0.1;
         range.yr = range.yr + 0.1;
       }


### PR DESCRIPTION
The problem was in plotGridlines function - data for gridlines (scope.rpipeGridlines) had NaN values.
This happened because plot had only one point and model range had equal xl/xr values. As the result we've got division by zero during calculating element.x percent value in PlotPoint.prototype.applyAxis.
To fix it I suggest increasing the model range if all elements have the same x or y axis coordinates.
