### PR TITLE
windows electron installer version can be wrong #3353

### DIFF
--- a/launcher/electron/build.gradle
+++ b/launcher/electron/build.gradle
@@ -124,7 +124,12 @@ task makeDist (dependsOn:[':beaker:build', 'unzipPython']) << {
 }
 
 task cleanElectron(type: Delete) {
-  delete 'dist', 'Beaker.app', '__MACOSX', 'jre', 'beaker', 'osxdmg', fileTree(dir: './', include: "beaker-notebook-*-electron-mac.dmg"), 'python', setupName + '.exe'
+  delete 'dist', 'Beaker.app', '__MACOSX', 'jre', 'beaker', 'osxdmg',
+    fileTree(dir: './', include: "beaker-notebook-*-electron-mac.dmg"),
+    fileTree(dir: './', include: "beaker-notebook-*-electron-windows.exe"),
+    'python',
+    setupName + '.exe',
+    "./templates/makeWinInstaller.iss"
 }
 
 task realCleanElectron(type: Delete, dependsOn: 'cleanElectron') {


### PR DESCRIPTION
> probably the template file was not run because it already existed.

Yes - I have added './templates/makeWinInstaller.iss' to the 'cleanElectron' task. This task should be executed before 'makeInstall' task
