### PR TITLE
fixes #3399, adds language env config option, $GROOVY_JAR_PATH variable

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -170,6 +170,8 @@ public class DefaultBeakerConfig implements BeakerConfig {
 
     augmentPluginOptions();
 
+    augmentPluginEnv();
+    
     this.publicServer = pref.getPublicServer();
     this.useHttpsCert = pref.getUseHttpsCert();
     this.useHttpsKey = pref.getUseHttpsKey();
@@ -469,5 +471,34 @@ public class DefaultBeakerConfig implements BeakerConfig {
     } catch (Exception e) {
       // ignore
     }
+  }
+  
+  @SuppressWarnings("unchecked")
+  private void augmentPluginEnv() {
+	  
+	  Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("languages");
+	  for(Map.Entry<String, JSONObject> entry : plugins.entrySet()) {
+		  
+		  String plugin = entry.getKey();
+		  
+		  Object env = entry.getValue().get("env");
+		  
+		  if(env == null) continue;
+		  
+		  if(!(env instanceof Map)) { throw new RuntimeException("'env' value must be a map"); };
+		  
+		  Map<String, String> m = (Map<String, String>) env;
+		  
+		  List<String> envL = new ArrayList<String>();
+		  
+		  for(Map.Entry<String, String> e : m.entrySet() ) {
+			  
+			  envL.add(e.getKey() + "=\"" + e.getValue().replace("\"", "\\\"") + "\"");			  
+		  }
+		  
+		  pluginEnvps.put(plugin, envL.toArray(new String[envL.size()]));
+		  
+		  
+	  }
   }
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -485,7 +485,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
         Map<String, String> m = (Map<String, String>) env;
         List<String> envL = new ArrayList<String>();
         for(Map.Entry<String, String> e : m.entrySet() ) {
-          envL.add(e.getKey() + "=\"" + e.getValue().replace("\"", "\\\"") + "\"");
+          envL.add(e.getKey() + "=" + e.getValue());
         }
         pluginEnvps.put(plugin, envL.toArray(new String[envL.size()]));
       }
@@ -493,4 +493,5 @@ public class DefaultBeakerConfig implements BeakerConfig {
         // ignore
     }
   }
+  
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -475,30 +475,22 @@ public class DefaultBeakerConfig implements BeakerConfig {
   
   @SuppressWarnings("unchecked")
   private void augmentPluginEnv() {
-	  
-	  Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("languages");
-	  for(Map.Entry<String, JSONObject> entry : plugins.entrySet()) {
-		  
-		  String plugin = entry.getKey();
-		  
-		  Object env = entry.getValue().get("env");
-		  
-		  if(env == null) continue;
-		  
-		  if(!(env instanceof Map)) { throw new RuntimeException("'env' value must be a map"); };
-		  
-		  Map<String, String> m = (Map<String, String>) env;
-		  
-		  List<String> envL = new ArrayList<String>();
-		  
-		  for(Map.Entry<String, String> e : m.entrySet() ) {
-			  
-			  envL.add(e.getKey() + "=\"" + e.getValue().replace("\"", "\\\"") + "\"");			  
-		  }
-		  
-		  pluginEnvps.put(plugin, envL.toArray(new String[envL.size()]));
-		  
-		  
-	  }
+    try {
+      Map<String, JSONObject> plugins = (Map<String, JSONObject>) this.prefs.get("languages");
+      for(Map.Entry<String, JSONObject> entry : plugins.entrySet()) {
+        String plugin = entry.getKey();
+        Object env = entry.getValue().get("env");
+        if(env == null) continue;
+        if(!(env instanceof Map)) { throw new RuntimeException("'env' value must be a map"); };
+        Map<String, String> m = (Map<String, String>) env;
+        List<String> envL = new ArrayList<String>();
+        for(Map.Entry<String, String> e : m.entrySet() ) {
+          envL.add(e.getKey() + "=\"" + e.getValue().replace("\"", "\\\"") + "\"");
+        }
+        pluginEnvps.put(plugin, envL.toArray(new String[envL.size()]));
+      }
+    } catch (Exception e) {
+        // ignore
+    }
   }
 }

