### PR TITLE
Electron on Windows OS hanging plugins processes fix #2555

### DIFF
--- a/plugin/clojure/src/dist/clojurePlugin
+++ b/plugin/clojure/src/dist/clojurePlugin
@@ -25,7 +25,8 @@ os.chdir(os.path.dirname(self_path))
 
 if os.name == 'nt':
     bin = "bin\\clojure"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin = "bin/clojure"
+    os.execlp(bin, bin, port)
 
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/clojure/src/dist/clojurePlugin
+++ b/plugin/clojure/src/dist/clojurePlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop(0)
@@ -27,4 +28,4 @@ if os.name == 'nt':
 else:
     bin = "bin/clojure"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/cpp/src/dist/cppPlugin
+++ b/plugin/cpp/src/dist/cppPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop(0)
@@ -29,4 +30,4 @@ if os.name == 'nt':
 else:
     bin = "bin/cpp"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/cpp/src/dist/cppPlugin
+++ b/plugin/cpp/src/dist/cppPlugin
@@ -27,7 +27,7 @@ os.environ["CPP_OPTS"] = "-Djava.library.path=/Users/diego/beaker-notebook/core/
 
 if os.name == 'nt':
     bin = "bin\\cpp"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin = "bin/cpp"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)

--- a/plugin/groovy/src/dist/groovyPlugin
+++ b/plugin/groovy/src/dist/groovyPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop(0)
@@ -29,4 +30,4 @@ if os.name == 'nt':
 else:
     bin = "bin/groovy"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/groovy/src/dist/groovyPlugin
+++ b/plugin/groovy/src/dist/groovyPlugin
@@ -27,7 +27,7 @@ os.environ["GROOVY_OPTS"] = " ".join(sys.argv)
 
 if os.name == 'nt':
     bin = "bin\\groovy"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin = "bin/groovy"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)

--- a/plugin/ipythonPlugins/src/dist/ipython/ipythonPlugin
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipythonPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 from subprocess import check_output
 
 def detect_cygwin_python():
@@ -53,6 +54,6 @@ else:
     old_path = ''
 os.environ["PYTHONPATH"] = plugin_dir + old_path
 if os.name == 'nt':
-    os.execlp("python", "python", "\"" + plugin_dir+"/ipythonPluginStart.py\"")
+    subprocess.call(["python", plugin_dir+"/ipythonPluginStart.py"], shell=True, stderr = subprocess.PIPE)
 else:
     os.execlp("python", "python", plugin_dir+"/ipythonPluginStart.py")

--- a/plugin/ipythonPlugins/src/dist/iruby/irubyPlugin
+++ b/plugin/ipythonPlugins/src/dist/iruby/irubyPlugin
@@ -39,6 +39,6 @@ if len(sys.argv) > 1:
 
 plugin_dir = os.path.dirname(sys.argv[0])
 if os.name == 'nt':
-    os.execlp("python", "python", "\"" + plugin_dir+"/irubyPluginStart.py\"")
+    subprocess.call(["python", plugin_dir+"/irubyPluginStart.py"], shell=True, stderr = subprocess.PIPE)
 else:
     os.execlp("python", "python", plugin_dir+"/irubyPluginStart.py")

--- a/plugin/ipythonPlugins/src/dist/julia/juliaPlugin
+++ b/plugin/ipythonPlugins/src/dist/julia/juliaPlugin
@@ -39,7 +39,7 @@ if len(sys.argv) > 1:
 
 plugin_dir = os.path.dirname(sys.argv[0])
 if os.name == 'nt':
-    os.execlp("python", "python", "\"" + plugin_dir+"/juliaPluginStart.py\"")
+    subprocess.call(["python", plugin_dir+"/juliaPluginStart.py"], shell=True, stderr = subprocess.PIPE)
 else:
     os.execlp("python", "python", plugin_dir+"/juliaPluginStart.py")
 

--- a/plugin/ipythonPlugins/src/dist/python3/python3Plugin
+++ b/plugin/ipythonPlugins/src/dist/python3/python3Plugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 if len(sys.argv) > 1:
     arg1 = sys.argv[1]
@@ -41,6 +42,6 @@ else:
 os.environ["PYTHONPATH"] = plugin_dir + old_path
 
 if os.name == 'nt':
-    os.execlp("python", "python", "\"" + plugin_dir+"/python3PluginStart.py\"")
+    subprocess.call(["python", plugin_dir+"/python3PluginStart.py"], shell=True, stderr = subprocess.PIPE)
 else:
     os.execlp("python", "python", plugin_dir+"/python3PluginStart.py")

