### PR TITLE
fix language popup needs badges #2210

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecellinputmenu-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecellinputmenu-directive.js
@@ -22,7 +22,7 @@
   'use strict';
   var module = angular.module('bk.notebook');
 
-  module.directive('bkCodeCellInputMenu', function(bkCoreManager) {
+  module.directive('bkCodeCellInputMenu', function(bkCoreManager, bkEvaluatorManager) {
     var getBkNotebookWidget = function() {
       return bkCoreManager.getBkApp().getBkNotebookWidget();
     } ;
@@ -51,6 +51,9 @@
           var cellId = $scope.cellmodel.id;
           $scope.cellmodel.evaluator = evaluatorName;
           getBkNotebookWidget().getFocusable(cellId).focus();
+        };
+        $scope.getEvaluatorDetails = function(name) {
+          return bkEvaluatorManager.getVisualParams(name);
         };
       }
     };

--- a/core/src/main/web/app/mainapp/components/notebook/codecellinputmenu.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/codecellinputmenu.jst.html
@@ -26,7 +26,12 @@
   <ul class="dropdown-menu inputcellmenu" role="menu" aria-labelledby="dLabel">
     <li ng-repeat="(evaluatorName, evaluator) in getEvaluators()">
       <a tabindex="-1" href="#" ng-click="setEvaluator(evaluatorName)" class="{{evaluatorName}}-menuitem" eat-click>
-        {{evaluatorName}}
+          <bk-language-menu-item
+                  key="{{evaluatorName}}"
+                  bg-color="{{getEvaluatorDetails(evaluatorName).bgColor}}"
+                  name="{{getEvaluatorDetails(evaluatorName).shortName}}"
+                  fg-color="{{getEvaluatorDetails(evaluatorName).fgColor}}"
+                  border-color="{{getEvaluatorDetails(evaluatorName).borderColor}}"></bk-language-menu-item>
         <i class="fa fa-check" ng-show="getShowEvalIcon(evaluatorName)"></i>
       </a>
     </li>

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
@@ -84,6 +84,10 @@
           return evaluatorName;
         };
 
+        $scope.getEvaluatorDetails = function(name) {
+          return bkEvaluatorManager.getVisualParams(name);
+        };
+
         function attachCell(cell) {
           bkSessionManager.setNotebookModelEdited(true);
           if ($scope.config && $scope.config.attachCell) {

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
@@ -22,7 +22,13 @@
   </button>
   <button class="btn btn-primary dropdown-toggle" ng-class="!isLarge && 'btn-xs'" data-toggle="dropdown" data-target=".code-dropdown">code <i class="fa fa-sort-down"></i><ul class="dropdown-menu code-dropdown" role="menu">
     <li ng-repeat="(key, value) in getEvaluators()">
-      <a ng-click="newCodeCell(key)">{{key}}</a>
+      <a ng-click="newCodeCell(key)"><bk-language-menu-item
+                            key="{{key}}"
+                            bg-color="{{getEvaluatorDetails(key).bgColor}}"
+                            name="{{getEvaluatorDetails(key).shortName}}"
+                            fg-color="{{getEvaluatorDetails(key).fgColor}}"
+                            border-color="{{getEvaluatorDetails(key).borderColor}}"></bk-language-menu-item>
+      </a>
     </li>
     <li>
        <a ng-click="showPluginManager()">Other languages...</a>

--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -255,6 +255,20 @@ bk-language-logo {
   }
 }
 
+bk-language-menu-item {
+  span {
+    width: 20px;
+    height: 20px;
+    line-height: 20px;
+    font-weight: bold;
+    text-align: center;
+    display: inline-block;
+    vertical-align: middle;
+    font-size: 10px;
+    padding-top: 1px;
+  }
+}
+
 .cell-run-time {
   color: #BDBDBD;
 }

--- a/core/src/main/web/app/utils/basic/commonui.js
+++ b/core/src/main/web/app/utils/basic/commonui.js
@@ -298,4 +298,43 @@
       }
     };
   });
+
+  module.directive('bkLanguageMenuItem', function() {
+    return {
+      restrict: 'E',
+      template: '<span ng-style="style">{{name}}</span>&nbsp;{{key}}',
+      scope: {
+        key: '@',
+        name: '@',
+        bgColor: '@',
+        fgColor: '@',
+        borderColor: '@'
+      },
+      link: function(scope, element, attrs) {
+        scope.style = {
+          'background-color': scope.bgColor,
+          'color': scope.fgColor
+        };
+        var updateStyle = function() {
+          scope.style = {
+            'background-color': scope.bgColor,
+            'color': scope.fgColor
+          };
+          if (scope.borderColor) {
+            scope.style['border-width'] = '1px';
+            scope.style['border-color'] = scope.borderColor;
+            scope.style['border-style'] = 'solid';
+          } else {
+            delete scope.style['border-width'];
+            delete scope.style['border-color'];
+            delete scope.style['border-style'];
+          }
+        };
+        scope.$watch('bgColor', updateStyle);
+        scope.$watch('fgColor', updateStyle);
+        scope.$watch('borderColor', updateStyle);
+      }
+    };
+  });
+
 })();


### PR DESCRIPTION
new bk-language-menu-item directive has been added.

use 

```
 <a ng-click="newCodeCell(key)"><bk-language-menu-item
                            key="{{key}}"
                            bg-color="{{getEvaluatorDetails(key).bgColor}}"
                            name="{{getEvaluatorDetails(key).shortName}}"
                            fg-color="{{getEvaluatorDetails(key).fgColor}}"
                            border-color="{{getEvaluatorDetails(key).borderColor}}"></bk-language-menu-item>
      </a>
```

instead 

```
 <a ng-click="newCodeCell(key)">{{key}}</a>
```

![image](https://cloud.githubusercontent.com/assets/13516511/9547376/b6c0fc8c-4da2-11e5-8d75-bc13f7af8d3a.png)

![image](https://cloud.githubusercontent.com/assets/13516511/9547408/f9cefe8e-4da2-11e5-9212-5d57ed11ae54.png)

![image](https://cloud.githubusercontent.com/assets/13516511/9547431/2414ce44-4da3-11e5-8106-214f4ab7570d.png)
