### PR TITLE
#2446. old notebook flashes during load

### DIFF
--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -722,7 +722,6 @@
           //if (_v.namespace === undefined)
           //  _v.namespace = { };
           _bo = new BeakerObject(_v);
-          bkHelper.initBeakerPrefs();
           if (this.isEmpty()) {
             bkNotebookCellModelManager.reset([]);
           } else {
@@ -867,6 +866,7 @@
         _format = format;
         _notebookUri.set(notebookUri);
         _notebookModel.set(notebookModel);
+        bkHelper.initBeakerPrefs();
         this.setNotebookModelEdited(!!edited);
         _sessionId = sessionId;
         bkNotebookNamespaceModelManager.init(sessionId, notebookModel, generateSaveData);
@@ -902,6 +902,7 @@
         _format = format;
         _notebookUri.set(notebookUri);
         _notebookModel.set(notebookModel);
+        bkHelper.initBeakerPrefs();
         _sessionId = sessionId;
 
         _needsBackup = _edited;


### PR DESCRIPTION
`initBeakerPrefs()` here makes `this.isEmpty()` falsy and cells are not cleared.
Move call to `initBeakerPrefs()` upwards and make it later.
