### PR TITLE
fix JS exception about missing fonts in open/save dialogs #2634

### DIFF
--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -132,6 +132,7 @@ gulp.task("buildSingleOutDispJs", function() {
 
 gulp.task("namespaceIPythonCss", function() {
   return gulp.src(Path.join(IPythonCssPath, "**.css"))
+      .pipe(replace('../components/bootstrap/fonts/', '../../app/fonts/'))
       .pipe(cssWrap({selector:'.ipy-output'}))
       .pipe(concat('ipython.min.css'))
       .pipe(gulp.dest(buildPath));


### PR DESCRIPTION
path '../components/bootstrap/fonts/' was hardcoded in the core/src/main/web/app/styles/ipython/style/style.min.css. It is replaced to the correct path in the gulp file now
