### PR TITLE
TimePlot autorange bug #2705

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotconverter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotconverter.js
@@ -209,8 +209,8 @@
             item.shape = this.pointShapeMap[item.shape];
           }
 
-          var yAxisSettings = plotUtils.useYAxisR(newmodel, item) ? yAxisRSettings : yAxisSettings;
-          if (item.base != null && yAxisSettings.logy) {
+          var itemYAxisSettings = plotUtils.useYAxisR(newmodel, item) ? yAxisRSettings : yAxisSettings;
+          if (item.base != null && itemYAxisSettings.logy) {
             if (item.base === 0) {
               item.base = 1;
             }
@@ -224,7 +224,7 @@
 
             // discard NaN entries
             if (ele.x === "NaN" || ele.y === "NaN" ||
-              logx && ele.x <= 0 || yAxisSettings.logy && ele.y <= 0 )
+              logx && ele.x <= 0 || itemYAxisSettings.logy && ele.y <= 0 )
               continue;
 
             if (item.colors != null) {

--- a/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
@@ -415,6 +415,15 @@
         var range = plotUtils.getDataRange(yAxisData).datarange;
         var rangeR = _.isEmpty(yAxisRData) ? null : plotUtils.getDataRange(yAxisRData).datarange;
 
+        if (newmodel.yIncludeZero === true && range.yl > 0) {
+          range.yl = 0;
+          range.yspan = range.yr - range.yl;
+        }
+        if (rangeR && newmodel.yRIncludeZero === true && rangeR.yl > 0) {
+          rangeR.yl = 0;
+          rangeR.yspan = rangeR.yr - rangeR.yl;
+        }
+
         var margin = newmodel.margin;
         if (margin.bottom == null) { margin.bottom = .05; }
         if (margin.top == null) { margin.top = .05; }
@@ -439,17 +448,6 @@
 
           if (newmodel.yPreventNegative === true) {
             vrange.yl = Math.min(0, range.yl);
-          }
-          if (newmodel.yIncludeZero === true) {
-            if (vrange.yl > 0) {
-              vrange.yl = 0;
-            }
-          }
-
-          if(vrangeR && newmodel.yRIncludeZero === true){
-            if (vrangeR.yl > 0) {
-              vrangeR.yl = 0;
-            }
           }
 
           var focus = newmodel.userFocus; // allow user to overide vrange

--- a/core/src/main/web/outputdisplay/bko-plot/plotutils.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotutils.js
@@ -82,6 +82,13 @@
           focus.xr = range.xr + range.xspan * margin.right;
         }
         if (focus.yl == null) {
+          if (model.yIncludeZero === true) {
+            var yl = model.vrange.yspan * range.yl + model.vrange.yl;
+            if(yl > 0){
+              range.yl = (0 - model.vrange.yl) / model.vrange.yspan;
+              range.yspan = range.yr - range.yl;
+            }
+          }
           focus.yl = range.yl - range.yspan * margin.bottom;
         }
         if (focus.yr == null) {

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/YAxis.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/xychart/plotitem/YAxis.java
@@ -47,7 +47,7 @@ public class YAxis {
   public YAxis(String label, double lowerMargin, double upperMargin) {
     this.label = label;
     this.autoRange = true;
-    this.autoRangeIncludesZero = true;
+    this.autoRangeIncludesZero = false;
     this.lowerMargin = lowerMargin;
     this.upperMargin = upperMargin;
     this.log = false;


### PR DESCRIPTION
Added support of autoRangeIncludesZero property on frontend.
I'd like to note that this property is set to true on backend by default. And now after this property started working usual plots (e.g. in charting tutorial) look different. Maybe it makes sense to set autoRangeIncludesZero to false by default?
