### PR TITLE
fix TimePlot tz problems #1454

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotaxis.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotaxis.js
@@ -22,7 +22,7 @@
       this.axisType = type == null ? "linear" : type; // linear, log, time, [nanotime, category]
       this.axisBase = 10;
       this.axisTime = 0;
-      this.axisTimezone = "America/New_York";
+      this.axisTimezone = "UTC";
       this.axisValL = 0;
       this.axisValR = 1;
       this.axisValSpan = 1;
@@ -236,13 +236,26 @@
       var calcCommonPart = function () {
         var common = '';
 
-        if (axisType === "time" && span >= HOUR) {
-          if (span <= DAY) {
-            common = labels[0].substring(0, 16);
-          } else if (span <= MONTH) {
-            common = labels[0].substring(0, 8);
-          } else if (span <= YEAR) {
-            common = labels[0].substring(0, 4);
+        if (axisType === "time" && span >= HOUR && labels.length > 1) {
+
+          var tokens = labels[0].split(' ');
+
+          var index = 0;
+
+          var checkCommon = function (index) {
+
+            var substring =  (common != '') ? common + ' ' + tokens[index] : tokens[index];
+            for (i = 1; i < labels.length; i++) {
+              if (substring !== labels[i].substring(0, substring.length)) {
+                return false;
+              }
+            }
+            return true;
+          };
+
+          while(checkCommon(index)){
+            common = (common != '') ? common + ' ' + tokens[index] : tokens[index];
+            index = index+1;
           }
 
           if (common.length > 1) {

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/XYChartSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/XYChartSerializer.java
@@ -88,7 +88,7 @@ public class XYChartSerializer extends JsonSerializer<XYChart> {
     jgen.writeObjectField("y_upper_bound", xychart.getYUpperBound());
     jgen.writeObjectField("log_x", xychart.getLogX());
     jgen.writeObjectField("log_y", xychart.getLogY());
-    jgen.writeObjectField("time_zone", xychart.getTimeZone());
+    jgen.writeObjectField("timezone", xychart.getTimeZone());
     jgen.writeObjectField("crosshair", xychart.getCrosshair());
     jgen.writeObjectField("legend_position", xychart.getLegendPosition());
     if (xychart.getLodThreshold() != null) {


### PR DESCRIPTION
Default timezone has been changed to the 'UTC'. Typo in the XYChartSerializer has been fixed. Also algorithm for an extraction common part from time values has been improved (see https://github.com/twosigma/beaker-notebook/issues/2081).

Notebook for tests https://www.dropbox.com/s/sipau5hou3hlywx/1454.bkr?dl=0
