### PR TITLE
hack big.js to load without modules (for native beaker)

### DIFF
--- a/core/src/main/web/vendor/bower_components/big.js/big.js
+++ b/core/src/main/web/vendor/bower_components/big.js/big.js
@@ -1008,19 +1008,21 @@
     // EXPORT
 
 
-    // Node and other CommonJS-like environments that support module.exports.
-    if ( typeof module !== 'undefined' && module.exports ) {
-        module.exports = Big
-
-    //AMD.
-    } else if ( typeof define == 'function' && define.amd ) {
-        define( function () {
-            return Big
-        })
-
-    //Browser.
-    } else {
-        global['Big'] = Big
-    }
+    global['Big'] = Big
+    //commented out to enable static loading for native beaker
+    //// Node and other CommonJS-like environments that support module.exports.
+    //if ( typeof module !== 'undefined' && module.exports ) {
+    //    module.exports = Big
+    //
+    ////AMD.
+    //} else if ( typeof define == 'function' && define.amd ) {
+    //    define( function () {
+    //        return Big
+    //    })
+    //
+    ////Browser.
+    //} else {
+    //    global['Big'] = Big
+    //}
 
 })( this );


### PR DESCRIPTION
for electron version Big is not set as global variable.

```
   // Node and other CommonJS-like environments that support module.exports.
   if ( typeof module !== 'undefined' && module.exports ) {
       module.exports = Big

   //AMD.
   } else if ( typeof define == 'function' && define.amd ) {
       define( function () {
           return Big
       })

   //Browser.
   } else {
       global['Big'] = Big
   }
```

that's how export in big.js looks like
for electron the 1st check works instead of the last one
