### PR TITLE
fix NPE in CI on /rest/session-backup/setEdited #2313

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/rest/SessionBackupRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/SessionBackupRest.java
@@ -204,7 +204,9 @@ public class SessionBackupRest {
       @FormParam("sessionid") String sessionID,
       @FormParam("edited") boolean edited) {
 
-    this.sessions.get(sessionID).edited = edited;
+    Session session = this.sessions.get(sessionID);
+    if (session != null)
+      session.edited = edited;
   }
 
   @GET


### PR DESCRIPTION
In some cases sessionID parameters is empty. Check for this situation was added. https://github.com/twosigma/beaker-notebook/issues/1814 is not reproduced because method backup has been changed (rev 23e7617634cac1437c9c1501c49a8ead4e0eae38)  
