### PR TITLE
#2978. show tab with arrow to bar

### DIFF
--- a/core/src/main/web/app/styles/vendor_overrides.scss
+++ b/core/src/main/web/app/styles/vendor_overrides.scss
@@ -126,3 +126,9 @@ table.DTFC_Cloned thead,
 table.DTFC_Cloned tfoot {
   background-color: #E6E6E6;
 }
+
+.cm-tab {
+  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAMCAYAAAAkuj5RAAAAAXNSR0IArs4c6QAAAGFJREFUSMft1LsRQFAQheHPowAKoACx3IgEKtaEHujDjORSgWTH/ZOdnZOcM/sgk/kFFWY0qV8foQwS4MKBCS3qR6ixBJvElOobYAtivseIE120FaowJPN75GMu8j/LfMwNjh4HUpwg4LUAAAAASUVORK5CYII=);
+  background-position: right;
+  background-repeat: no-repeat;
+}


### PR DESCRIPTION
Arrows for tabs using code mirror's css class.
They all disappear when Tab key is pressed, because this leads to autoIndent which is done using spaces, not tabs
