### PR TITLE
fix language popup vertical position broken #2209

### DIFF
--- a/core/src/main/web/app/styles/cells.scss
+++ b/core/src/main/web/app/styles/cells.scss
@@ -108,9 +108,6 @@ bk-section-cell {
   white-space: pre;
 }
 
-.bkcell bk-code-cell-input-menu .dropdown .dropdown-menu {
-  margin-top: -$grid-row-height;
-}
 
 .code-cell-area {
   .code-cell-input {


### PR DESCRIPTION
Menu has been moved down completely below the button. Second click hides menu.
