### PR TITLE
#3044. Time series autotranslation bug

### DIFF
--- a/core/src/main/web/app/mainapp/services/sessionmanager.js
+++ b/core/src/main/web/app/mainapp/services/sessionmanager.js
@@ -371,7 +371,11 @@
           if (v.subtype === "Dictionary") {
             var o = {}
             for (var r in v.values) {
-              o[v.values[r][0]] = transformBack(v.values[r][1]);
+              if (typeof(v.values[r][0]) === 'object') {
+                o[transformBack(v.values[r][0])] = transformBack(v.values[r][1]);
+              } else {
+                o[v.values[r][0]] = transformBack(v.values[r][1]);
+              }
             }
             return o;
           }

--- a/plugin/r/src/dist/beaker/R/beaker.r
+++ b/plugin/r/src/dist/beaker/R/beaker.r
@@ -477,7 +477,12 @@ transformJSON <- function(tres) {
 		    if (exists("subtype", where=tres) && tres$subtype == "Dictionary") {
 		      o = list()
 		      for (i in 1:rows) {
-		        o[[ tres$values[[i]][[1]] ]] = transformJSON(tres$values[[i]][[2]])
+            theval = tres$values[[i]][[1]]
+            if (is.list(theval) && !is.null(names(theval)) && exists("type", where=theval) && exists("timestamp", where=theval) && theval$type == "Date") {
+              o[[ transformJSON(theval) ]] = transformJSON(tres$values[[i]][[2]])
+            } else {
+		          o[[ tres$values[[i]][[1]] ]] = transformJSON(tres$values[[i]][[2]])
+            }
 		      }
 		      tres = o
 		    } else if (exists("subtype", where=tres) && tres$subtype == "ListOfMaps") {


### PR DESCRIPTION
I found that autotranslation in JS ruins DataTable with complex(object) key.
Here: `o[v.values[r][0]] =` index is an object with type=Date and timestamp field. As it converted to string as `[object object]` all values will be mapped to this key and we can see:
[object object] 0.1234123123

Confirm if that's what we need, please.
