### PR TITLE
fix Broken 'new folder' button on 'Save as...' dialog #1697

### DIFF
--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -346,9 +346,12 @@
             var self = this;
             this.showSpinner = true;
             bkUtils.httpPost("../beaker/rest/file-io/createDirectory", {path: path})
-                .complete(function (list) {
-                  self.showSpinner = false;
-                });
+              .success(function (list) {
+                self.showSpinner = false;
+              }).error(function (response) {
+                self.showSpinner = false;
+                console.log(response);
+              });
           };
           fileChooserStrategy.getSaveBtnDisabled = function() {
             return _.isEmpty(this.input) || _.string.endsWith(this.input, '/');


### PR DESCRIPTION
Problem with signature httpPost has been fixed. I see that our file save and file open dialog has very non standard view and behaviour, May be have sense use something like this https://github.com/eligrey/FileSaver.js?
