### PR TITLE
fix "Level-of-Detail (LOD) is enabled" banner gets annoying #898

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/notebook-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/notebook-directive.js
@@ -86,6 +86,12 @@
             },
             isDebugging: function () {
               return this._debugging;
+            },
+            getLodThreshold: function () {
+              return this._lodThreshold;
+            },
+            setLodThreshold: function (lodThreshold) {
+               this._lodThreshold = lodThreshold;
             }
           },
           getViewModel: function () {
@@ -307,6 +313,12 @@
         }).success(function(editMode) {
           if (editMode !== '')
             _impl._viewModel.setEditMode(editMode);
+        });
+
+        bkUtils.httpGet(bkUtils.serverUrl('beaker/rest/util/getPreference'), {
+          preference: 'lod-threshold'
+        }).success(function (lodThreshold) {
+          _impl._viewModel.setLodThreshold(lodThreshold);
         });
       },
       link: function (scope, element, attrs) {

--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -287,17 +287,7 @@
               scope.hasUnorderedItem = true;
             }
           }
-          if (scope.hasLodItem === true && scope.showLodHint === true) {
-            scope.showLodHint = false;
-            scope.renderMessage("Level-of-Detail (LOD) is enabled",
-              [ "Some data items contain too many elements to be directly plotted.",
-              "Level-of-Detail (LOD) rendering is automatically enabled. " +
-              "LOD hint is displayed at the right of the item legend.",
-              "LOD by default runs in auto mode. In auto mode, " +
-              "LOD will be automatically turned off when you reach detailed enough zoom level.",
-              "To switch LOD type, left click the LOD hint. " +
-              "To turn off LOD, right click the LOD hint." ]);
-          }
+
           if (scope.hasUnorderedItem === true && scope.showUnorderedHint === true) {
             scope.showUnorderedHint = false;
             scope.renderMessage("Unordered line / area detected",

--- a/core/src/main/web/outputdisplay/bko-plot/plotfactory.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotfactory.js
@@ -21,9 +21,11 @@
     PlotConstline, PlotConstband, PlotText,
     PlotLineLodLoader, PlotBarLodLoader, PlotStemLodLoader, PlotAreaLodLoader,
     PlotPointLodLoader) {
-    var lodthresh = 1500;
     return {
-      createPlotItem : function(item) {
+      createPlotItem : function(item, lodthresh) {
+        if (!lodthresh){
+          lodthresh = 4500;
+        }
         var size = item.elements.length;
         var plotitem;
         switch (item.type) {

--- a/core/src/main/web/outputdisplay/bko-plot/plotfactory.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotfactory.js
@@ -24,7 +24,7 @@
     return {
       createPlotItem : function(item, lodthresh) {
         if (!lodthresh){
-          lodthresh = 4500;
+          lodthresh = 1500;
         }
         var size = item.elements.length;
         var plotitem;

--- a/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
@@ -16,7 +16,8 @@
 
 (function() {
   'use strict';
-  var retfunc = function(bkUtils, plotConverter, PlotAxis, plotFactory, plotUtils) {
+  var retfunc = function(bkUtils, plotConverter, PlotAxis, plotFactory, plotUtils, bkHelper) {
+
     return {
       lineDasharrayMap : {
         "solid" : "",
@@ -276,7 +277,7 @@
           // recreate rendering objects
           item.index = i;
           item.id = "i" + i;
-          data[i] = plotFactory.createPlotItem(item);
+          data[i] = plotFactory.createPlotItem(item, bkHelper.getBkNotebookViewModel().getLodThreshold());
         }
 
         // apply log to focus
@@ -465,5 +466,5 @@
     };
   };
   beaker.bkoFactory('plotFormatter',
-    ["bkUtils", 'plotConverter', 'PlotAxis', 'plotFactory', 'plotUtils', retfunc]);
+    ["bkUtils", 'plotConverter', 'PlotAxis', 'plotFactory', 'plotUtils', 'bkHelper', retfunc]);
 })();

--- a/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
@@ -277,7 +277,8 @@
           // recreate rendering objects
           item.index = i;
           item.id = "i" + i;
-          data[i] = plotFactory.createPlotItem(item, bkHelper.getBkNotebookViewModel().getLodThreshold());
+
+          data[i] = plotFactory.createPlotItem(item, newmodel.lodThreshold);
         }
 
         // apply log to focus
@@ -379,6 +380,10 @@
             timezone : model.timezone
           };
         }
+
+        newmodel.lodThreshold = (model.lodThreshold) ?
+          model.lodThreshold :
+          bkHelper.getBkNotebookViewModel().getLodThreshold();
 
         newmodel.data = [];
 

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotarealodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotarealodloader.js
@@ -27,7 +27,7 @@
     };
     // class constants
     PlotAreaLodLoader.prototype.lodTypes = ["area", "river"];
-    PlotAreaLodLoader.prototype.lodSteps = [5, 5];
+    PlotAreaLodLoader.prototype.lodSteps = [1, 3];
 
     PlotAreaLodLoader.prototype.format = function() {
       // create plot type index

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotarealodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotarealodloader.js
@@ -31,7 +31,7 @@
 
     PlotAreaLodLoader.prototype.format = function() {
       // create plot type index
-      this.lodTypeIndex = 0;
+      this.lodTypeIndex =  (this.datacopy.lod_filter) ? this.lodTypes.indexOf(this.datacopy.lod_filter) : 0;
       this.lodType = this.lodTypes[this.lodTypeIndex]; // line, box
 
       // create the plotters
@@ -94,10 +94,14 @@
     };
 
     PlotAreaLodLoader.prototype.applyLodType = function(type) {
-      this.lodType = type;
-      this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
-      if (this.lodTypeIndex === -1) { this.lodTypeIndex = 0; }
-      this.createLodPlotter();
+      if (!this.datacopy.lod_filter) {
+        this.lodType = type;
+        this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
+        if (this.lodTypeIndex === -1) {
+          this.lodTypeIndex = 0;
+        }
+        this.createLodPlotter();
+      }
     };
 
     PlotAreaLodLoader.prototype.createLodPlotter = function() {

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotbarlodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotbarlodloader.js
@@ -30,7 +30,7 @@
 
     PlotBarLodLoader.prototype.format = function() {
       // create plot type index
-      this.lodTypeIndex = 0;
+      this.lodTypeIndex =  (this.datacopy.lod_filter) ? this.lodTypes.indexOf(this.datacopy.lod_filter) : 0;
       this.lodType = this.lodTypes[this.lodTypeIndex]; // line, box
 
       // create the plotters
@@ -93,10 +93,14 @@
     };
 
     PlotBarLodLoader.prototype.applyLodType = function(type) {
-      this.lodType = type;
-      this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
-      if (this.lodTypeIndex === -1) { this.lodTypeIndex = 0; }
-      this.createLodPlotter();
+      if (!this.datacopy.lod_filter) {
+        this.lodType = type;
+        this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
+        if (this.lodTypeIndex === -1) {
+          this.lodTypeIndex = 0;
+        }
+        this.createLodPlotter();
+      }
     };
 
     PlotBarLodLoader.prototype.createLodPlotter = function() {

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotbarlodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotbarlodloader.js
@@ -26,7 +26,7 @@
     };
     // class constants
     PlotBarLodLoader.prototype.lodTypes = ["bar", "box"];
-    PlotBarLodLoader.prototype.lodSteps = [5, 10];
+    PlotBarLodLoader.prototype.lodSteps = [3, 10];
 
     PlotBarLodLoader.prototype.format = function() {
       // create plot type index

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotlinelodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotlinelodloader.js
@@ -30,7 +30,7 @@
 
     PlotLineLodLoader.prototype.format = function() {
       // create plot type index
-      this.lodTypeIndex = 2;
+      this.lodTypeIndex =  (this.datacopy.lod_filter) ? this.lodTypes.indexOf(this.datacopy.lod_filter) : 2;
       this.lodType = this.lodTypes[this.lodTypeIndex];
 
       // create the plotters
@@ -81,10 +81,14 @@
     };
 
     PlotLineLodLoader.prototype.applyLodType = function(type) {
-      this.lodType = type;
-      this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
-      if (this.lodTypeIndex === -1) { this.lodTypeIndex = 0; }
-      this.createLodPlotter();
+      if (!this.datacopy.lod_filter) {
+        this.lodType = type;
+        this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
+        if (this.lodTypeIndex === -1) {
+          this.lodTypeIndex = 0;
+        }
+        this.createLodPlotter();
+      }
     };
 
     PlotLineLodLoader.prototype.createLodPlotter = function() {

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotlinelodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotlinelodloader.js
@@ -26,7 +26,7 @@
     };
     // class constants
     PlotLineLodLoader.prototype.lodTypes = ["line", "box", "river"];
-    PlotLineLodLoader.prototype.lodSteps = [5, 10, 5];
+    PlotLineLodLoader.prototype.lodSteps = [1, 10, 3];
 
     PlotLineLodLoader.prototype.format = function() {
       // create plot type index

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotpointlodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotpointlodloader.js
@@ -30,7 +30,7 @@
 
     PlotPointLodLoader.prototype.format = function() {
       // create plot type index
-      this.lodTypeIndex = 0;
+      this.lodTypeIndex =  (this.datacopy.lod_filter) ? this.lodTypes.indexOf(this.datacopy.lod_filter) : 0;
       this.lodType = this.lodTypes[this.lodTypeIndex]; // line, box
 
       // create the plotters
@@ -168,10 +168,14 @@
     };
 
     PlotPointLodLoader.prototype.applyLodType = function(type) {
-      this.lodType = type;
-      this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
-      if (this.lodTypeIndex === -1) { this.lodTypeIndex = 0; }
-      this.createLodPlotter();
+      if (!this.datacopy.lod_filter) {
+        this.lodType = type;
+        this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
+        if (this.lodTypeIndex === -1) {
+          this.lodTypeIndex = 0;
+        }
+        this.createLodPlotter();
+      }
     };
 
     PlotPointLodLoader.prototype.createSampler = function() {

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotpointlodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotpointlodloader.js
@@ -26,7 +26,7 @@
     };
     // class constants
     PlotPointLodLoader.prototype.lodTypes = ["point", "box"];
-    PlotPointLodLoader.prototype.lodSteps = [5, 10];
+    PlotPointLodLoader.prototype.lodSteps = [3, 10];
 
     PlotPointLodLoader.prototype.format = function() {
       // create plot type index

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotstemlodloader.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/lodloader/plotstemlodloader.js
@@ -31,7 +31,7 @@
 
     PlotStemLodLoader.prototype.format = function() {
       // create plot type index
-      this.lodTypeIndex = 0;
+      this.lodTypeIndex =  (this.datacopy.lod_filter) ? this.lodTypes.indexOf(this.datacopy.lod_filter) : 0;
       this.lodType = this.lodTypes[this.lodTypeIndex]; // line, box
 
       // create the plotters
@@ -94,10 +94,14 @@
     };
 
     PlotStemLodLoader.prototype.applyLodType = function(type) {
-      this.lodType = type;
-      this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
-      if (this.lodTypeIndex === -1) { this.lodTypeIndex = 0; }
-      this.createLodPlotter();
+      if (!this.datacopy.lod_filter) {
+        this.lodType = type;
+        this.lodTypeIndex = this.lodTypes.indexOf(type);  // maybe -1
+        if (this.lodTypeIndex === -1) {
+          this.lodTypeIndex = 0;
+        }
+        this.createLodPlotter();
+      }
     };
 
     PlotStemLodLoader.prototype.createLodPlotter = function() {

--- a/plugin/groovy/src/dist/groovy.js
+++ b/plugin/groovy/src/dist/groovy.js
@@ -164,6 +164,7 @@ define(function(require, exports, module) {
     "com.twosigma.beaker.NamespaceClient",
     "com.twosigma.beaker.BeakerProgressUpdate",
     "com.twosigma.beaker.chart.Color",
+    "com.twosigma.beaker.chart.Filter",
     "com.twosigma.beaker.chart.xychart.*",
     "com.twosigma.beaker.chart.xychart.plotitem.*",
     "com.twosigma.beaker.easyform.*",

--- a/plugin/javash/src/dist/javash.js
+++ b/plugin/javash/src/dist/javash.js
@@ -161,6 +161,7 @@ define(function(require, exports, module) {
   };
   var defaultImports = [
     "com.twosigma.beaker.chart.Color",
+    "com.twosigma.beaker.chart.Filter",
     "com.twosigma.beaker.BeakerProgressUpdate",
     "com.twosigma.beaker.chart.xychart.*",
     "com.twosigma.beaker.chart.xychart.plotitem.*",

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/Filter.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/Filter.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2014 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+
+package com.twosigma.beaker.chart;
+
+public enum Filter {
+
+  AREA("area"),
+  LINE("line"),
+  BAR("bar"),
+  BOX("box"),
+  POINT("point"),
+  STEAM("stem"),
+  STEAM_PLUS("stem+"),
+  RIVER("river");
+
+  private String text;
+
+  Filter(String text) {
+    this.text = text;
+  }
+
+  public String getText() {
+    return text;
+  }
+
+}

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/AreaSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/AreaSerializer.java
@@ -40,6 +40,8 @@ public class AreaSerializer extends JsonSerializer<Area> {
     jgen.writeObjectField("y", area.getY());
     jgen.writeObjectField("visible", area.getVisible());
     jgen.writeObjectField("display_name", area.getDisplayName());
+    if (area.getLodFilter() != null)
+      jgen.writeObjectField("lod_filter", area.getLodFilter().getText());
     if (area.getColor() instanceof Color) {
       jgen.writeObjectField("color", area.getColor());
     }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/BarsSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/BarsSerializer.java
@@ -39,6 +39,8 @@ public class BarsSerializer extends JsonSerializer<Bars> {
     jgen.writeObjectField("y", bars.getY());
     jgen.writeObjectField("visible", bars.getVisible());
     jgen.writeObjectField("display_name", bars.getDisplayName());
+    if (bars.getLodFilter() != null)
+      jgen.writeObjectField("lod_filter", bars.getLodFilter().getText());
     if (bars.getBases() != null) {
       jgen.writeObjectField("bases", bars.getBases());
     } else {

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/LineSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/LineSerializer.java
@@ -36,6 +36,8 @@ public class LineSerializer extends JsonSerializer<Line> {
     jgen.writeObjectField("y", line.getY());
     jgen.writeObjectField("visible", line.getVisible());
     jgen.writeObjectField("display_name", line.getDisplayName());
+    if (line.getLodFilter() != null)
+      jgen.writeObjectField("lod_filter", line.getLodFilter().getText());
     if (line.getColor() instanceof Color) {
       jgen.writeObjectField("color", line.getColor());
     }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/PointsSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/PointsSerializer.java
@@ -39,6 +39,8 @@ public class PointsSerializer extends JsonSerializer<Points> {
     jgen.writeObjectField("y", points.getY());
     jgen.writeObjectField("visible", points.getVisible());
     jgen.writeObjectField("display_name", points.getDisplayName());
+    if (points.getLodFilter() != null)
+      jgen.writeObjectField("lod_filter", points.getLodFilter().getText());
     if (points.getSizes() != null) {
       jgen.writeObjectField("sizes", points.getSizes());
     } else {

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/StemsSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/StemsSerializer.java
@@ -39,6 +39,8 @@ public class StemsSerializer extends JsonSerializer<Stems> {
     jgen.writeObjectField("y", stems.getY());
     jgen.writeObjectField("visible", stems.getVisible());
     jgen.writeObjectField("display_name", stems.getDisplayName());
+    if (stems.getLodFilter() != null)
+      jgen.writeObjectField("lod_filter", stems.getLodFilter().getText());
     if (stems.getBases() != null) {
       jgen.writeObjectField("bases", stems.getBases());
     } else {

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/XYChartSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/XYChartSerializer.java
@@ -90,6 +90,8 @@ public class XYChartSerializer extends JsonSerializer<XYChart> {
     jgen.writeObjectField("log_y", xychart.getLogY());
     jgen.writeObjectField("time_zone", xychart.getTimeZone());
     jgen.writeObjectField("crosshair", xychart.getCrosshair());
+    if (xychart.getLodThreshold() != null)
+      jgen.writeObjectField("lodThreshold", xychart.getLodThreshold());
     jgen.writeEndObject();
   }
 

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/XYChart.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/XYChart.java
@@ -16,6 +16,7 @@
 
 package com.twosigma.beaker.chart.xychart;
 
+import com.twosigma.beaker.chart.Filter;
 import com.twosigma.beaker.chart.xychart.plotitem.ConstantBand;
 import com.twosigma.beaker.chart.xychart.plotitem.ConstantLine;
 import com.twosigma.beaker.chart.xychart.plotitem.Crosshair;
@@ -47,6 +48,7 @@ abstract public class XYChart {
   private boolean logX = false;
   protected TimeZone timeZone;
   private Crosshair crosshair;
+  private Integer lodThreshold = null;
 
   protected XYChart() {
     yAxes.add(yAxis);
@@ -404,5 +406,14 @@ abstract public class XYChart {
 
   public Crosshair getCrosshair() {
     return this.crosshair;
+  }
+
+
+  public Integer getLodThreshold() {
+    return lodThreshold;
+  }
+
+  public void setLodThreshold(Integer lodThreshold) {
+    this.lodThreshold = lodThreshold;
   }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Area.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Area.java
@@ -17,10 +17,15 @@
 package com.twosigma.beaker.chart.xychart.plotitem;
 
 import com.twosigma.beaker.chart.Color;
+import com.twosigma.beaker.chart.Filter;
+
+import java.util.EnumSet;
 import java.util.List;
 
 
 public class Area extends XYGraphics {
+
+  private final static EnumSet<Filter> POSSIBLE_LOD_FILTERS = EnumSet.of(Filter.AREA, Filter.RIVER);
 
   private Color color;
   private Number baseBase = 0.0d;
@@ -73,5 +78,10 @@ public class Area extends XYGraphics {
 
   public Integer getInterpolation() {
     return this.interpolation;
+  }
+
+  @Override
+  protected EnumSet<Filter> getPossibleFilters() {
+    return POSSIBLE_LOD_FILTERS;
   }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Bars.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Bars.java
@@ -17,12 +17,17 @@
 package com.twosigma.beaker.chart.xychart.plotitem;
 
 import com.twosigma.beaker.chart.Color;
+import com.twosigma.beaker.chart.Filter;
+
+import java.util.EnumSet;
 import java.util.List;
 
 
 public class Bars extends XYGraphics {
 
-  private Number baseWidth;
+  private final static EnumSet<Filter> POSSIBLE_LOD_FILTERS = EnumSet.of(Filter.BAR, Filter.BOX);
+
+  private Number       baseWidth;
   private List<Number> widths;
   private Number baseBase = 0.0d;
   private List<Number> bases;
@@ -40,7 +45,7 @@ public class Bars extends XYGraphics {
       setBases(ss);
     } else {
       throw new IllegalArgumentException(
-          "setBase takes Number or List of Number");
+        "setBase takes Number or List of Number");
     }
   }
 
@@ -138,4 +143,9 @@ public class Bars extends XYGraphics {
     return this.outlineColors;
   }
 
+
+  @Override
+  protected EnumSet<Filter> getPossibleFilters() {
+    return POSSIBLE_LOD_FILTERS;
+  }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Line.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Line.java
@@ -17,16 +17,24 @@
 package com.twosigma.beaker.chart.xychart.plotitem;
 
 import com.twosigma.beaker.chart.Color;
+import com.twosigma.beaker.chart.Filter;
+
+import java.util.EnumSet;
 import java.util.List;
 
 
 public class Line extends XYGraphics {
 
-  private Color color;
+  private final static EnumSet<Filter> POSSIBLE_LOD_FILTERS = EnumSet.of(Filter.LINE,
+                                                                         Filter.BOX,
+                                                                         Filter.RIVER);
+
+
+  private Color       color;
   private List<Color> colors;
   private Float width = 1.5f;
   private StrokeType style;
-  private Integer interpolation;
+  private Integer    interpolation;
 
   public Line() {
 
@@ -50,7 +58,7 @@ public class Line extends XYGraphics {
       setColors(temp);
     } else {
       throw new IllegalArgumentException(
-          "setColor takes Color or List of Color");
+        "setColor takes Color or List of Color");
     }
   }
 
@@ -102,4 +110,8 @@ public class Line extends XYGraphics {
     return this.interpolation;
   }
 
+  @Override
+  protected EnumSet<Filter> getPossibleFilters() {
+    return POSSIBLE_LOD_FILTERS;
+  }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Points.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Points.java
@@ -17,10 +17,16 @@
 package com.twosigma.beaker.chart.xychart.plotitem;
 
 import com.twosigma.beaker.chart.Color;
+import com.twosigma.beaker.chart.Filter;
+
+import java.util.EnumSet;
 import java.util.List;
 
 
 public class Points extends XYGraphics {
+
+  private final static EnumSet<Filter> POSSIBLE_LOD_FILTERS = EnumSet.of(Filter.POINT,
+                                                                         Filter.BOX);
 
   private float baseSize = 6.0f;
   private List<Number> sizes;
@@ -164,5 +170,9 @@ public class Points extends XYGraphics {
     return this.outlineColors;
   }
 
+  @Override
+  protected EnumSet<Filter> getPossibleFilters() {
+    return POSSIBLE_LOD_FILTERS;
+  }
 
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Stems.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/Stems.java
@@ -17,10 +17,18 @@
 package com.twosigma.beaker.chart.xychart.plotitem;
 
 import com.twosigma.beaker.chart.Color;
+import com.twosigma.beaker.chart.Filter;
+
+import java.util.EnumSet;
 import java.util.List;
 
 
 public class Stems extends XYGraphics {
+
+  private final static EnumSet<Filter> POSSIBLE_LOD_FILTERS = EnumSet.of(Filter.STEAM,
+                                                                         Filter.STEAM_PLUS,
+                                                                         Filter.BOX);
+
 
   private Number baseBase;
   private List<Number> bases;
@@ -31,7 +39,7 @@ public class Stems extends XYGraphics {
   private List<StrokeType> styles;
 
 
-   public void setBase(Object base) {
+  public void setBase(Object base) {
     if (base instanceof Number) {
       this.baseBase = ((Number) base).floatValue();
     } else if (base instanceof List) {
@@ -40,7 +48,7 @@ public class Stems extends XYGraphics {
       setBases(ss);
     } else {
       throw new IllegalArgumentException(
-          "setBase takes Number or List of Number");
+        "setBase takes Number or List of Number");
     }
   }
 
@@ -118,5 +126,10 @@ public class Stems extends XYGraphics {
 
   public List<StrokeType> getStyles() {
     return this.styles;
+  }
+
+  @Override
+  protected EnumSet<Filter> getPossibleFilters() {
+    return POSSIBLE_LOD_FILTERS;
   }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/XYGraphics.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/XYGraphics.java
@@ -17,15 +17,19 @@
 package com.twosigma.beaker.chart.xychart.plotitem;
 
 import com.twosigma.beaker.chart.Color;
+import com.twosigma.beaker.chart.Filter;
+
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 abstract public class XYGraphics {
   private List<Number> xs;
   private List<Number> ys;
-  private boolean visible = true;
-  private String displayName = "";
-  private String yAxisName = null;
+  private boolean visible     = true;
+  private String  displayName = "";
+  private String  yAxisName   = null;
+  private Filter lodFilter;
 
   public void setX(List<Number> xs) {
     this.xs = xs;
@@ -81,6 +85,22 @@ abstract public class XYGraphics {
     }
   }
 
+  public Filter getLodFilter() {
+    return lodFilter;
+  }
+
+  public void setLodFilter(Filter lodFilter){
+    if (getPossibleFilters().contains(lodFilter)){
+      this.lodFilter = lodFilter;
+    }else{
+      throw new RuntimeException(String.format("%s doesn't not support '%s' filter.",
+                                               getClass().getSimpleName(),
+                                               lodFilter.getText()));
+    }
+
+  }
+
   abstract public void setColori(Color color);
   abstract public Color getColor();
+  abstract protected EnumSet<Filter> getPossibleFilters();
 }

--- a/plugin/scala/src/dist/scala.js
+++ b/plugin/scala/src/dist/scala.js
@@ -157,6 +157,7 @@ define(function(require, exports, module) {
                         "com.twosigma.beaker.NamespaceClient",
                         "com.twosigma.beaker.BeakerProgressUpdate",
                         "com.twosigma.beaker.chart.Color",
+                        "com.twosigma.beaker.chart.Filter",
                         "com.twosigma.beaker.chart.xychart.*",
                         "com.twosigma.beaker.chart.xychart.plotitem.*",
                         "com.twosigma.beaker.easyform.*",


### PR DESCRIPTION
The LoD indicator has been removed (the legend is enough).

The default  LoD threshold has been increased 3x .

LoD threshold now can be changed in the breaker.pref.json (for example "lod-threshold": 4500) (I can add API to XYChart. Is it necessary?)

API control of display method (avg, river, box and etc.) has been added in all XYGraphics successors.
Filter getLodFilter()
void setLodFilter(Filter lodFilter)
