### PR TITLE
fix combined plot title position wrong #2287

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-combinedplot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-combinedplot.js
@@ -52,7 +52,7 @@
         scope.initLayout = function() {
           var model = scope.stdmodel;
           if (model.title != null) {
-            element.find("#combplotTitle").text(model.title).css("width", scope.width);
+            element.find("#combplotTitle").text(model.title).css("width", scope.width || scope.stdmodel.plotSize.width);
           }
         };
 


### PR DESCRIPTION
Initialisation behaviours has been improved -  use scope.stdmodel.plotSize.width instead   scope.width if scope.width is not defined, 

Use Interactive Charts tutorial for tests
