### PR TITLE
Issue #2334 - Lazy output instantiation Tom/2334

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -393,10 +393,14 @@
 
         };
 
+        scope.displayOutput = false;
 
         Scrollin.track(element[0], function() {
           if (scope.cm === undefined) {
-            initCodeMirror();
+            $timeout(function() {
+              initCodeMirror();
+              scope.displayOutput = true;
+            }, 1);
           }
         });
 

--- a/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
@@ -35,7 +35,7 @@
         </a>
       </div>
     </div>
-    <div ng-if ="hasOutput()" class="code-cell-output" ng-class="{
+    <div ng-if ="displayOutput && hasOutput()" class="code-cell-output" ng-class="{
       'no-output': isHiddenOutput(),
       'input-hidden': cellmodel.input.hidden,
       'output-hidden': cellmodel.output.hidden,

--- a/test/protractorPerfConf.js
+++ b/test/protractorPerfConf.js
@@ -18,6 +18,7 @@ var config = {
   seleniumAddress: 'http://localhost:4444/wd/hub',
   framework: 'jasmine2',
   restartBrowserBetweenTests: false,
+  allScriptsTimeout: 20000,
   getPageTimeout: 30000,
   jasmineNodeOpts: {
     defaultTimeoutInterval: 900000,

--- a/test/tests/perf-tests.js
+++ b/test/tests/perf-tests.js
@@ -147,9 +147,8 @@ function reloadAndSaveStats() {
 }
 
 function reload() {
-  try {
-    browser.switchTo().alert().accept();
-  } catch (e) {
-    console.log(e);
-  }
+  browser.switchTo().alert().then(
+    function(alert) {alert.accept();},
+    function(err) {console.log(err);}
+  );
 }


### PR DESCRIPTION
This gives us a dramatic performance boost on notebook loading. However, the drawback is that the scroll lags because the browser needs to render the output cells during scroll.
This is very noticeable in the performance notebook in the Giant Tables section since there is a table there with 1000 columns that takes a while to render once you scroll to it.

Still, I believe that this is a good tradeoff.