--- a/plugin/groovy/build.gradle
+++ b/plugin/groovy/build.gradle
@@ -70,7 +70,23 @@ compileJava {
 task pathingJar(type: Jar) {
   appendix = 'pathing'
   manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
+	//skip groovy jars, let it be picked during runtime, using env GROOVY_JAR_PATH
+    attributes("Class-Path": {
+		
+		def cp = ""
+		
+		configurations.runtime.each {
+			if( it.getName().matches("groovy-.+\\.jar") ) {
+				return
+			}
+			if(cp.length() > 0) cp += ' '
+			cp += it.getName()
+		}
+		
+		cp += ( ' ' + jar.archiveName )
+		
+		return cp
+	}.call() )
   }
 }
 
@@ -79,15 +95,86 @@ applicationDistribution.from(pathingJar) {
 }
 
 startScripts {
+	
+  def builtInGroovyJars = []
+	
+  doFirst {
+	
+    def inputClasspath = getClasspath()
+	  
+    def filteredClasspath = inputClasspath.filter {
+      if( it.getName().matches("groovy-.+\\.jar") ) {
+        builtInGroovyJars.add( it.getName() )
+		return false	  
+      } else {
+        return true
+      }
+    }
+	
+	
+	setClasspath(filteredClasspath)
+	  	    
+  }
+  
   doLast {
+	  
     def winScriptFile  = file getWindowsScript()
     def winFileText = winScriptFile.text
+	
+	def winGroovyJars = ''
+	for(String groovyJar : builtInGroovyJars) {
+		
+		if(winGroovyJars.length() > 0) {
+			winGroovyJars += ';'
+		}
 
+		winGroovyJars += "%APP_HOME%\\\\lib\\\\${groovyJar}"
+				
+	}
+	
+	//prepare the class path based on GROOVY_JAR_PATH variable
+	def winFileGroovyPath = """\
+if defined GROOVY_JAR_PATH (
+    echo Using GROOVY_JAR_PATH = %GROOVY_JAR_PATH%
+) else (
+  set GROOVY_JAR_PATH="${winGroovyJars}"
+)
+"""
     // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
+    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.\n' + winFileGroovyPath)
+    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%GROOVY_JAR_PATH%;%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
 
     winScriptFile.text = winFileText
+	
+	
+	
+	def unixScriptFile = file getUnixScript()
+	def unixFileText = unixScriptFile.text
+	
+	def unixGroovyJars = ''
+	for(String groovyJar : builtInGroovyJars) {
+		
+		if(unixGroovyJars.length() > 0) {
+			unixGroovyJars += ':'
+		} 
+		
+		unixGroovyJars += "\\\$APP_HOME/lib/${groovyJar}"
+	}
+	
+	def unixFileGroovyPath = """\
+if [ -n "\\\$GROOVY_JAR_PATH" ] ; then
+  echo Using GROOVY_JAR_PATH = \\\$GROOVY_JAR_PATH
+else 
+  GROOVY_JAR_PATH="${unixGroovyJars}"
+fi
+
+"""
+	
+	unixFileText = unixFileText.replaceAll('(exec "\\$JAVACMD" "\\$\\{JVM_OPTS\\[@\\]\\}" -classpath ")(\\$CLASSPATH" .*)',
+			unixFileGroovyPath +
+			'$1\\$GROOVY_JAR_PATH:$2')
+	unixScriptFile.text = unixFileText
+	
   }
 }
 


### PR DESCRIPTION
this PR lets the environment variables from beaker.pref.json be injected when language scripts are executed. The env values are read into com.twosigma.beaker.core.module.config.DefaultBeakerConfig#pluginEnvps

```
{
  "pref-format" : "1",
  "allow-anonymous-usage-tracking" : false,
  "edit-mode" : "default",

  "languages" : {
    "Groovy" : {
      "env" : {
        "GROOVY_JAR_PATH": "/var/lib/groovy/groovy-all-2.5.0-SNAPSHOT.jar",
        "someVar": "someValue"
      }
    }
  }
}
```

the groovy plugin env build script update honors that particular env variable (GROOVY_JAR_PATH) to override default built-in groovy jars
