### PR TITLE
fix charts width can differ after rerun #2304

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -1738,12 +1738,11 @@
         };
 
         var watchCellSize = function () {
-          if (scope.model.isShowOutput !== undefined && scope.model.isShowOutput() === true) {
+          if (!scope.model.isShowOutput || (scope.model.isShowOutput && scope.model.isShowOutput() === true)) {
             scope.plotSize.width = scope.getCellWidth();
             scope.plotSize.height = scope.getCellHeight();
+            scope.setDumpState(scope.dumpState());
           }
-
-          scope.setDumpState(scope.dumpState());
         };
 
         scope.$watch('getCellWidth()', function () {


### PR DESCRIPTION
'watchCellSize' has been improved in a bko-plot.js. scope.model.isShowOutput always undefined. Treatment this has been added
