### PR TITLE
#2891 - Prevent double instantiation of Code Mirror

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -305,13 +305,6 @@
         };
         scope.scrollTo = function(){
           window.scrollTo(0, element.offset().top - 100);
-          scope.focus();
-        };
-        scope.focus = function() {
-          if (scope.cm === undefined) {
-            initCodeMirror();
-          }
-          scope.cm.focus();
         };
         CodeMirror.on(window, 'resize', resizeHandler);
 
@@ -396,12 +389,10 @@
         scope.displayOutput = false;
 
         Scrollin.track(element[0], function() {
-          if (scope.cm === undefined) {
-            $timeout(function() {
-              initCodeMirror();
-              scope.displayOutput = true;
-            }, 1);
-          }
+          $timeout(function() {
+            initCodeMirror();
+            scope.displayOutput = true;
+          }, 1);
         });
 
         scope.bkNotebook.registerFocusable(scope.cellmodel.id, scope);


### PR DESCRIPTION
We were instantiating CM when it entered the viewport and when it was focused.

Since we are focusing on the CodeMirror whenever the code cell is created and it, of course, enters the viewport when it was created, we were instantiating two CodeMirrors per code cell.

This PR removes CM instantiation on focus.
