### PR TITLE
fix replace resize thumb #2290

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -97,6 +97,10 @@
         scope.initLayout = function() {
           var model = scope.stdmodel;
 
+          element.find(".ui-icon-gripsmall-diagonal-se")
+            .removeClass("ui-icon-gripsmall-diagonal-se")
+            .addClass("ui-icon-grip-diagonal-se");
+
           // hook container to use jquery interaction
           scope.container = d3.select(element[0]).select("#plotContainer");
           scope.jqcontainer = element.find("#plotContainer");


### PR DESCRIPTION
resize thumb has been replaced ('ui-icon-grip-diagonal-se' instead 'ui-icon-gripsmall-diagonal-se' from jquery-ui package).

ui-icon-gripsmall-diagonal-se
![image](https://cloud.githubusercontent.com/assets/13516511/9733767/acfe9924-5636-11e5-9d52-f9447b1e20b8.png)

ui-icon-grip-diagonal-se
![image](https://cloud.githubusercontent.com/assets/13516511/9733776/b803ecc0-5636-11e5-996d-6798b7defee8.png)
