### PR TITLE
selecting code can fail #2531

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -108,13 +108,16 @@
           // Even better would be to detect left/right and move to
           // beginning or end of line, but we can live with this for now.
           var cm = $scope.cm;
-          if (event.pageY < (top + bottom) / 2) {
-            cm.setCursor(0, 0);
-          } else {
-            cm.setCursor(cm.lineCount() - 1,
-                         cm.getLine(cm.lastLine()).length);
-          }
-          cm.focus();
+          setTimeout(function(){
+            if (event.pageY < (top + bottom) / 2) {
+              cm.setCursor(0, 0);
+            } else {
+              cm.setCursor(cm.lineCount() - 1,
+                cm.getLine(cm.lastLine()).length);
+            }
+            cm.focus();
+          }, 0);
+
         };
 
         $scope.isShowOutput = function() {

--- a/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
@@ -20,10 +20,10 @@
   'empty': isEmpty()
   }">
   <div class="bkcell code-cell-area">
-    <div class="code-cell-input" ng-click="backgroundClick($event)" ng-hide="isLocked()" ng-class="{'input-hidden': cellmodel.input.hidden}">
+    <div class="code-cell-input" ng-mousedown="backgroundClick($event)" ng-hide="isLocked()" ng-class="{'input-hidden': cellmodel.input.hidden}">
       <div class="code-cell-input-content">
         <bk-code-cell-input-menu class="advanced-hide"></bk-code-cell-input-menu>
-        <div ng-click="$event.stopPropagation()">
+        <div ng-mousedown="$event.stopPropagation()">
           <div class="bkcelltextarea">{{cellmodel.input.body}}</div>
           <bk-cell-tooltip editor="cm"></bk-cell-tooltip>
         </div>


### PR DESCRIPTION
the problem was in ng-click which fires on mouse up event (https://github.com/codef0rmer/angular-dragdrop/issues/50). 
when we release the mouse inside code cell but outside codemirror element backgroundClick function is called and it clears selection and set up cursor position in editor.
i used ng-mousedown directive instead of ng-click.
