### PR TITLE
2943 - Checking if upper and lower bounds of the graph are equal

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotconverter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotconverter.js
@@ -283,11 +283,13 @@
         newmodel.margin = {};
         // set axis bound as focus
         if (model.x_auto_range === false) {
-          if (model.x_lower_bound != null) {
-            newmodel.userFocus.xl = model.x_lower_bound;
-          }
-          if (model.x_upper_bound != null) {
-            newmodel.userFocus.xr = model.x_upper_bound;
+          if (model.x_lower_bound !== model.x_upper_bound) {
+            if (model.x_lower_bound != null) {
+              newmodel.userFocus.xl = model.x_lower_bound;
+            }
+            if (model.x_upper_bound != null) {
+              newmodel.userFocus.xr = model.x_upper_bound;
+            }
           }
         } else {
           if (model.x_lower_margin != null) {


### PR DESCRIPTION
This fixes the browser crashing on TimePlot.

Note that this is a fix in the frontend. This problem happens when the values for upper and lower bound of X are the same. I believe they are used to calculate zoom. If both values are the same, we default to no zoom which I believe is fine;.

This PR gets us rid of this bug. However, eventually we should dig deeper into backend to see what's happening there with these values. In this case we were getting 0.0 as both upper and lower bound from the backend.
