### PR TITLE
fix X axis labels should adjust to interval #1456

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -203,8 +203,16 @@
         scope.calcGridlines = function() {
           // prepare the gridlines
           var focus = scope.focus, model = scope.stdmodel;
-          model.xAxis.setGridlines(focus.xl, focus.xr, scope.numIntervals.x);
-          model.yAxis.setGridlines(focus.yl, focus.yr, scope.numIntervals.y);
+          model.xAxis.setGridlines(focus.xl,
+            focus.xr,
+            scope.numIntervals.x,
+            model.margin.left,
+            model.margin.right);
+          model.yAxis.setGridlines(focus.yl,
+            focus.yr,
+            scope.numIntervals.y,
+            model.margin.bottom,
+            model.margin.top);
         };
         scope.renderGridlines = function() {
           var focus = scope.focus, model = scope.stdmodel;

--- a/core/src/main/web/outputdisplay/bko-plot/plotaxis.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotaxis.js
@@ -34,6 +34,9 @@
       this.axisGridlineLabels = [];
       this.axisStep = 1;
       this.axisFixed = 0;
+
+      this.axisMarginValL = 0;
+      this.axisMarginValR = 0;
     };
     var dateIntws = [
       // milliseconds
@@ -82,7 +85,7 @@
       }
       this.axisValSpan = this.axisValR - this.axisValL;
     };
-    PlotAxis.prototype.setGridlines = function(pl, pr, count) {
+    PlotAxis.prototype.setGridlines = function(pl, pr, count, ml, mr) {
       if (pr < pl) {
         console.error("cannot set right coord < left coord");
         return;
@@ -94,6 +97,12 @@
       this.axisPctL = pl;
       this.axisPctR = pr;
       this.axisPctSpan = pr - pl;
+
+      if (this.axisType === "time") {
+        this.axisMarginValL = ml * this.axisValSpan;
+        this.axisMarginValR = mr * this.axisValSpan;
+      }
+
       var span = this.axisPctSpan * this.axisValSpan;
       var intws, fixs;
       if (this.axisType === "time") {
@@ -177,7 +186,7 @@
         }
       }
       var val = this.getValue(pct);
-      var span = this.axisValSpan * this.axisPctSpan;
+      var span = (this.axisValSpan - (this.axisMarginValL + this.axisMarginValR)) * this.axisPctSpan;
 
       var d, ret = "";
       if (this.axisType === "time") {
@@ -200,12 +209,14 @@
         ret = moment(d).tz(this.axisTimezone).format("mm:ss.SSS");
       } else if (span <= 1000 * 60 * 60) {
         ret = moment(d).tz(this.axisTimezone).format("HH:mm:ss");
-      } else if (span <= 1000) {
-        ret = moment(d).tz(this.axisTimeozne).format("MMM DD ddd, HH:mm");
+      } else if (span <= 1000 * 60 * 60 * 24) {
+        ret = moment(d).tz(this.axisTimezone).format("MMM DD ddd, HH:mm");
       } else if (span <= 1000 * 60 * 60 * 24 * 30) {
         ret = moment(d).tz(this.axisTimezone).format("MMM DD ddd");
-      } else {
+      } else if (span <= 1000 * 60 * 60 * 24 * 365) {
         ret = moment(d).tz(this.axisTimezone).format("YYYY MMM");
+      } else {
+        ret = moment(d).tz(this.axisTimezone).format("YYYY");
       }
 
       /*


### PR DESCRIPTION
Algorithm calculation x axis labels  has been fixed. Margins now will be used in PlotAxis.prototype.getString function. I will give an example

nye = 1230918822367

d = 30.0 \* 24 \* 60 \* 60 \* 1000

p = new TimePlot()
p << new Points(x:[nye, nye + d], y:[3,4])

X span in this case is equals ~33 days. Not 30 days.  We need remove left and right margins for selecting date format

 if (span <= 1000) {
        ret = val + "  ";
        ret = moment(d).tz(this.axisTimezone).format(".SSS") + ( (d - Math.floor(d)).toFixed(this.axisFixed));
      } else if (span <= 1000 \* 60) {
        ret = moment(d).tz(this.axisTimezone).format("mm:ss.SSS");
      } else if (span <= 1000 \* 60 \* 60) {
        ret = moment(d).tz(this.axisTimezone).format("HH:mm:ss");
      } else if (span <= 1000 \* 60 \* 60 \* 24) {
        ret = moment(d).tz(this.axisTimezone).format("MMM DD ddd, HH:mm");
      } else if (span <= 1000 \* 60 \* 60 \* 24 \* 30) {
        ret = moment(d).tz(this.axisTimezone).format("MMM DD ddd");
      } else if (span <= 1000 \* 60 \* 60 \* 24 \* 365) {
        ret = moment(d).tz(this.axisTimezone).format("YYYY MMM");
      } else {
        ret = moment(d).tz(this.axisTimezone).format("YYYY");
      }
