### PR TITLE
#3292. Scala on windows broken

### DIFF
--- a/plugin/scala/build.gradle
+++ b/plugin/scala/build.gradle
@@ -43,31 +43,6 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-// Fix command-length issue in windows startscript
-task pathingJar(type: Jar) {
-  appendix = 'pathing'
-  manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
-  }
-}
-
-applicationDistribution.from(pathingJar) {
-  into "lib"
-}
-
-startScripts {
-  doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
-  }
-}
-
 if (hasProperty('evalPluginDir')) {
   installDist.into new File(evalPluginDir, 'scala')
 }

--- a/plugin/scala/src/main/scala/com/twosigma/beaker/scala/util/ScalaEvaluator.java
+++ b/plugin/scala/src/main/scala/com/twosigma/beaker/scala/util/ScalaEvaluator.java
@@ -22,7 +22,6 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.file.FileSystems;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,7 +48,6 @@ import scala.collection.Iterable;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.twosigma.beaker.scala.util.ScalaEvaluatorGlue;
 import com.twosigma.beaker.NamespaceClient;
 import com.twosigma.beaker.jvm.classloader.DynamicClassLoaderSimple;
 import com.twosigma.beaker.jvm.object.SimpleEvaluationObject;
@@ -321,13 +319,14 @@ public class ScalaEvaluator {
       loader_cp += outDir;
       DynamicClassLoaderSimple cl = new DynamicClassLoaderSimple(ClassLoader.getSystemClassLoader());
       cl.addJars(classPath);
+      cl.addDynamicDir(outDir);
       return cl;
     }
 
     protected void newEvaluator() throws MalformedURLException
     {
       logger.fine("creating new evaluator");
-      shell = new ScalaEvaluatorGlue(newClassLoader(), loader_cp+System.getProperty("java.class.path"));
+      shell = new ScalaEvaluatorGlue(newClassLoader(), loader_cp + File.pathSeparatorChar + System.getProperty("java.class.path"));
 
       if (!imports.isEmpty()) {
         for (int i = 0; i < imports.size(); i++) {
@@ -385,13 +384,14 @@ public class ScalaEvaluator {
         
     DynamicClassLoaderSimple cl = new DynamicClassLoaderSimple(ClassLoader.getSystemClassLoader());
     cl.addJars(classPath);
+    cl.addDynamicDir(outDir);
     return cl;
   }
 
   protected void newAutoCompleteEvaluator() throws MalformedURLException
   {
     logger.fine("creating new autocomplete evaluator");
-    acshell = new ScalaEvaluatorGlue(newAutoCompleteClassLoader(), acloader_cp+System.getProperty("java.class.path"));
+    acshell = new ScalaEvaluatorGlue(newAutoCompleteClassLoader(), acloader_cp + File.pathSeparatorChar + System.getProperty("java.class.path"));
 
     if (!imports.isEmpty()) {
       for (int i = 0; i < imports.size(); i++) {


### PR DESCRIPTION
Remove usage of pathing jar as it breaks scala evaluator.
Minor fixes: removed unused imports, added files separator. Set addDynamicDir property to outDir as it's done in groovy in DynamicClassLaoderSimple.