--- a/plugin/javash/src/dist/javashPlugin
+++ b/plugin/javash/src/dist/javashPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop(0)
@@ -29,4 +30,4 @@ if os.name == 'nt':
 else:
     bin = "bin/javash"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/javash/src/dist/javashPlugin
+++ b/plugin/javash/src/dist/javashPlugin
@@ -27,7 +27,7 @@ os.environ["JAVASH_OPTS"] = " ".join(sys.argv)
 
 if os.name == 'nt':
     bin = "bin\\javash"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin = "bin/javash"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)

--- a/plugin/kdb/src/dist/kdbPlugin
+++ b/plugin/kdb/src/dist/kdbPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop()
@@ -29,4 +30,4 @@ if os.name == 'nt':
 else:
     bin ="bin/kdb"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/kdb/src/dist/kdbPlugin
+++ b/plugin/kdb/src/dist/kdbPlugin
@@ -27,7 +27,7 @@ os.environ['beaker_r_init'] = os.getcwd() + '/beaker'
 
 if os.name == 'nt':
     bin = "bin\\kdb"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin ="bin/kdb"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)

--- a/plugin/node/src/dist/nodePlugin
+++ b/plugin/node/src/dist/nodePlugin
@@ -16,10 +16,11 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop()
 
 os.chdir(os.path.dirname(self_path))
 
-os.execlp("node", "node", "app/app.js", port, "127.0.0.1")
+subprocess.call([bin, "app/app.js", port, "127.0.0.1"], shell=True, stderr = subprocess.PIPE)

--- a/plugin/node/src/dist/nodePlugin
+++ b/plugin/node/src/dist/nodePlugin
@@ -23,4 +23,7 @@ self_path = sys.argv.pop()
 
 os.chdir(os.path.dirname(self_path))
 
-subprocess.call([bin, "app/app.js", port, "127.0.0.1"], shell=True, stderr = subprocess.PIPE)
+if os.name == 'nt':
+    subprocess.call([bin, "app/app.js", port, "127.0.0.1"], shell=True, stderr = subprocess.PIPE)
+else:
+    os.execlp("node", "node", "app/app.js", port, "127.0.0.1")

--- a/plugin/r/src/dist/rPlugin
+++ b/plugin/r/src/dist/rPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop()
@@ -36,4 +37,4 @@ if os.name == 'nt':
 else:
     bin ="bin/r"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/r/src/dist/rPlugin
+++ b/plugin/r/src/dist/rPlugin
@@ -34,7 +34,7 @@ if os.name == 'nt':
     except:
         pass # ignore any error
     bin = "bin\\r"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin ="bin/r"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)

--- a/plugin/scala/src/dist/scalaPlugin
+++ b/plugin/scala/src/dist/scalaPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop(0)
@@ -29,4 +30,4 @@ if os.name == 'nt':
 else:
     bin = "bin/scala"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/scala/src/dist/scalaPlugin
+++ b/plugin/scala/src/dist/scalaPlugin
@@ -27,7 +27,7 @@ os.environ["SCALA_OPTS"] = " ".join(sys.argv)
 
 if os.name == 'nt':
     bin = "bin\\scala"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin = "bin/scala"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)

--- a/plugin/sqlsh/src/dist/sqlshPlugin
+++ b/plugin/sqlsh/src/dist/sqlshPlugin
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import subprocess
 
 port = sys.argv.pop()
 self_path = sys.argv.pop(0)
@@ -29,4 +30,4 @@ if os.name == 'nt':
 else:
     bin = "bin/sqlsh"
 
-os.execlp(bin, bin, port)
+subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)

--- a/plugin/sqlsh/src/dist/sqlshPlugin
+++ b/plugin/sqlsh/src/dist/sqlshPlugin
@@ -27,7 +27,7 @@ os.environ["SQLSH_OPTS"] = " ".join(sys.argv)
 
 if os.name == 'nt':
     bin = "bin\\sqlsh"
+    subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
 else:
     bin = "bin/sqlsh"
-
-subprocess.call([bin, port], shell=True, stderr = subprocess.PIPE)
+    os.execlp(bin, bin, port)


### PR DESCRIPTION
use python subprocess.call command to start plugins in the same process tree on windows.
so plugins' processes can be killed by "taskkill" command when electron is closed
