### PR TITLE
Add http_host variable to fix redirects when nginx is not reached on …

### DIFF
--- a/core/nginx/nginx.conf.template
+++ b/core/nginx/nginx.conf.template
@@ -61,10 +61,10 @@ http {
 
     # redirect to the starting page
     location = / {
-      return 301 %(start_page)s;
+      return 301 $scheme://$http_host%(start_page)s;
     }
     location = /beaker {
-      return 301 %(start_page)s;
+      return 301 $scheme://$http_host%(start_page)s;
     }
 
     # user directory
@@ -82,7 +82,7 @@ http {
       proxy_set_header Authorization "Basic %(auth)s";
     }
     location = /%(urlhash)s/beaker/ {
-      return 301 %(start_page)s;
+      return 301 $scheme://$http_host%(start_page)s;
     }
 
     # this serves the actual (static) content


### PR DESCRIPTION
…the same port it listens on.

This fixes incorrect 301 redirects. nginx uses its configuration to respond with full `Location` header in 301 response. However, the port in configuration does not always match the port in $http_host, especially when Beaker is behind NAT.
