### PR TITLE
plot date range incorrect #3052

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotaxis.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotaxis.js
@@ -241,7 +241,12 @@
           val = val.div(w).round(0, 0).times(w);
         }
       }else{
-        val = Math.ceil(val / w) * w
+        val = Math.ceil(val / w) * w;
+        if (this.axisType === "time") {
+          if (w >= this.YEAR) {
+            val = moment(val).tz("UTC").endOf("year").add(1, "ms");
+          }
+        }
       }
       var valr = this.getValue(pr);
       var lines = [];


### PR DESCRIPTION
I have added logging for this chart

left:2007 Aug 12 Sun, 12:00:00 .000
right:2016 Feb 19 Fri, 12:00:00 .000
line:2007 Dec 23 Sun, 00:00:00 .000
line:2009 Dec 22 Tue, 00:00:00 .000
line:2011 Dec 22 Thu, 00:00:00 .000
line:2013 Dec 21 Sat, 00:00:00 .000
line:2015 Dec 21 Mon, 00:00:00 .000

I think we can find nearest start of year. We can use '2008 Jan 1, 00:00:00 .000'  instead '2007 Dec 23 Sun, 00:00:00 .000'.
