### PR TITLE
[Native Beaker] Show stdout/err menu doesn't work #3259. 

### DIFF
--- a/core/src/main/web/app/helpers/helper.js
+++ b/core/src/main/web/app/helpers/helper.js
@@ -584,6 +584,12 @@
         }
       },
       // bk-notebook
+      refreshBkNotebook: function () {
+        var bkNotebook = getBkNotebookWidget();
+        if (bkNotebook) {
+          return bkNotebook.refreshScope();
+        }
+      },
       deleteAllOutputCells: function() {
         var bkNotebook = getBkNotebookWidget();
         if (bkNotebook) {

--- a/core/src/main/web/app/mainapp/components/notebook/notebook-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/notebook-directive.js
@@ -94,6 +94,11 @@
                this._lodThreshold = lodThreshold;
             }
           },
+          refreshScope: function () {
+            if(!($scope.$$phase || $scope.$root.$$phase)){
+              $scope.$apply();
+            }
+          },
           getViewModel: function () {
             return this._viewModel;
           },

--- a/core/src/main/web/app/utils/electron.js
+++ b/core/src/main/web/app/utils/electron.js
@@ -156,7 +156,13 @@
                 label: bkItem.name
               }
               if (bkItem.action !== undefined) {
-                newItem.click = bkItem.action.bind({});
+                var item = {
+                  action: function(itemAction, refreshBkNotebook){
+                    itemAction();
+                    refreshBkNotebook();
+                  }.bind(this, bkItem.action, bkHelper.refreshBkNotebook)
+                };
+                newItem.click = item.action;
               }
               if ((bkItem.isRadio !== true) && (bkItem.isChecked !== undefined)) {
                 newItem.type = 'checkbox';


### PR DESCRIPTION
partial fix for updating notebook after menu was clicked.
there is still a bug with updating checks in menu if they were changed from the application (like for example when we hide stdoutput div with the "hide" button and menu should be unchecked)
