### PR TITLE
scroll on code cell create #3039

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -321,9 +321,7 @@
           }
           showing.CodeMirror.getWrapperElement().style.height = winHeight() + 'px';
         };
-        scope.scrollTo = function(){
-          window.scrollTo(0, element.offset().top - 100);
-        };
+
         CodeMirror.on(window, 'resize', resizeHandler);
 
         var codeMirrorOptions = bkCoreManager.codeMirrorOptions(scope, notebookCellOp);
@@ -484,7 +482,6 @@
             }
 
             scope._shouldFocusCodeMirror = true;
-            scope.scrollTo();
           }
         });
 


### PR DESCRIPTION
My proposal is to using standard codemirror focus mechanism instead hand-made function scrollIn. When we are creating codecell (or markdown cell) we are calling codemirror focus function. This function moves offscreen codemiiror in the center of window. This is not full expected behaviour for this issue but I have opinion that using standard tested mechanism is a better solution. What is your opinion?
