### PR TITLE
show spinner during switch #2203

### DIFF
--- a/core/src/main/web/app/mainapp/mainapp.js
+++ b/core/src/main/web/app/mainapp/mainapp.js
@@ -340,7 +340,7 @@
               if (bkUtils.isElectron && (target.type == 'file')){
                 bkElectron.app.addRecentDocument(target.uri);
               }
-
+              bkSessionManager.updateNotebookUri(target.uri, target.type, target.readOnly, target.format);
               var importer = bkCoreManager.getNotebookImporter(target.format);
               if (!importer) {
                 if (retry) {
@@ -380,6 +380,8 @@
               }
             },
             fromSession: function(sessionId) {
+              $scope.loading = true;
+              showLoadingStatusMessage("Loading notebook");
               bkSession.load(sessionId).then(function(session) {
                 var notebookUri = session.notebookUri;
                 var uriType = session.uriType;
@@ -387,8 +389,11 @@
                 var format = session.format;
                 var notebookModel = angular.fromJson(session.notebookModelJson);
                 var edited = session.edited;
-                loadNotebookModelAndResetSession(
+                bkSessionManager.updateNotebookUri(notebookUri, uriType, readOnly, format);
+                $timeout(function() {
+                  loadNotebookModelAndResetSession(
                     notebookUri, uriType, readOnly, format, notebookModel, edited, sessionId, true);
+                }, 0);
               });
             },
             fromImport: function(sessionId) {


### PR DESCRIPTION
The problem was in angular binding. If variables are assigned in $http callback angular'll invoke $digest (which binds the variables) only after the whole callback is executed.
In our case variable for notebook’s title and flag to show spinner were bound only after the notebook had been loaded.
To enforce angular $digest I firstly update notebook’s name and spinner flag and then call method for loading notebook in timeout function.
