### PR TITLE
Tweak markdown cell menu vertical alignment

### DIFF
--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -245,3 +245,7 @@ bk-language-logo {
 .cell-run-time {
   color: #BDBDBD;
 }
+
+.markdown .toggle-menu {
+  top: 6px;
+}


### PR DESCRIPTION
##### Before:

<img width="885" alt="screen shot 2015-08-04 at 2 37 48 pm" src="https://cloud.githubusercontent.com/assets/883126/9069294/7611887c-3ab6-11e5-92b0-d8ee0af85ee0.png">
##### After:

<img width="935" alt="screen shot 2015-08-04 at 2 31 24 pm" src="https://cloud.githubusercontent.com/assets/883126/9069166/b5849d06-3ab5-11e5-8c43-5a2b6b339096.png">
