### PR TITLE
add tick marks to plots #2028

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.css
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.css
@@ -84,7 +84,9 @@
   stroke-width: 3;
   opacity: .75;
 }
-
+.plot-tick {
+  stroke: #333333;
+}
 
 
 .plot-constline,

--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -151,6 +151,8 @@
             y : -1
           };
 
+          scope.gridlineTickLength = 3;
+
           var factor = 2.0;
           if (model.xAxis.axisLabel == null) { factor -= 1.0; }
           if (model.xAxis.showGridlineLabels === false) { factor -= 1.0; }
@@ -509,6 +511,58 @@
               "y" : y,
               "transform" : "rotate(-90 " + x + " " + y + ")"
             });
+          }
+        };
+
+        scope.renderGridlineTicks = function() {
+          var tickLength = scope.gridlineTickLength;
+          var mapX = scope.data2scrX, mapY = scope.data2scrY;
+          var focus = scope.focus;
+          var model = scope.stdmodel;
+          if (model.xAxis.showGridlineLabels !== false) {
+            var lines = model.xAxis.getGridlines(),
+              labels = model.xAxis.getGridlineLabels();
+            for (var i = 0; i < labels.length; i++) {
+              var x = lines[i];
+              scope.rpipeTicks.push({
+                "id" : "tick_x_" + i,
+                "class" : "plot-tick",
+                "x1" : mapX(x),
+                "y1" : mapY(focus.yl),
+                "x2" : mapX(x),
+                "y2" : mapY(focus.yl) + tickLength
+              });
+            }
+          }
+          if (model.yAxis.showGridlineLabels !== false) {
+            lines = model.yAxis.getGridlines();
+            labels = model.yAxis.getGridlineLabels();
+            for (var i = 0; i < labels.length; i++) {
+              var y = lines[i];
+              scope.rpipeTicks.push({
+                "id" : "tick_y_" + i,
+                "class" : "plot-tick",
+                "x1" : mapX(focus.xl) - tickLength,
+                "y1" : mapY(y),
+                "x2" : mapX(focus.xl),
+                "y2" : mapY(y)
+              });
+            }
+          }
+          if (model.yAxisR && model.yAxisR.showGridlineLabels !== false) {
+            lines = model.yAxisR.getGridlines();
+            labels = model.yAxisR.getGridlineLabels();
+            for (var i = 0; i < labels.length; i++) {
+              var y = lines[i];
+              scope.rpipeTicks.push({
+                "id" : "tick_yr_" + i,
+                "class" : "plot-tick",
+                "x1" : mapX(focus.xr),
+                "y1" : mapY(y),
+                "x2" : mapX(focus.xr) + tickLength,
+                "y2" : mapY(y)
+              });
+            }
           }
         };
 
@@ -1397,6 +1451,7 @@
 
           scope.rpipeGridlines = [];
           scope.rpipeTexts = [];
+          scope.rpipeTicks = [];
         };
         scope.enableZoom = function() {
           scope.svg.call(scope.zoomObj.on("zoomstart", function(d) {
@@ -1589,8 +1644,10 @@
 
           scope.renderData();
           scope.renderGridlineLabels();
+          scope.renderGridlineTicks();
           scope.renderCoverBox(); // redraw
           plotUtils.plotLabels(scope); // redraw
+          plotUtils.plotTicks(scope); // redraw
 
           scope.renderTips();
           scope.renderLocateBox(); // redraw

--- a/core/src/main/web/outputdisplay/bko-plot/plotutils.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotutils.js
@@ -106,6 +106,17 @@
           .attr("y1", function(d) { return d.y1; })
           .attr("y2", function(d) { return d.y2; });
       },
+      plotTicks: function(scope){
+        scope.labelg.selectAll("line").remove();
+        scope.labelg.selectAll("line")
+          .data(scope.rpipeTicks, function(d) { return d.id; }).enter().append("line")
+          .attr("id", function(d) { return d.id; })
+          .attr("class", function(d) { return d.class; })
+          .attr("x1", function(d) { return d.x1; })
+          .attr("x2", function(d) { return d.x2; })
+          .attr("y1", function(d) { return d.y1; })
+          .attr("y2", function(d) { return d.y2; });
+      },
       plotLabels: function(scope) {   // redraw
         var pipe = scope.rpipeTexts;
         scope.labelg.selectAll("text").remove();


### PR DESCRIPTION
Tick marks were added to plots.

![image](https://cloud.githubusercontent.com/assets/12935591/9255150/19c657dc-41f0-11e5-8ccd-c0399a63c469.png)

tick marks are not displayed if there are not gridline labels
![image](https://cloud.githubusercontent.com/assets/12935591/9255210/80000dea-41f0-11e5-91f6-d2836b88dd57.png)

plot with two yAxes
![image](https://cloud.githubusercontent.com/assets/12935591/9255055/93382e98-41ef-11e5-952b-13e3e3c3ab76.png)
