### PR TITLE
fix Windows OS - Java plugin doesn't work in the electron application…

### DIFF
--- a/launcher/electron/app/backend-runner.js
+++ b/launcher/electron/app/backend-runner.js
@@ -34,14 +34,14 @@ module.exports = (function() {
       var eventEmitter = new events.EventEmitter();
 
       if (_osName.startsWith('Windows')) {
-        process.env['JAVA_HOME'] = path.resolve(__dirname + '/../jre');
+        process.env['JAVA_HOME'] = path.resolve(__dirname + '/../jdk');
         process.chdir(__dirname + '/../dist');
         _backend = spawn(path.resolve(__dirname + '/../dist/beaker.command.bat'), ['--open-browser', 'false']);
       } else if (_osName.startsWith('Darwin')) {
-        process.env['JAVA_HOME'] = path.resolve(__dirname + '/../jre/Contents/Home');
+        process.env['JAVA_HOME'] = path.resolve(__dirname + '/../jdk/Contents/Home');
         _backend = spawn(path.resolve(__dirname + '/../dist/beaker.command'), ['--open-browser', 'false']);
       } else if (_osName.startsWith('Linux')) {
-        process.env['JAVA_HOME'] = path.resolve(__dirname + '/../jre');
+        process.env['JAVA_HOME'] = path.resolve(__dirname + '/../jdk');
         _backend = spawn(path.resolve(__dirname + '/../dist/beaker.command'), ['--open-browser', 'false']);
       }
 

--- a/launcher/electron/build.gradle
+++ b/launcher/electron/build.gradle
@@ -166,18 +166,18 @@ task copyJRE(type: Copy, dependsOn: ['unzipJRE']) {
   from 'jre'
   if (mac) {
     dependsOn 'macCopyElectron'
-    into 'Beaker.app/Contents/Resources/jre'
+    into 'Beaker.app/Contents/Resources/jdk'
   } else if (win || linux) {
-    into 'beaker/resources/jre'
+    into 'beaker/resources/jdk'
   }
 }
 
 task copyTools(type: Copy, dependsOn: 'copyJRE') {
   from 'tools.jar'
   if (mac) {
-    into 'Beaker.app/Contents/Resources/jre/Contents/Home/lib'
+    into 'Beaker.app/Contents/Resources/jdk/Contents/Home/lib'
   } else if (win || linux) {
-    into 'beaker/resources/jre/lib'
+    into 'beaker/resources/jdk/lib'
   }
 }
 


### PR DESCRIPTION
… for the windows OS #2549

 \resources\jre has been renamed to \resources\jdk because for JAVA_HOME with name 'jre' tools.jar is searched on the level jre folder.
