### PR TITLE
Removing mouseleave listener on destroy

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/close-dropdown-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/close-dropdown-directive.js
@@ -23,6 +23,8 @@
       restrict: 'A',
       link: function(scope, element) {
         element.on('mouseleave', function() {$(document).trigger('click.bs.dropdown.data-api');});
+
+        scope.$on('$destroy', function() {element.off();});
       }
     };
   });


### PR DESCRIPTION
As @samccone pointed out here: https://github.com/twosigma/beaker-notebook/pull/2853

I didn't remove the listener when the scope gets destroyed. This PR fixes that.
