### PR TITLE
fix 404 error for JQueryUI images, close Issue #1618

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,9 +105,15 @@ task (copyRequireJS, type: Copy) {
 	into 'src/main/web/app/vendor/requirejs/'
 }
 
+task (copyJQueryUIImages, type: Copy) {
+    from 'src/main/web/vendor/jquery-ui/css/smoothness/images/'
+    into 'src/main/web/app/dist/images/'
+}
+
 task copyVendorStuff
 copyVendorStuff.dependsOn copyKatex
 copyVendorStuff.dependsOn copyRequireJS
+copyVendorStuff.dependsOn copyJQueryUIImages
 
 task (compileAssets, type: Exec) {
   commandLine(*(winOrUnix('npm', 'run-script', 'compile')))


### PR DESCRIPTION
use gradle to copy jquery-ui images from original vendor location to dist/images

For reproducing this bug you can try open Help menu, select "Tutorial", and then click on the link "Interactive Charts".
 You can see 404 error in console log. This error will disappear after applying my changes
