### PR TITLE
#2841 - Hovering over the insert cell menus no longer triggers digest…

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/close-dropdown-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/close-dropdown-directive.js
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2014 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+(function() {
+  'use strict';
+  var module = angular.module('bk.notebook');
+
+  module.directive('closeDropdownOnMouseout', function() {
+    return {
+      restrict: 'A',
+      link: function(scope, element) {
+        element.on('mouseleave', function() {$(document).trigger('click.bs.dropdown.data-api');});
+      }
+    };
+  });
+})();

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu-directive.js
@@ -41,10 +41,7 @@
         $scope.getEvaluators = function() {
           return bkEvaluatorManager.getLoadedEvaluators();
         };
-        var levels = [1, 2, 3, 4];
-        $scope.getLevels = function() {
-          return levels;
-        };
+        $scope.sectionLevels = [1, 2, 3, 4];
 
         $scope.newCodeCell = function(evaluatorName) {
           var newCell = newCellFactory.newCodeCell(evaluatorName);

--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<ul class="nav nav-pills new-cell" role="tablist" ng-mouseleave="hideOpenMenus()">
+<ul class="nav nav-pills new-cell" role="tablist">
   <li role="presentation" class="active">
     <button ng-click="newDefaultCodeCell()"
             class="btn btn-primary insert-cell"
@@ -26,7 +26,7 @@
     </span>
     </button>
   </li>
-  <li role="presentation" class="dropdown" ng-mouseleave="hideOpenMenus()">
+  <li role="presentation" class="dropdown" close-dropdown-on-mouseout>
     <button class="btn btn-primary dropdown-toggle"
             ng-class="!isLarge && 'btn-xs'"
             data-toggle="dropdown"
@@ -54,15 +54,15 @@
             ng-click="newMarkdownCell()">text<i class="fa fa-sort-down fa-hidden"></i>
     </button>
   </li>
-  <li role="presentation" class="dropdown" ng-mouseleave="hideOpenMenus()">
+  <li role="presentation" class="dropdown" close-dropdown-on-mouseout>
     <button class="btn btn-primary"
             ng-class="!isLarge && 'btn-xs'"
             data-toggle="dropdown"
             data-target=".section-menu">section <i class="fa fa-sort-down"></i>
     </button>
     <ul class="dropdown-menu section-menu" role="menu">
-      <li ng-repeat='level in getLevels()'>
-        <a class="new-cell-menu-item" ng-click="newSectionCell(level)">Level {{level}}</a>
+      <li ng-repeat='level in ::sectionLevels'>
+        <a class="new-cell-menu-item" ng-click="newSectionCell(level)">Level {{::level}}</a>
       </li>
     </ul>
   </li>

--- a/core/src/main/web/app/template/index_template.html
+++ b/core/src/main/web/app/template/index_template.html
@@ -138,6 +138,7 @@
   <script src="app/mainapp/components/notebook/codecell-directive.js"></script>
   <script src="app/mainapp/components/notebook/celltooltip-directive.js"></script>
   <script src="app/mainapp/components/notebook/codecellinputmenu-directive.js"></script>
+  <script src="app/mainapp/components/notebook/close-dropdown-directive.js"></script>
   <script src="app/mainapp/components/notebook/codecelloutput-directive.js"></script>
   <script src="app/mainapp/components/notebook/codecelloutputmenu-directive.js"></script>
   <script src="app/mainapp/components/notebook/markdown-editable-directive.js"></script>


### PR DESCRIPTION
… loops

While this does improves performance, it's a very minor improvement. The main reason for doing this is that random digests while scrolling the page made the performance analysis inaccurate and tricky.
