### PR TITLE
CombinedPlots heights #2706

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/combinedplotformatter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/combinedplotformatter.js
@@ -58,13 +58,26 @@
         var plotType = model.plot_type;
         if (plotType == null) { plotType = "Plot"; }
 
+        var layout = {
+          bottomLayoutMargin : 30,
+          labelHeight: 12
+        };
         var sumweights = 0;
+        var sumvmargins = 0;
+        var vmargins = [];
         var weights = model.weights == null ? [] : model.weights;
         for(var i = 0; i < model.plots.length; i++) {
           if(weights[i] == null) {
             weights[i] = 1;
           }
           sumweights += weights[i];
+          if (i < model.plots.length - 1) {  //add margins for correct height calculation
+            vmargins[i] = layout.bottomLayoutMargin;
+            sumvmargins += vmargins[i];
+          } else {
+            vmargins[i] = layout.bottomLayoutMargin + layout.labelHeight * 2;
+            sumvmargins += vmargins[i];
+          }
         }
         var plots = model.plots;
         for(var i = 0; i < plots.length; i++) {
@@ -85,7 +98,8 @@
           }
 
           newplotmodel.plotSize.width = width;
-          newplotmodel.plotSize.height = height * weights[i] / sumweights;
+
+          newplotmodel.plotSize.height = (height - sumvmargins) * weights[i] / sumweights + vmargins[i];
 
           newmodel.plots.push(newplotmodel);
         }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/CombinedPlot.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/CombinedPlot.java
@@ -78,6 +78,12 @@ public class CombinedPlot {
     return this;
   }
 
+  public CombinedPlot add(XYChart plot) {
+    this.subplots.add(plot);
+    this.weights.add(1);
+    return this;
+  }
+
   public CombinedPlot leftShift(Object obj) {
     if (obj instanceof XYChart) {
       this.add((XYChart) obj, 1);


### PR DESCRIPTION
1. API was updated: now we can add subplot without providing weight (default weight is 1)
2. Actually plots’ weights are translated linearly to heights, but plot’s height also includes margins (which are constant for plots) and that’s why visually it seems that subplots have different heights (http://clip2net.com/s/3oPBjYd). 
   I've changed the algorithm of heights calculation so it  includes margins as well.

Concerning your screenshot with different heights: maybe you created plots with different weights, then ran the cell and then tried to change weight?  
in this case, yes, the heights will be different because plot size is saved to state and remains unchanged between cell evaluations. If you create new cell it should work.
