### PR TITLE
fix after leaving and returning, cursor broken #2448

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -379,7 +379,6 @@
               //codecomplete is up, skip
               return;
             }
-            scope.cm.doc.sel.ranges[0].anchor.ch = -1;
             CodeMirror.signal(scope.cm, "cursorActivity", scope.cm);
           });
           scope.cm.on('focus', function () {


### PR DESCRIPTION
this is a serious regression, perhaps related to #2299 ?? Yes. Problem has been fixed but matching brackets stays highlighted on click outside editor (for example on the area near buttons).
