### PR TITLE
#3126. section headings editing is off

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/markdown-editable-directive.js
@@ -115,9 +115,17 @@
         scope.cm.setValue(scope.cellmodel[contentAttribute]);
         preview();
 
-        scope.cm.on("blur", function(cm){
+        scope.cm.on("mousedown", function(cm) {
+          scope.mousedown = true;
+        });
+
+        $(scope.cm.getWrapperElement()).on("mouseup", function(cm) {
+          scope.mousedown = false;
+        });
+
+        scope.cm.on("blur", function(cm) {
           setTimeout(function() {
-            if(!cm.state.focused){
+            if (!scope.mousedown) {
               scope.$apply(function() {
                 syncContentAndPreview();
               });


### PR DESCRIPTION
This is the mentioned workaround.
Please check if it's ok.
The thing that is fixed by this: click inside CM selection doesn't switch CM into preview mode anymore.
