### PR TITLE
Resolved warnings in build

### DIFF
--- a/core/gulpfile.js
+++ b/core/gulpfile.js
@@ -19,7 +19,6 @@ var sass      = require('gulp-ruby-sass');
 var cssWrap  = require('gulp-css-wrap');
 var template  = require('gulp-template-compile');
 var concat    = require('gulp-concat');
-var minifyCSS = require('gulp-minify-css');
 var minifyJS  = require('gulp-uglify');
 var htmlmin   = require('gulp-htmlmin');
 var htmlClass = require('html-classer-gulp');

--- a/core/package.json
+++ b/core/package.json
@@ -15,7 +15,6 @@
     "yargs" : "",
     "gulp-css-wrap": "^0.1.2",
     "gulp-ruby-sass": "^2.0.4",
-    "gulp-minify-css": "0.3.5",
     "gulp-uglify": "",
     "gulp-template-compile": "^0.2.0",
     "gulp-template": "",


### PR DESCRIPTION
Resolved #3287 by removing `gulp-minify-css` and looking into the lodash warning.

The lodash warning is caused by gulp's dependencies as discussed [here](https://github.com/gulpjs/glob-watcher/issues/23). In short, it's only resolvable by upgrading gulp, something which I'd consider outside of the scope of this issue.
