### PR TITLE
Temporary fix for install-dependencies.sh for the Big Split

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - sudo apt-get install nginx
   - sudo apt-get install libzmq3-dbg libzmq3-dev libzmq3
   - sudo apt-get install python-pip python-dev
-  - sudo pip install ipython jinja2 tornado
+  - sudo pip install ipython==3.2.1 jinja2 tornado
   - sudo pip install pyzmq
   - sudo apt-get install python-matplotlib python-scipy python-pandas
   - sudo apt-get install r-base r-base-dev

--- a/launcher/ubuntu/install-dependencies.sh
+++ b/launcher/ubuntu/install-dependencies.sh
@@ -57,13 +57,13 @@ sudo apt-get install -y libzmq3-dbg libzmq3-dev libzmq3
 
 # ipython
 sudo apt-get install -y python-pip python-dev python-yaml
-sudo pip install ipython jinja2 tornado pyzmq pandas jsonschema
+sudo pip install ipython==3.2.1 jinja2 tornado pyzmq pandas jsonschema
 sudo apt-get install -y python-matplotlib python-scipy
 
 # python3
 
-sudo apt-get install -y python-virtualenv python3-dev pkgconf libfreetype6-dev libfreetype6 libxft-dev libblas-dev liblapack-dev gfortran libyaml-dev 
-virtualenv ~/py3k -p python3 
+sudo apt-get install -y python-virtualenv python3-dev pkgconf libfreetype6-dev libfreetype6 libxft-dev libblas-dev liblapack-dev gfortran libyaml-dev
+virtualenv ~/py3k -p python3
 ~/py3k/bin/pip install ipython[notebook]==3.0.0
 ~/py3k/bin/pip install numpy matplotlib scipy jinja2 tornado pyzmq pandas pyaml
 


### PR DESCRIPTION
Using a straight pip install ipython now downloads ipython 4. However, the ipython notebook has been spun off as jupyter starting in 4, causing some errors in the start up script (ImportError: No module named notebook.notebookapp). This can be seen by running `./beaker.command` or by running `ipython notebook`.

This fix forces pip to install version 3.2.1, where the command still works, until Beaker supports "The Big Split".
