### PR TITLE
1878. ggmap crashes R backend

### DIFF
--- a/plugin/r/build.gradle
+++ b/plugin/r/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
   provided project(':plugin:jvm')
   provided group: 'net.rforge', name: 'Rserve', version: '0.6-8.1'
-  compile 'org.apache.xmlgraphics:batik-rasterizer:1.7'
+  compile 'org.apache.xmlgraphics:batik-rasterizer:1.8'
   compile 'org.apache.xmlgraphics:batik-codec:1.7'
   compile 'org.apache.xmlgraphics:xmlgraphics-commons:2.0.1'
 }

--- a/plugin/r/build.gradle
+++ b/plugin/r/build.gradle
@@ -28,7 +28,8 @@ repositories {
 dependencies {
   provided project(':plugin:jvm')
   provided group: 'net.rforge', name: 'Rserve', version: '0.6-8.1'
-  compile 'org.apache.xmlgraphics:batik-rasterizer:1.8'
+  compile 'org.apache.xmlgraphics:batik-rasterizer:1.7'
+  compile 'org.apache.xmlgraphics:batik-codec:1.7'
   compile 'org.apache.xmlgraphics:xmlgraphics-commons:2.0.1'
 }
 


### PR DESCRIPTION
Apache Batik 1.8 crashes when SVG file contains <image> with inlined base64 encoded content.
There are several issues in Apache Batik's Jira. The most recent is https://issues.apache.org/jira/browse/BATIK-1125
They are still not fixed and according to comment the only solution is:
"A temporary solution is to include the 1.7 codecs which has the classes org/apache/batik/ext/awt/image/codec/imageio/*"

I've changed batik-rasterizer version from 1.8 to 1.7 and added batik-codec 1.7 to beaker R plugin.

Please, give advice or confirm.
