### PR TITLE
scroll wheel stops working over charts #3078

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -1629,6 +1629,7 @@
         };
         scope.disableZoom = function() {
           scope.svg.call(scope.zoomObj.on("zoomstart", null).on("zoom", null).on("zoomend", null));
+          scope.svg.on("wheel.zoom", null);
         };
 
         scope.mouseleaveClear = function() {
@@ -1779,13 +1780,14 @@
             return scope.mouseDown();
           }).on("mouseup", function() {
             return scope.mouseUp();
+          }).on("mouseleave", function() {
+            return scope.disableZoom();
           });
           scope.jqsvg.mousemove(function(e) {
             return scope.renderCursor(e);
           }).mouseleave(function(e) {
             return scope.mouseleaveClear(e);
           });
-          scope.enableZoom();
           scope.calcRange();
 
           // init copies focus to defaultFocus, called only once


### PR DESCRIPTION
until we click on the chart mouse the wheel will be used to scroll the page
when we click on the chart then mouse wheel will be for d3 zoom
but then if we leave the chart, the mouse wheel will once again be used to scroll the page, even if the mouse is over the chart (until we click on the chart once again)
please check if this is what we need
