### PR TITLE
Change svg marker link to work in embedded beaker

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plottext.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plottext.js
@@ -200,7 +200,7 @@
           .attr("y2", 0)
           .attr("class", "text-line-style")
           .attr("stroke-width", 1)
-          .attr("marker-end", "url(/beaker/#Triangle)");
+          .attr("marker-end", "url("+window.location.pathname+"#Triangle)");
 
 
         itemsvg.selectAll("line")


### PR DESCRIPTION
This works both in beaker and in beaker publication and fixes #3275 
