### PR TITLE
#2352. windows python error

### DIFF
--- a/plugin/ipythonPlugins/src/dist/ipython/beaker_runtime.py
+++ b/plugin/ipythonPlugins/src/dist/ipython/beaker_runtime.py
@@ -308,7 +308,7 @@ class DataFrameEncoder(json.JSONEncoder):
         if type(obj) == datetime.datetime or type(obj) == datetime.date or type(obj).__name__ == 'Timestamp':
             out = {}
             out['type'] = "Date"
-            out['timestamp'] = int(obj.strftime("%s"))*1000
+            out['timestamp'] = calendar.timegm(obj.timetuple()) * 1000
             return out
         if type(obj) == pandas.core.frame.DataFrame:
             out = {}

--- a/plugin/ipythonPlugins/src/dist/python3/beaker_runtime3.py
+++ b/plugin/ipythonPlugins/src/dist/python3/beaker_runtime3.py
@@ -309,7 +309,7 @@ class DataFrameEncoder(json.JSONEncoder):
         if type(obj) == datetime.datetime or type(obj) == datetime.date or type(obj).__name__ == 'Timestamp':
             out = {}
             out['type'] = "Date"
-            out['timestamp'] = int(obj.strftime("%s"))*1000
+            out['timestamp'] = calendar.timegm(obj.timetuple()) * 1000
             return out
         if type(obj) == pandas.core.frame.DataFrame:
             out = {}


### PR DESCRIPTION
According to http://stackoverflow.com/questions/11743019/convert-python-datetime-to-epoch-with-strftime

Python `strftime` function doesn't support `%s` option. It works on Unix because Python `strftime` calls native `strftime` and `%s` is supported there on Unix, but not on Windows.

It's replaced with `calendar.timegm()`.

But it still doesn't fix Python Dates NaN error(issue #2333)
