### PR TITLE
fix h scrollbar on markdown cells is broken #2231

### DIFF
--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -636,7 +636,8 @@
           lineNumbers: true,
           matchBrackets: true,
           extraKeys: keys,
-          goToNextCell: moveFocusDown
+          goToNextCell: moveFocusDown,
+          scrollbarStyle: "simple"
         };
       },
 

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
@@ -55,7 +55,7 @@
     </button>
   </li>
   <li role="presentation" class="dropdown" ng-mouseleave="hideOpenMenus()">
-    <button class="btn btn-primary  insert-text"
+    <button class="btn btn-primary"
             ng-class="!isLarge && 'btn-xs'"
             data-toggle="dropdown"
             data-target=".section-menu">section <i class="fa fa-sort-down"></i>

--- a/core/src/main/web/app/template/index_template.html
+++ b/core/src/main/web/app/template/index_template.html
@@ -61,6 +61,7 @@
   <script src="vendor/bower_components/angular-animate/angular-animate.js"></script>
   <script src="vendor/bower_components/angular-touch/angular-touch.js"></script>
   <script src="vendor/bower_components/codemirror/lib/codemirror.js"></script>
+  <script src="vendor/bower_components/codemirror/addon/scroll/simplescrollbars.js"></script>
   <script src="vendor/bower_components/codemirror/addon/hint/show-hint.js"></script>
   <script src="vendor/bower_components/codemirror/addon/hint/javascript-hint.js"></script>
   <script src="vendor/bower_components/codemirror/addon/hint/html-hint.js"></script>

--- a/core/src/main/web/app/vendor.scss
+++ b/core/src/main/web/app/vendor.scss
@@ -18,6 +18,7 @@
 @import "../vendor/bower_components/font-awesome/css/font-awesome.css";
 @import "../vendor/bower_components/codemirror/lib/codemirror.css";
 @import "../vendor/bower_components/codemirror/addon/hint/show-hint.css";
+@import "../vendor/bower_components/codemirror/addon/scroll/simplescrollbars.css";
 
 @import "../vendor/jquery-ui/css/smoothness/jquery-ui.custom.min.css";
 


### PR DESCRIPTION
I found that problem exists only for chrome browser.OnBlur event for a codemirror editor is triggered after click on a h-scrollbar after notebook vertical scrolling. But without vertical scrolling all ok. I have used  scrollbarStyle from codemirror 'SimpleScrollbar' addon instead native scrollbars
