### PR TITLE
 R plugin interrupt does not work on windows #542

### DIFF
--- a/plugin/r/src/main/java/com/twosigma/beaker/r/utils/RServerEvaluator.java
+++ b/plugin/r/src/main/java/com/twosigma/beaker/r/utils/RServerEvaluator.java
@@ -376,13 +376,14 @@ public class RServerEvaluator {
     }
 
     public void cancelExecution() {
-      if (iswindows) {
-        return;
-      }
-      if (pid >0) {
+      if (pid > 0) {
         try {
           logger.fine("sending signal");
-          Runtime.getRuntime().exec("kill -SIGINT " + pid);
+          String command = "kill -SIGINT " + pid;
+          if (iswindows) {
+            command = "taskkill /pid " + pid + " /F";
+          }
+          Runtime.getRuntime().exec(command);
         } catch (IOException e) {
           logger.log(Level.SEVERE, "exception sending signal: ", e);
         }


### PR DESCRIPTION
It will kill process by PID in the same fashion that we already do for not-windows OS.
But I'm not sure if it's ok to stop this process. Cell is in interrupted state(ok), but I can't execute other cells.
The same behavior is observed in mac/ubuntu.
@scottdraves, need your opinion here.
