### PR TITLE
depending on zoom, markdown text may flow into gray zone #2112.

### DIFF
--- a/core/src/main/web/app/styles/cell-outputs.scss
+++ b/core/src/main/web/app/styles/cell-outputs.scss
@@ -47,7 +47,7 @@ bk-code-cell-output {
     display: block;
     float: right;
     height: 10px;
-    width: 117px;
+    width: 147px;
   }
 }
 


### PR DESCRIPTION
fix for or preview mode
