### PR TITLE
#2868 - Set dropdown menu data-target to a child of the current element

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/newcellmenu.jst.html
@@ -30,7 +30,7 @@
     <button class="btn btn-primary dropdown-toggle"
             ng-class="!isLarge && 'btn-xs'"
             data-toggle="dropdown"
-            data-target=".code-dropdown">code <i class="fa fa-sort-down"></i>
+            data-target="> .code-dropdown">code <i class="fa fa-sort-down"></i>
     </button>
     <ul class="dropdown-menu code-dropdown" role="menu">
       <li ng-repeat="(key, value) in getEvaluators()">
@@ -58,7 +58,7 @@
     <button class="btn btn-primary"
             ng-class="!isLarge && 'btn-xs'"
             data-toggle="dropdown"
-            data-target=".section-menu">section <i class="fa fa-sort-down"></i>
+            data-target="> .section-menu">section <i class="fa fa-sort-down"></i>
     </button>
     <ul class="dropdown-menu section-menu" role="menu">
       <li ng-repeat='level in ::sectionLevels'>


### PR DESCRIPTION
Fixes opening multiple menus.

Also reduces the number of paints the browser has to do which is always nice. 
