### PR TITLE
After successful sign up to Publications pass the auth token to Beaker

### DIFF
--- a/core/src/main/web/app/beaker.js
+++ b/core/src/main/web/app/beaker.js
@@ -412,8 +412,9 @@
         };
       });
     });
-    beaker.run(function(bkPublicationAuth) {
-      return bkPublicationAuth.initSession();
+    beaker.run(function(bkPublicationAuth, $location, $localStorage) {
+      var params = $location.search();
+      return bkPublicationAuth.initSession(params["token"]);
     });
   };
   var bootstrapBkApp = function() {

--- a/core/src/main/web/app/mainapp/components/publication/publication.js
+++ b/core/src/main/web/app/mainapp/components/publication/publication.js
@@ -20,8 +20,8 @@
   var module = angular.module('bk.core');
 
   module.controller('publicationCtrl',
-    ['$scope', 'bkUtils', 'bkPublicationApi', 'bkPublicationAuth', 'bkSessionManager', '$modalInstance',
-    function($scope, bkUtils, bkPublicationApi, bkPublicationAuth, bkSessionManager, $modalInstance) {
+    ['$scope', 'bkUtils', 'bkPublicationApi', 'bkPublicationAuth', 'bkSessionManager', '$modalInstance', '$location',
+    function($scope, bkUtils, bkPublicationApi, bkPublicationAuth, bkSessionManager, $modalInstance, $location) {
 
       bkPublicationAuth.initSession();
 
@@ -30,8 +30,7 @@
       $scope.user = {role: 'beaker'};
       $scope.model = {};
       $scope.baseUrl = bkPublicationApi.getBaseUrl();
-      $scope.signupUrl = $scope.baseUrl + '/#/sign_up';
-      
+
       $scope.signIn = function() {
         return bkPublicationAuth.signIn($scope.user)
         .then(function() {
@@ -138,6 +137,10 @@
 
       $scope.close = function() {
         $modalInstance.close('ok');
+      };
+
+      $scope.signupUrl = function() {
+        return $scope.baseUrl + '#/sign_up?redirect=' + encodeURIComponent($location.absUrl());
       };
   }]);
 })();

--- a/core/src/main/web/app/mainapp/components/publication/publish.jst.html
+++ b/core/src/main/web/app/mainapp/components/publication/publish.jst.html
@@ -25,7 +25,7 @@
       </form>
       <div class="sign-up">
         No account?
-        <a target="_blank" href="{{signupUrl}}">Create New Account</a>
+        <a target="_blank" ng-href="{{signupUrl()}}">Create New Account</a>
       </div>
     </div>
     <div class="publish" ng-if="isSignedIn()">

--- a/core/src/main/web/app/utils/publication.js
+++ b/core/src/main/web/app/utils/publication.js
@@ -76,7 +76,10 @@
         delete $localStorage.token;
         currentUser = null;
       },
-      initSession: function() {
+      initSession: function(token) {
+        if (token) {
+          $localStorage.token = token;
+        }
         return bkPublicationApi.getCurrentUser()
         .then(function(resp) {
           return currentUser = resp.data;


### PR DESCRIPTION
via redirection back to Beaker with the auth token passed as a query param.

Fixes: https://github.com/twosigma/beaker-notebook/issues/2197
Depends on: https://github.com/twosigma/bunsen/pull/1098
