### PR TITLE
Unexplained Bayeux Null #1976

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/rest/SessionBackupRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/SessionBackupRest.java
@@ -114,7 +114,7 @@ public class SessionBackupRest {
       Map<String, Object> data = new HashMap<String, Object>();
       sessionChangeChannel.publish(this.localSession, data, null);
     } else {
-      System.out.println("Warning: Caught NPE of unknown origin.");
+      System.out.println("Warning: Caught NPE of unknown origin. frontend");
     }
   }
 
@@ -126,7 +126,7 @@ public class SessionBackupRest {
       data.put("id", sessionid);
       sessionChangeChannel.publish(this.localSession, data, null);
     } else {
-      System.out.println("Warning: Caught NPE of unknown origin.");
+      System.out.println("Warning: Caught NPE of unknown origin. electron");
     }
   }
 

--- a/core/src/main/web/app/mainapp/services/notebookmanager.js
+++ b/core/src/main/web/app/mainapp/services/notebookmanager.js
@@ -22,7 +22,7 @@
 
   module.factory('bkNotebookManager', function() {
     var registrations = [];
-
+    var listeners = [];
     return {
       init: function(notebookModel) {
         registrations.push(
@@ -34,10 +34,20 @@
             });
           })
         );
+
+        registrations.push($.cometd.subscribe('/sessionChange', function(reply){}));
+        listeners.push($.cometd.addListener("/meta/handshake", function (reply) {
+          if (reply.successful) {
+            registrations.push($.cometd.subscribe('/sessionChange', function(reply){}));
+          }
+        }));
       },
       reset: function() {
         _.each(registrations, function(v) {
           $.cometd.unsubscribe(v);
+        });
+        _.each(listeners, function(l) {
+          $.cometd.removeListener(l);
         });
       }
     };


### PR DESCRIPTION
subscription to 'sessionChange' channel was only in controlpanel-directive.
if we open notebook and then reload the page re-handshake will be performed and "sessionChange" subscriber will be removed. when we perform session backup we are trying to find "sessionChange" channel to publish data but we can't because subscriber was removed. 
to avoid this i added subscription to "sessionChange" channel also to notebookmanager.js
