### PR TITLE
Start page menu style tweaks

### DIFF
--- a/core/src/main/web/app/styles/notebook.scss
+++ b/core/src/main/web/app/styles/notebook.scss
@@ -69,3 +69,11 @@ bk-new-cell-menu {
     }
   }
 }
+
+#start-page-menu-item {
+  border-bottom: solid 1px #CCC;
+
+  i {
+    color: #CCC;
+  }
+}

--- a/core/src/main/web/app/template/dropdown_item.jst.html
+++ b/core/src/main/web/app/template/dropdown_item.jst.html
@@ -22,6 +22,7 @@
      title="{{item.tooltip}}"
      eat-click>
     <i class="glyphicon glyphicon-ok" ng-show="isMenuItemChecked(item)"></i>
+    <span ng-bind-html="getCustomMarkup(item)"></span>
     {{getName(item)}}
   </a>
 </li>

--- a/core/src/main/web/app/utils/basic/commonui.js
+++ b/core/src/main/web/app/utils/basic/commonui.js
@@ -126,7 +126,7 @@
       }
     };
   });
-  module.directive('bkDropdownMenuItem', function($compile) {
+  module.directive('bkDropdownMenuItem', function($compile, $sce) {
     return {
       restrict: 'E',
       template: JST['template/dropdown_item'](),
@@ -191,6 +191,10 @@
             }
           }
         };
+
+        $scope.getCustomMarkup = function(item) {
+          return $sce.trustAsHtml(_.result(item, 'markup') || '');
+        }
 
         $scope.getName = function(item) {
           var name = '';

--- a/core/src/main/web/plugin/menu/view.js
+++ b/core/src/main/web/plugin/menu/view.js
@@ -24,6 +24,8 @@ define(function(require, exports, module) {
     {
       name: 'Start Page',
       sortorder: 100,
+      id: 'start-page-menu-item',
+      markup: '<i class="glyphicon glyphicon-home"></i>',
       action: function() {
         bkHelper.gotoControlPanel();
       }


### PR DESCRIPTION
Initially I have updated the icon to use the house icon that comes with the font-icon lib that we are using.

<img width="292" alt="screen shot 2015-08-17 at 1 57 34 pm" src="https://cloud.githubusercontent.com/assets/883126/9311979/f40f7d2a-44e7-11e5-9b86-666c994e8ddf.png">

When we do the next pass on this feature to update the checkmark style and home icon I think that we should create a custom glyphion font-set via https://icomoon.io/app/#/select
