### PR TITLE
plots rendered inside a closed section have size 0 #2157

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -1708,11 +1708,11 @@
         });
 
         scope.getCellWidth = function () {
-          return scope.container.node().getBoundingClientRect().width;
+          return scope.jqcontainer.width();
         };
 
         scope.getCellHeight= function () {
-          return scope.container.node().getBoundingClientRect().height;
+          return scope.jqcontainer.height();
         };
 
         var watchCellSize = function () {


### PR DESCRIPTION
scope.container.node().getBoundingClientRect().width/height gives 0 when section is collapsed, use jQuery width()/height() instead
