### PR TITLE
fix ipython backends broken in Docker #2591

### DIFF
--- a/plugin/ipythonPlugins/src/dist/ipython/ipythonPluginStart.py
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipythonPluginStart.py
@@ -19,7 +19,7 @@ import sys
 from IPython import start_ipython
 from subprocess import check_output
 
-ipyversion = check_output(["ipython", "ipython", "--version"])
+ipyversion = check_output(["ipython", "ipython", "--version"]).decode("utf-8")
 if ipyversion[0] == "4":
   sys.exit(start_ipython(["notebook", "--config=" + os.environ["beaker_ipython_notebook_config"]]))
 else:

--- a/plugin/ipythonPlugins/src/dist/iruby/irubyPluginStart.py
+++ b/plugin/ipythonPlugins/src/dist/iruby/irubyPluginStart.py
@@ -19,7 +19,7 @@ import sys
 from IPython import start_ipython
 from subprocess import check_output
 
-ipyversion = check_output(["ipython", "ipython", "--version"])
+ipyversion = check_output(["ipython", "ipython", "--version"]).decode("utf-8")
 if ipyversion[0] == "4":
   sys.exit(start_ipython(["notebook", "--config=" + os.environ["beaker_ipython_notebook_config"]]))
 else:

--- a/plugin/ipythonPlugins/src/dist/julia/juliaPluginStart.py
+++ b/plugin/ipythonPlugins/src/dist/julia/juliaPluginStart.py
@@ -19,7 +19,7 @@ import sys
 from IPython import start_ipython
 from subprocess import check_output
 
-ipyversion = check_output(["ipython", "ipython", "--version"])
+ipyversion = check_output(["ipython", "ipython", "--version"]).decode("utf-8")
 if ipyversion[0] == "4":
   sys.exit(start_ipython(["notebook", "--config=" + os.environ["beaker_ipython_notebook_config"]]))
 else:

--- a/plugin/ipythonPlugins/src/dist/python3/python3PluginStart.py
+++ b/plugin/ipythonPlugins/src/dist/python3/python3PluginStart.py
@@ -19,7 +19,7 @@ import sys
 from IPython import start_ipython
 from subprocess import check_output
 
-ipyversion = check_output(["ipython", "ipython", "--version"])
+ipyversion = check_output([ "ipython", "ipython", "--version"]).decode("utf-8")
 if ipyversion[0] == "4":
   sys.exit(start_ipython(["notebook", "--config=" + os.environ["beaker_ipython_notebook_config"]]))
 else:


### PR DESCRIPTION
I got ipyversion[0] == "51" without decoding to utf-8. All python languages except ruby are working now on the docker. IPython version == 4.0.0
