### PR TITLE
#3438. Nodejs nodePlugin doesn't work on Windows bin

### DIFF
--- a/plugin/node/src/dist/nodePlugin
+++ b/plugin/node/src/dist/nodePlugin
@@ -24,6 +24,7 @@ self_path = sys.argv.pop()
 os.chdir(os.path.dirname(self_path))
 
 if os.name == 'nt':
-    subprocess.call([bin, "app/app.js", port, "127.0.0.1"], shell=True)
+    os.chdir("app")
+    subprocess.call(["node", "app.js", port, "127.0.0.1"], shell=True)
 else:
     os.execlp("node", "node", "app/app.js", port, "127.0.0.1")


### PR DESCRIPTION
Usage of `bin` here was copy-pasted from other plugins run scripts.

Here you can see that I change folder to nested one. That is because if I execute the script from current folder it tries to run directly `node.js` file from current folder. But we need to run Node starter from the `PATH`.
So to avoid shell confusion I switched folder to `app` where there are no confusing files.
But if someone tries to run: `subprocess.call(["node", "app/app.js", port, "127.0.0.1"], shell=True)` without changing the folder and Node js will run fine, I will consider it to be my local problem and will remove `os.chdir("app")` statement.
