### PR TITLE
Tom/autocomplete

### DIFF
--- a/core/src/main/web/app/helpers/autocomplete.service.js
+++ b/core/src/main/web/app/helpers/autocomplete.service.js
@@ -18,6 +18,8 @@
   'use strict';
   angular.module('bk.core').factory('autocompleteService', function(codeMirrorExtension, bkEvaluatorManager, $q) {
 
+  var completionActive = false;
+
   var showAutocomplete = function(cm, scope) {
     var getToken = function(editor, cur) {
       return editor.getTokenAt(cur);
@@ -51,7 +53,7 @@
 
         var evaluator = bkEvaluatorManager.getEvaluator(scope.cellmodel.evaluator);
         if (_.isFunction(evaluator.showDocs)) {
-          attachAutocompleteListeners(hintData, evaluator, scope, cm);
+          attachAutocompleteListeners(hintData, evaluator, scope, cm, matched_text);
         }
 
         if (waitfor.length > 0) {
@@ -94,20 +96,81 @@
       showAutocomplete(cm, scope);
     }
   };
-  var attachAutocompleteListeners = function(hintData, evaluator, scope, cm) {
+
+  var attachAutocompleteListeners = function(hintData, evaluator, scope, cm, matched_text) {
     CodeMirror.on(hintData, 'select', function(selectedWord, selectedListItem) {
+      completionActive = true;
+
       evaluator.showDocs(selectedWord, selectedWord.length - 1, function(documentation) {
         scope.$broadcast('showDocumentationForAutocomplete', documentation, true);
+
+        if (documentation.ansiHtml) {
+          var params = getParameters(ansi_up.ansi_to_html(documentation.ansiHtml));
+          writeCompletion(selectedWord, params, cm, matched_text);
+        } else {
+          var index = selectedWord.indexOf(matched_text) + matched_text.length;
+          replaceSelection(selectedWord.substring(index), cm);
+        }
       });
     });
     CodeMirror.on(cm, 'endCompletion', function() {
+      completionActive = false;
       scope.$broadcast('hideDocumentationForAutocomplete');
     });
+    CodeMirror.on(hintData, 'pick', function(completion) {
+      // Removing duplicate completion since we already have it from when we wrote the parameters
+      var lengthToRemove = completion.length - matched_text.length;
+      var cursorPos = cm.getCursor('from');
+      cm.doc.replaceRange('', {line: cursorPos.line, ch: cursorPos.ch - lengthToRemove}, cursorPos);
+      cm.setCursor(cm.getCursor());
+    })
   };
+
+  function getParameters(documentation) {
+    // Parsing parameters from documentation
+    debugger;
+    var start = documentation.indexOf('Parameters\n');
+    if (start === -1) {
+      return [];
+    }
+    documentation = documentation.substring(start);
+    documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
+    return _.map(documentation.split(/\n(?=\S)/), function(param) {
+      var s = param.split(':');
+      return {name: s[0].trim(), description: s[1].trim()};
+    });
+  }
+
+  function writeCompletion(funcName, params, cm, matched_text) {
+    // writes the selected completion with parameters
+    var str = _.map(params, function(p) {
+      return p.name;
+    });
+    var index = funcName.indexOf(matched_text) + matched_text.length;
+
+    replaceSelection(funcName.substring(index) + '(' + str.join(', ') + ')', cm);
+  }
+
+  function replaceSelection(s, cm) {
+    // Disabling and enabling showhint event handlers that fire on every change
+    var handlers = cm._handlers.cursorActivity;
+    cm._handlers.cursorActivity = [];
+    cm.doc.replaceSelection(s, 'around');
+    cm._handlers.cursorActivity = handlers;
+  }
+
+  function backspace(cursor, cm) {
+    // If backspace is pressed while autocompletion selection is active we delete one extra character
+    if (completionActive) {
+      var from = cm.findPosH(cursor, -1, 'char', false);
+      cm.replaceRange('', from, cursor);
+    }
+  }
 
   return {
     showAutocomplete: showAutocomplete,
-    maybeShowAutocomplete: maybeShowAutocomplete
+    maybeShowAutocomplete: maybeShowAutocomplete,
+    backspace: backspace
   };
 
   });

--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -625,7 +625,7 @@
           var lineLen = cm.getLine(cursor.line).length;
           var rightLine = cm.getRange(cursor, {line: cursor.line, ch: lineLen});
           var leftLine = cm.getRange({line: cursor.line, ch: 0}, cursor);
-          if (leftLine.match(/^\s*$/)) {
+          if (leftLine.match(/^\s*$/) || leftLine.match(/\s+$/)) {
             cm.execCommand("indentMore");
           } else {
             if (rightLine.match(/^\s*$/)) {
@@ -656,6 +656,7 @@
           _.each(toKill, function(i) {
             cm.replaceRange("", i.from, i.to);
           });
+          autocompleteService.backspace(cursor, cm);
         };
 
         var keys = {

--- a/core/src/main/web/app/mainapp/components/notebook/celltooltip-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/celltooltip-directive.js
@@ -47,14 +47,12 @@
           if (html) {
             displayTooltip(html);
             var autocompleteList = $('ul.CodeMirror-hints');
-            _.defer(function() {
-              tooltip.addClass('CodeMirror-hints');
-              setTooltipPosition(_.merge(calculateTooltipPosition(), {left: autocompleteList.position().left + autocompleteList.outerWidth() - $('.bkcell').offset().left}));
+            tooltip.addClass('CodeMirror-hints');
+            setTooltipPosition(_.merge(calculateTooltipPosition(), {left: autocompleteList.position().left + autocompleteList.outerWidth() - $('.bkcell').offset().left}));
 
-              if (autocompleteListAboveCursor(autocompleteList)) {
-                moveTooltipAboveCursor();
-              }
-            });
+            if (autocompleteListAboveCursor(autocompleteList)) {
+              moveTooltipAboveCursor();
+            }
           }
         });
 

--- a/core/src/main/web/app/mainapp/components/notebook/celltooltip-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/celltooltip-directive.js
@@ -44,15 +44,14 @@
         scope.$on('showDocumentationForAutocomplete', function(event, doc) {
           tooltip.empty();
           var html = getDocContent(doc);
-          if (html) {
-            displayTooltip(html);
-            var autocompleteList = $('ul.CodeMirror-hints');
-            tooltip.addClass('CodeMirror-hints');
-            setTooltipPosition(_.merge(calculateTooltipPosition(), {left: autocompleteList.position().left + autocompleteList.outerWidth() - $('.bkcell').offset().left}));
 
-            if (autocompleteListAboveCursor(autocompleteList)) {
-              moveTooltipAboveCursor();
-            }
+          displayTooltip(doc);
+          var autocompleteList = $('ul.CodeMirror-hints');
+          tooltip.addClass('CodeMirror-hints');
+          setTooltipPosition(_.merge(calculateTooltipPosition(), {left: autocompleteList.position().left + autocompleteList.outerWidth() - $('.bkcell').offset().left}));
+
+          if (autocompleteListAboveCursor(autocompleteList)) {
+            moveTooltipAboveCursor();
           }
         });
 

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -390,6 +390,18 @@ define(function(require, exports, module) {
           });
         }
       },
+      getAutocompleteDocumentation: function(matchedWord, callback) {
+        this.showDocs(matchedWord, matchedWord.length - 1, function(docs) {
+          var documentation = {};
+          if (docs.ansiHtml) {
+            documentation.description = ansi_up.ansi_to_html(docs.ansiHtml);
+            documentation.parameters = this.getParametersFromDocumentation(documentation.description);
+            return callback(documentation);
+          }
+          documentation.description = docs;
+          return callback(documentation);
+        }.bind(this));
+      },
       showDocs: function(code, cpos, cb) {
         var kernel = kernels[this.settings.shellID];
         if (ipyVersion == '1') {
@@ -403,6 +415,19 @@ define(function(require, exports, module) {
             });
           });
         }
+      },
+      getParametersFromDocumentation: function(documentation) {
+        // Parsing parameters from documentation
+        var start = documentation.indexOf('Parameters\n');
+        if (start === -1) {
+          return [];
+        }
+        documentation = documentation.substring(start);
+        documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
+        return _.map(documentation.split(/\n(?=\S)/), function(param) {
+          var s = param.split(':');
+          return {name: s[0].trim(), description: s[1].trim()};
+        });
       },
       exit: function(cb) {
         this.cancelExecution();

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -394,7 +394,7 @@ define(function(require, exports, module) {
           var documentation = {};
           if (docs.ansiHtml) {
             documentation.description = ansi_up.ansi_to_html(docs.ansiHtml);
-            documentation.parameters = getParametersFromDocumentation(documentation.description);
+            documentation.parameters = matchedWord[0] === '%' ? void 0 : getParametersFromDocumentation(documentation.description);
             return callback(documentation);
           }
           documentation.description = docs;

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -485,14 +485,43 @@ define(function(require, exports, module) {
     // Parsing parameters from documentation
     var start = documentation.indexOf('Parameters\n');
     if (start === -1) {
-      return [];
+      var div = document.createElement('div');
+      div.innerHTML = documentation;
+      return getParametersFromSection(getDocumentationSection(div.innerText, 'Signature'));
     }
+
     documentation = documentation.substring(start);
     documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
     return _.map(documentation.split(/\n(?=\S)/), function(param) {
       var s = param.split(':');
       return {name: s[0].trim(), description: s[1].trim()};
     });
+  }
+
+  function getDocumentationSection(documentation, sectionName) {
+    var start = documentation.indexOf(sectionName);
+    if (start === -1) {
+      return '';
+    }
+    start += sectionName.length + 1;
+    stop = documentation.lastIndexOf('\n', documentation.indexOf(':', start));
+    if (stop === -1) {
+      return documentation.substr(start);
+    }
+    return documentation.substring(start, stop).trim();
+  }
+
+  function getParametersFromSection(documentationSection) {
+    if (_.isEmpty(documentationSection)) {
+      return [];
+    }
+    var paramArray = documentationSection.substring(documentationSection.indexOf('(') + 1, documentationSection.indexOf(')')).split(',');
+    return _(paramArray).filter(function(param) {
+      // filtering out *args and **kwargs parameters
+      return !_.includes(['*args', '**kwargs'], param);
+    }).map(function(param) {
+      return {name: param.trim()};
+    }).value();
   }
 
   var defaultSetup = ("%matplotlib inline\n" +

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -478,7 +478,9 @@ define(function(require, exports, module) {
     if (_.isEmpty(matchedText)) {
       return;
     }
-    callback(matches, matchedText);
+    callback(_.filter(matches, function(match) {
+      return _.startsWith(match, matchedText);
+    }), matchedText);
   }
 
   function getParametersFromDocumentation(documentation) {

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -394,7 +394,7 @@ define(function(require, exports, module) {
           var documentation = {};
           if (docs.ansiHtml) {
             documentation.description = ansi_up.ansi_to_html(docs.ansiHtml);
-            documentation.parameters = this.getParametersFromDocumentation(documentation.description);
+            documentation.parameters = getParametersFromDocumentation(documentation.description);
             return callback(documentation);
           }
           documentation.description = docs;
@@ -414,19 +414,6 @@ define(function(require, exports, module) {
             });
           });
         }
-      },
-      getParametersFromDocumentation: function(documentation) {
-        // Parsing parameters from documentation
-        var start = documentation.indexOf('Parameters\n');
-        if (start === -1) {
-          return [];
-        }
-        documentation = documentation.substring(start);
-        documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
-        return _.map(documentation.split(/\n(?=\S)/), function(param) {
-          var s = param.split(':');
-          return {name: s[0].trim(), description: s[1].trim()};
-        });
       },
       exit: function(cb) {
         this.cancelExecution();
@@ -492,6 +479,20 @@ define(function(require, exports, module) {
       return;
     }
     callback(matches, matchedText);
+  }
+
+  function getParametersFromDocumentation(documentation) {
+    // Parsing parameters from documentation
+    var start = documentation.indexOf('Parameters\n');
+    if (start === -1) {
+      return [];
+    }
+    documentation = documentation.substring(start);
+    documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
+    return _.map(documentation.split(/\n(?=\S)/), function(param) {
+      var s = param.split(':');
+      return {name: s[0].trim(), description: s[1].trim()};
+    });
   }
 
   var defaultSetup = ("%matplotlib inline\n" +

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -382,7 +382,7 @@ define(function(require, exports, module) {
           var documentation = {};
           if (docs.ansiHtml) {
             documentation.description = ansi_up.ansi_to_html(docs.ansiHtml);
-            documentation.parameters = getParametersFromDocumentation(documentation.description);
+            documentation.parameters = matchedWord[0] === '%' ? void 0 : getParametersFromDocumentation(documentation.description);
             return callback(documentation);
           }
           documentation.description = docs;

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -378,6 +378,18 @@ define(function(require, exports, module) {
           });
         }
       },
+      getAutocompleteDocumentation: function(matchedWord, callback) {
+        this.showDocs(matchedWord, matchedWord.length - 1, function(docs) {
+          var documentation = {};
+          if (docs.ansiHtml) {
+            documentation.description = ansi_up.ansi_to_html(docs.ansiHtml);
+            documentation.parameters = this.getParametersFromDocumentation(documentation.description);
+            return callback(documentation);
+          }
+          documentation.description = docs;
+          return callback(documentation);
+        }.bind(this));
+      },
       showDocs: function(code, cpos, cb) {
         var kernel = kernels[this.settings.shellID];
         if (ipyVersion == '1') {
@@ -391,6 +403,19 @@ define(function(require, exports, module) {
             });
           });
         }
+      },
+      getParametersFromDocumentation: function(documentation) {
+        // Parsing parameters from documentation
+        var start = documentation.indexOf('Parameters\n');
+        if (start === -1) {
+          return [];
+        }
+        documentation = documentation.substring(start);
+        documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
+        return _.map(documentation.split(/\n(?=\S)/), function(param) {
+          var s = param.split(':');
+          return {name: s[0].trim(), description: s[1].trim()};
+        });
       },
       exit: function(cb) {
         this.cancelExecution();

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -364,19 +364,18 @@ define(function(require, exports, module) {
       autocomplete: function(code, cpos, cb) {
         var kernel = kernels[this.settings.shellID];
         if (ipyVersion == '1') {
-          kernel.complete(code, cpos, {'complete_reply': function(reply) {
-            cb(reply.matches, reply.matched_text);
+          return kernel.complete(code, cpos, {'complete_reply': function(reply) {
+            autocompleteCallback(reply.matches, reply.matched_text, cb);
           }});
-        } else if (ipyVersion == '2')  {
-          kernel.complete(code, cpos, function(reply) {
-            cb(reply.content.matches, reply.content.matched_text);
-          });
-        } else {
-          kernel.complete(code, cpos, function(reply) {
-            cb(reply.content.matches, code.substring(reply.content.cursor_start,
-                reply.content.cursor_end));
+        }
+        if (ipyVersion == '2') {
+          return kernel.complete(code, cpos, function(reply) {
+            autocompleteCallback(reply.content.matches, reply.content.matched_text, cb);
           });
         }
+        kernel.complete(code, cpos, function(reply) {
+          autocompleteCallback(reply.content.matches, code.substring(reply.content.cursor_start, reply.content.cursor_end), cb);
+        });
       },
       getAutocompleteDocumentation: function(matchedWord, callback) {
         this.showDocs(matchedWord, matchedWord.length - 1, function(docs) {
@@ -475,6 +474,12 @@ define(function(require, exports, module) {
         setup: {type: "settableString", action: "updateShell", name: "Setup Code"}
       }
   };
+  function autocompleteCallback(matches, matchedText, callback) {
+    if (_.isEmpty(matchedText)) {
+      return;
+    }
+    callback(matches, matchedText);
+  }
   var defaultSetup = ("%matplotlib inline\n" +
       "import numpy\n" +
       "import matplotlib\n" +

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -382,7 +382,7 @@ define(function(require, exports, module) {
           var documentation = {};
           if (docs.ansiHtml) {
             documentation.description = ansi_up.ansi_to_html(docs.ansiHtml);
-            documentation.parameters = this.getParametersFromDocumentation(documentation.description);
+            documentation.parameters = getParametersFromDocumentation(documentation.description);
             return callback(documentation);
           }
           documentation.description = docs;
@@ -402,19 +402,6 @@ define(function(require, exports, module) {
             });
           });
         }
-      },
-      getParametersFromDocumentation: function(documentation) {
-        // Parsing parameters from documentation
-        var start = documentation.indexOf('Parameters\n');
-        if (start === -1) {
-          return [];
-        }
-        documentation = documentation.substring(start);
-        documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
-        return _.map(documentation.split(/\n(?=\S)/), function(param) {
-          var s = param.split(':');
-          return {name: s[0].trim(), description: s[1].trim()};
-        });
       },
       exit: function(cb) {
         this.cancelExecution();
@@ -480,6 +467,21 @@ define(function(require, exports, module) {
     }
     callback(matches, matchedText);
   }
+
+  function getParametersFromDocumentation(documentation) {
+    // Parsing parameters from documentation
+    var start = documentation.indexOf('Parameters\n');
+    if (start === -1) {
+      return [];
+    }
+    documentation = documentation.substring(start);
+    documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
+    return _.map(documentation.split(/\n(?=\S)/), function(param) {
+      var s = param.split(':');
+      return {name: s[0].trim(), description: s[1].trim()};
+    });
+  }
+
   var defaultSetup = ("%matplotlib inline\n" +
       "import numpy\n" +
       "import matplotlib\n" +

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -472,14 +472,43 @@ define(function(require, exports, module) {
     // Parsing parameters from documentation
     var start = documentation.indexOf('Parameters\n');
     if (start === -1) {
-      return [];
+      var div = document.createElement('div');
+      div.innerHTML = documentation;
+      return getParametersFromSection(getDocumentationSection(div.innerText, 'Signature'));
     }
+
     documentation = documentation.substring(start);
     documentation = documentation.substring(documentation.indexOf('-\n') + 2, documentation.indexOf('\n\n'));
     return _.map(documentation.split(/\n(?=\S)/), function(param) {
       var s = param.split(':');
       return {name: s[0].trim(), description: s[1].trim()};
     });
+  }
+
+  function getDocumentationSection(documentation, sectionName) {
+    var start = documentation.indexOf(sectionName);
+    if (start === -1) {
+      return '';
+    }
+    start += sectionName.length + 1;
+    stop = documentation.lastIndexOf('\n', documentation.indexOf(':', start));
+    if (stop === -1) {
+      return documentation.substr(start);
+    }
+    return documentation.substring(start, stop).trim();
+  }
+
+  function getParametersFromSection(documentationSection) {
+    if (_.isEmpty(documentationSection)) {
+      return [];
+    }
+    var paramArray = documentationSection.substring(documentationSection.indexOf('(') + 1, documentationSection.indexOf(')')).split(',');
+    return _(paramArray).filter(function(param) {
+      // filtering out *args and **kwargs parameters
+      return !_.includes(['*args', '**kwargs'], param);
+    }).map(function(param) {
+      return {name: param.trim()};
+    }).value();
   }
 
   var defaultSetup = ("%matplotlib inline\n" +

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -465,7 +465,9 @@ define(function(require, exports, module) {
     if (_.isEmpty(matchedText)) {
       return;
     }
-    callback(matches, matchedText);
+    callback(_.filter(matches, function(match) {
+      return _.startsWith(match, matchedText);
+    }), matchedText);
   }
 
   function getParametersFromDocumentation(documentation) {


### PR DESCRIPTION
Standardized interface for autcomplete documentation. Autocomplete expects language plugins to implement getAutocompleteDocumentation(selectedWord) which returns an object with the following structure:

```
{
  description: "documentation on the selected function",
  parameters: [{
    name: 'parameterOne',
    description: "Type and description of parameter one"
  },{
    name: "parameterTwo",
    description: "Type and description of parameter two"
  }]
}
```

Also implemented the completion of iPython and Python3 function calls with parameters.
