### PR TITLE
add option for location of prefs and temp files #2779

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/Main.java
+++ b/core/src/main/java/com/twosigma/beaker/core/Main.java
@@ -95,6 +95,7 @@ public class Main {
     opts.addOption(null, "use-ssl-key", true, "Enable SSL - requires path to key file (both SSL options should be used)");
     opts.addOption(null, "require-password", false, "Ask for password when connecting");
     opts.addOption(null, "listen-interface", true, "Interface to listen on - requires ip address or '*'");
+    opts.addOption(null, "portable", false, "is portable application");
     
     CommandLine line = parser.parse(opts, args);
     if (line.hasOption("help")) {
@@ -176,7 +177,7 @@ public class Main {
     final Boolean requirePassword = options.hasOption("require-password");
     final String listenInterface = options.hasOption("listen-interface") ?
         options.getOptionValue("listen-interface") : null;
-    
+    final Boolean portable = options.hasOption("portable");
     
     
     // create preferences for beaker core from cli options and others
@@ -191,7 +192,8 @@ public class Main {
         useHttpsCert,
         useHttpsKey,
         requirePassword,
-        listenInterface);
+        listenInterface,
+        portable);
 
     WebAppConfigPref webAppPref = createWebAppConfigPref(
         portBase + BEAKER_SERVER_PORT_OFFSET,
@@ -241,7 +243,8 @@ public class Main {
       final String useHttpsCert,
       final String useHttpsKey,
       final Boolean requirePassword,
-      final String listenInterface) {
+      final String listenInterface,
+      final Boolean portable) {
     return new BeakerConfigPref() {
 
       @Override
@@ -287,6 +290,11 @@ public class Main {
       @Override
       public Map<String, List<String>> getPluginOptions() {
         return pluginOptions;
+      }
+
+      @Override
+      public Boolean getPortable() {
+        return portable;
       }
     };
   }

--- a/core/src/main/java/com/twosigma/beaker/core/Main.java
+++ b/core/src/main/java/com/twosigma/beaker/core/Main.java
@@ -95,7 +95,7 @@ public class Main {
     opts.addOption(null, "use-ssl-key", true, "Enable SSL - requires path to key file (both SSL options should be used)");
     opts.addOption(null, "require-password", false, "Ask for password when connecting");
     opts.addOption(null, "listen-interface", true, "Interface to listen on - requires ip address or '*'");
-    opts.addOption(null, "portable", false, "is portable application");
+    opts.addOption(null, "portable", false, "Configuration and runtime files located in application instead of user home directory.");
     
     CommandLine line = parser.parse(opts, args);
     if (line.hasOption("help")) {

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfigPref.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfigPref.java
@@ -54,4 +54,10 @@ public interface BeakerConfigPref {
    */
   public Map<String, List<String>> getPluginOptions();
 
+  /**
+   * Puts what normally goes in ~/.beaker instead into the root of the drive where the application
+   * is mounted G:/.beaker or whatever drive.
+   */
+  public Boolean getPortable();
+
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -100,8 +100,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
 
     if (pref.getPortable()){
       //get parent for the 'core' folder
-      Path path = Paths.get("").toAbsolutePath();
-      this.dotDir =  "/"+ path.subpath(0, path.getNameCount()-1).toString() + "/.beaker/v1";
+      this.dotDir =  Paths.get("").toAbsolutePath().getParent().toString() + "/.beaker/v1";
     }else {
       this.dotDir = System.getProperty("user.home") + "/.beaker/v1";
     }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -24,6 +24,8 @@ import java.io.PrintWriter;
 import java.lang.Exception;
 import java.net.UnknownHostException;
 import java.net.InetAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -94,7 +96,18 @@ public class DefaultBeakerConfig implements BeakerConfig {
     this.useKerberos = pref.getUseKerberos();
     this.portBase = pref.getPortBase();
     this.reservedPortCount = 4;
-    this.dotDir = System.getProperty("user.home") + "/.beaker/v1";
+
+
+    if (pref.getPortable()){
+      String path = Paths.get("").toAbsolutePath().toString();
+      boolean endsWithSlash = path.endsWith(File.separator);
+      path = path.substring(0,
+                      path.lastIndexOf(File.separatorChar,
+                                    endsWithSlash ? path.length() - 2 : path.length() - 1));
+      this.dotDir = path + "/.beaker/v1";
+    }else {
+      this.dotDir = System.getProperty("user.home") + "/.beaker/v1";
+    }
     this.pluginDir = this.installDir + "/config/plugins/eval";
     utils.ensureDirectoryExists(this.dotDir);
     this.nginxDir = this.installDir + "/nginx";

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -104,7 +104,6 @@ public class DefaultBeakerConfig implements BeakerConfig {
     }else {
       this.dotDir = System.getProperty("user.home") + "/.beaker/v1";
     }
-    System.out.println("this.dotDir: "+this.dotDir);
     this.pluginDir = this.installDir + "/config/plugins/eval";
     utils.ensureDirectoryExists(this.dotDir);
     this.nginxDir = this.installDir + "/nginx";

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -99,15 +99,13 @@ public class DefaultBeakerConfig implements BeakerConfig {
 
 
     if (pref.getPortable()){
-      String path = Paths.get("").toAbsolutePath().toString();
-      boolean endsWithSlash = path.endsWith(File.separator);
-      path = path.substring(0,
-                      path.lastIndexOf(File.separatorChar,
-                                    endsWithSlash ? path.length() - 2 : path.length() - 1));
-      this.dotDir = path + "/.beaker/v1";
+      //get parent for the 'core' folder
+      Path path = Paths.get("").toAbsolutePath();
+      this.dotDir =  "/"+ path.subpath(0, path.getNameCount()-1).toString() + "/.beaker/v1";
     }else {
       this.dotDir = System.getProperty("user.home") + "/.beaker/v1";
     }
+    System.out.println("this.dotDir: "+this.dotDir);
     this.pluginDir = this.installDir + "/config/plugins/eval";
     utils.ensureDirectoryExists(this.dotDir);
     this.nginxDir = this.installDir + "/nginx";


### PR DESCRIPTION
--portable
puts what normally goes in ~/.beaker instead into the folder where the application is mounted - {path_to_beaker_application}/.beaker .
