### PR TITLE
missing menu items #2408

### DIFF
--- a/core/src/main/web/app/helpers/menupluginmanager.js
+++ b/core/src/main/web/app/helpers/menupluginmanager.js
@@ -23,6 +23,8 @@
     // add newItem to itemsList, if an item with same name already exists in itemsList,
     // compare priorities, if newItem.priority > existingItem.priority, newItem will
     // replace the existingItem in place.
+    //
+    // if newItem already exists in itemsList with the same priority and has type submenu then merge submenus' items
     var addMenuItem = function(itemsList, newItem) {
       // check if an entry with same name already exist
       var existingItem = _(itemsList).find(function(it) {
@@ -31,7 +33,14 @@
       if (existingItem) {
         existingItem.priority = existingItem.priority ? existingItem.priority : DEFAULT_PRIORITY;
         newItem.priority = newItem.priority ? newItem.priority : DEFAULT_PRIORITY;
-        if (newItem.priority >= existingItem.priority) {
+        if (existingItem.type === 'submenu' && newItem.priority === existingItem.priority) {
+          //merge submenu items
+          if(newItem.items){
+            newItem.items.forEach(function (item) {
+              addMenuItem(existingItem.items, item);
+            });
+          }
+        } else if (newItem.priority >= existingItem.priority) {
           // replace in place
           itemsList.splice(itemsList.indexOf(existingItem), 1, newItem);
         } else {

--- a/core/src/main/web/plugin/menu/file_ipython.js
+++ b/core/src/main/web/plugin/menu/file_ipython.js
@@ -240,6 +240,7 @@ define(function(require, exports, module) {
         parent: "File",
         id: "file-menu",
         submenu: "Open",
+        submenusortorder: 110,
         items: [
           {
             name: "Open... IPython (.ipynb)",


### PR DESCRIPTION
The problem is in asynchronous calls. Sometimes file_ipython.js menu plugin is loaded before file.js menu plugin. In this case we create menu File -> Open -> Open.. IPython. Then when file.js menu is loaded we find existing File menu and start adding items to it. File.js menu also has Open submenu item and based on items priority we just replace existing Open submenu item (with Open.. IPython item) with the new one. That's why we have missing Open.. IPython menu item.
I suggest the following fix: if we have submenu with the same name and priority merge their items instead of replacing menus
