### PR TITLE
Silence 4XX errors when probing for user session

### DIFF
--- a/core/src/main/web/app/beaker.js
+++ b/core/src/main/web/app/beaker.js
@@ -411,10 +411,6 @@
         };
       });
     });
-
-    beaker.run(function(bkPublicationAuth) {
-      return bkPublicationAuth.initSession();
-    });
   };
   var bootstrapBkApp = function() {
     // make sure requirejs reports error

--- a/core/src/main/web/app/mainapp/components/publication/publication.js
+++ b/core/src/main/web/app/mainapp/components/publication/publication.js
@@ -23,6 +23,8 @@
     ['$scope', 'bkUtils', 'bkPublicationApi', 'bkPublicationAuth', 'bkSessionManager', '$modalInstance',
     function($scope, bkUtils, bkPublicationApi, bkPublicationAuth, bkSessionManager, $modalInstance) {
 
+      bkPublicationAuth.initSession();
+
       var notebook = bkSessionManager.getRawNotebookModel();
 
       $scope.user = {role: 'beaker'};

--- a/core/src/main/web/app/utils/publication.js
+++ b/core/src/main/web/app/utils/publication.js
@@ -35,7 +35,7 @@
         return bkUtils.httpPostJson(baseUrl + '/user/v1/sessions', params)
       },
       getCurrentUser: function() {
-        return bkUtils.httpGetJson(baseUrl + '/user/v1/current_user', {}, headers())
+        return bkUtils.httpGetJson(baseUrl + '/user/v1/current_user', {silent: true}, headers())
       },
       createPublication: function(params) {
         return bkUtils.httpPostJson(baseUrl + '/notebook/v1/publications', params, headers());


### PR DESCRIPTION
With this change the 404 request will be logged to dev console when the publish modal is opened and not on Beaker start-up.

Fixes https://github.com/twosigma/beaker-notebook/issues/2127
