### PR TITLE
Add settings for Java source/target version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -18,6 +18,9 @@ apply plugin:'java'
 apply plugin:'application'
 mainClassName = 'com.twosigma.beaker.core.Main'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 def windows() {
   return System.getProperty('os.name').contains('Windows')
 }

--- a/core/config/builds/dev/build.gradle
+++ b/core/config/builds/dev/build.gradle
@@ -17,6 +17,8 @@ def coreDir = file("../../../") // TODO, this can come from a property
 
 ext {
   evalPluginDir = new File(coreDir, "config/plugins/eval")
+  javaSourceVersion = JavaVersion.VERSION_1_7
+  javaTargetVersion = JavaVersion.VERSION_1_7
 }
 
 task build

--- a/plugin/clojure/build.gradle
+++ b/plugin/clojure/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/plugin/cpp/build.gradle
+++ b/plugin/cpp/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/plugin/groovy/build.gradle
+++ b/plugin/groovy/build.gradle
@@ -16,6 +16,9 @@
 apply plugin: 'java'
 apply plugin: 'groovy'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/plugin/javash/build.gradle
+++ b/plugin/javash/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/plugin/jvm/build.gradle
+++ b/plugin/jvm/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/plugin/kdb/build.gradle
+++ b/plugin/kdb/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/plugin/scala/build.gradle
+++ b/plugin/scala/build.gradle
@@ -16,6 +16,9 @@
 apply plugin: 'java'
 apply plugin: 'scala'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -15,6 +15,9 @@
  */
 apply plugin: 'java'
 
+sourceCompatibility = javaSourceVersion
+targetCompatibility = javaTargetVersion
+
 repositories {
   mavenCentral()
 }


### PR DESCRIPTION
This allows the setting (in a single place) of the Java source and target versions, these usually should match the JRE being built and/or deployed, but helps maintain backwards compatibility with Java versions.

The single setting is in core/config/builds/dev/build.gradle, the projects that apply the Java plugin will set the properties (added by the Java plugin) to those values.
