### PR TITLE
markdown h scrollbar broken #2500

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
@@ -200,10 +200,14 @@
         scope.cm.setValue(scope.cellmodel[contentAttribute]);
         preview();
 
-        scope.cm.on("blur", function(){
-          scope.$apply(function() {
-            syncContentAndPreview();
-          });
+        scope.cm.on("blur", function(cm){
+          setTimeout(function() {
+            if(!cm.state.focused){
+              scope.$apply(function() {
+                syncContentAndPreview();
+              });
+            }
+          }, 0);
         });
 
         scope.$on('beaker.cell.added', function(e, cellmodel) {


### PR DESCRIPTION
seems like a defect in codemirror: blur event fires when we click on bkg part of a scroll.
but we can check cm.state.focused property to get to know whether the editor lost focus
