### PR TITLE
#2730 - Promoted the header to a layer to prevent repainting on scroll

### DIFF
--- a/core/src/main/web/app/styles/header.scss
+++ b/core/src/main/web/app/styles/header.scss
@@ -24,6 +24,8 @@
 }
 
 header {
+  @include promote-to-layer();
+
   .navbar {
     padding-left: 35px;
     padding-right: 35px;

--- a/core/src/main/web/app/styles/variables.scss
+++ b/core/src/main/web/app/styles/variables.scss
@@ -74,3 +74,8 @@ $code-bg: #F4F4F4;
 @function strip-units($number) {
   @return $number / ($number * 0 + 1);
 }
+
+@mixin promote-to-layer() {
+	-webkit-transform: translate3d(0, 0, 0);
+	transform: translate3d(0, 0, 0);
+}

--- a/core/src/main/web/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_navbar.scss
+++ b/core/src/main/web/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_navbar.scss
@@ -137,7 +137,6 @@
 // Fix the top/bottom navbars when screen real estate supports it
 .navbar-fixed-top,
 .navbar-fixed-bottom {
-  @include promote-to-layer();
   position: fixed;
   right: 0;
   left: 0;

--- a/core/src/main/web/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_navbar.scss
+++ b/core/src/main/web/vendor/bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_navbar.scss
@@ -137,6 +137,7 @@
 // Fix the top/bottom navbars when screen real estate supports it
 .navbar-fixed-top,
 .navbar-fixed-bottom {
+  @include promote-to-layer();
   position: fixed;
   right: 0;
   left: 0;


### PR DESCRIPTION
Fixed elements repaint when content underneath them changes. To prevent repainting they have to be promoted to a composite layer.

More about this issue: http://benfrain.com/improving-css-performance-fixed-position-elements/
