### PR TITLE
unlocking notebook breaks code cells #3080

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -18,6 +18,26 @@
   'use strict';
   var module = angular.module('bk.notebook');
 
+  module.directive('ngHideEx', function($animate) {
+    return {
+      scope: {
+        'ngHideEx': '=',
+        'afterShow': '&',
+        'afterHide': '&'
+      },
+      link: function(scope, element) {
+        scope.$watch('ngHideEx', function(hide, oldHide) {
+          if (hide) {
+            $animate.addClass(element, 'ng-hide', {tempClasses: 'ng-hide-animate'}).then(scope.afterHide);
+          }
+          if (!hide) {
+            $animate.removeClass(element, 'ng-hide', {tempClasses: 'ng-hide-animate'}).then(scope.afterShow);
+          }
+        });
+      }
+    }
+  });
+
   module.directive('bkCodeCell', function(
       bkUtils,
       bkEvaluatorManager,
@@ -76,18 +96,11 @@
 
         $scope.bkNotebook = getBkNotebookWidget();
 
-        // ensure cm refreshes when 'unhide'
-        $scope.$watch('isShowInput()', function(newValue, oldValue) {
-          if ($scope.cm && newValue !== oldValue) {
-						var inputCodeCell = $(".code-cell-input");
-            if (newValue === true){
-              inputCodeCell.removeClass("ng-hide");
-              $scope.cm.refresh();
-            }else{
-              inputCodeCell.addClass("ng-hide");
-            }
-          }
-        });
+        //ensure cm refreshes when 'unhide'
+        $scope.afterShow = function () {
+          $scope.cm.refresh();
+        };
+
 
         $scope.isHiddenOutput = function() {
           return $scope.cellmodel.output.selectedType == 'Hidden';

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -25,7 +25,8 @@
       bkSessionManager,
       bkCoreManager,
       bkPublicationHelper,
-      $timeout) {
+      $timeout,
+      $animate) {
 
     var notebookCellOp = bkSessionManager.getNotebookCellOp();
     var getBkNotebookWidget = function() {
@@ -76,18 +77,17 @@
         $scope.bkNotebook = getBkNotebookWidget();
 
         // ensure cm refreshes when 'unhide'
-        var lastInputHidden = $(".code-cell-input").hasClass("ng-hide");
-        window.setInterval(function () {
-          var inputHidden = $(".code-cell-input").hasClass("ng-hide");
-          if (inputHidden !== lastInputHidden) {
-            if ($scope.cm && inputHidden === false) {
-              bkUtils.fcall(function () {
-                $scope.cm.refresh();
-              });
+        $scope.$watch('isShowInput()', function(newValue, oldValue) {
+          if ($scope.cm && newValue !== oldValue) {
+						var inputCodeCell = $(".code-cell-input");
+            if (newValue === true){
+              inputCodeCell.removeClass("ng-hide");
+              $scope.cm.refresh();
+            }else{
+              inputCodeCell.addClass("ng-hide");
             }
-            lastInputHidden = inputHidden;
           }
-        }, 10);
+        });
 
         $scope.isHiddenOutput = function() {
           return $scope.cellmodel.output.selectedType == 'Hidden';

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -100,6 +100,13 @@
         $scope.afterShow = function () {
           $scope.cm.refresh();
         };
+        $scope.$watch('cellmodel.input.hidden', function(newValue, oldValue) {
+          if ($scope.cm && oldValue === true && newValue !== oldValue) {
+            bkUtils.fcall(function() {
+              $scope.afterShow();
+            });
+          }
+        });
 
 
         $scope.isHiddenOutput = function() {

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -70,21 +70,24 @@
           if ($scope.isLocked()) {
             return false;
           }
-          if ($scope.cellmodel.input.hidden === true) {
-            return false;
-          }
-          return true;
+          return $scope.cellmodel.input.hidden !== true;
         };
 
         $scope.bkNotebook = getBkNotebookWidget();
+
         // ensure cm refreshes when 'unhide'
-        $scope.$watch('isShowInput()', function(newValue, oldValue) {
-          if ($scope.cm && newValue === true && newValue !== oldValue) {
-            bkUtils.fcall(function() {
-              $scope.cm.refresh();
-            });
+        var lastInputHidden = $(".code-cell-input").hasClass("ng-hide");
+        window.setInterval(function () {
+          var inputHidden = $(".code-cell-input").hasClass("ng-hide");
+          if (inputHidden !== lastInputHidden) {
+            if ($scope.cm && inputHidden === false) {
+              bkUtils.fcall(function () {
+                $scope.cm.refresh();
+              });
+            }
+            lastInputHidden = inputHidden;
           }
-        });
+        }, 10);
 
         $scope.isHiddenOutput = function() {
           return $scope.cellmodel.output.selectedType == 'Hidden';

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -45,8 +45,7 @@
       bkSessionManager,
       bkCoreManager,
       bkPublicationHelper,
-      $timeout,
-      $animate) {
+      $timeout) {
 
     var notebookCellOp = bkSessionManager.getNotebookCellOp();
     var getBkNotebookWidget = function() {

--- a/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
@@ -20,7 +20,7 @@
     'empty': isEmpty()
   }">
   <div class="bkcell code-cell-area">
-    <div class="code-cell-input" ng-mousedown="backgroundClick($event)" ng-hide="isLocked()" ng-class="{'input-hidden': cellmodel.input.hidden}">
+    <div class="code-cell-input" ng-mousedown="backgroundClick($event)" ng-class="{'input-hidden': cellmodel.input.hidden}">
       <div class="code-cell-input-content">
         <bk-code-cell-input-menu class="advanced-hide"></bk-code-cell-input-menu>
         <div ng-mousedown="$event.stopPropagation()">

--- a/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell.jst.html
@@ -20,7 +20,7 @@
     'empty': isEmpty()
   }">
   <div class="bkcell code-cell-area">
-    <div class="code-cell-input" ng-mousedown="backgroundClick($event)" ng-class="{'input-hidden': cellmodel.input.hidden}">
+    <div class="code-cell-input" ng-mousedown="backgroundClick($event)" ng-hide-ex="isLocked()" after-hide="afterHide()" after-show="afterShow()" ng-class="{'input-hidden': cellmodel.input.hidden}">
       <div class="code-cell-input-content">
         <bk-code-cell-input-menu class="advanced-hide"></bk-code-cell-input-menu>
         <div ng-mousedown="$event.stopPropagation()">


### PR DESCRIPTION
Functionality for the refresh codemirror after unhide cell has been added. In current momemt we are using 2 way for refreshing codemirror:
1. After changing 'IsLocked' property
   2/ After click on "Unhide" menu button
