### PR TITLE
error from setShellOptions not well handled #3437

### DIFF
--- a/plugin/clojure/src/main/java/com/twosigma/beaker/clojure/rest/ClojureShellRest.java
+++ b/plugin/clojure/src/main/java/com/twosigma/beaker/clojure/rest/ClojureShellRest.java
@@ -38,7 +38,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("clojuresh")
 @Produces(MediaType.APPLICATION_JSON)
@@ -147,7 +149,14 @@ public class ClojureShellRest {
     if(!this.shells.containsKey(shellId)) {
       return;
     }
-    this.shells.get(shellId).setShellOptions(classPath, imports, outDir, requirements);
+    try {
+      this.shells.get(shellId).setShellOptions(classPath, imports, outDir, requirements);
+    } catch (Throwable x) {
+      throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                                                .entity(x.getMessage())
+                                                .type(MediaType.TEXT_PLAIN)
+                                                .build());
+    }
   }
 
   @POST

--- a/plugin/cpp/src/main/java/com/twosigma/beaker/cpp/rest/CppShellRest.java
+++ b/plugin/cpp/src/main/java/com/twosigma/beaker/cpp/rest/CppShellRest.java
@@ -22,7 +22,6 @@ import com.twosigma.beaker.cpp.utils.CppEvaluator;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -31,7 +30,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("cpp")
 @Produces(MediaType.APPLICATION_JSON)
@@ -147,7 +148,14 @@ public class CppShellRest {
     if(!this.shells.containsKey(shellId)) {
       return;
     }
-    this.shells.get(shellId).setShellOptions(flags);
+    try {
+      this.shells.get(shellId).setShellOptions(flags);
+    } catch (Throwable x) {
+      throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                                                .entity(x.getMessage())
+                                                .type(MediaType.TEXT_PLAIN)
+                                                .build());
+    }
   }
 
 }

--- a/plugin/groovy/src/main/java/com/twosigma/beaker/groovy/rest/GroovyShellRest.java
+++ b/plugin/groovy/src/main/java/com/twosigma/beaker/groovy/rest/GroovyShellRest.java
@@ -29,7 +29,9 @@ import javax.ws.rs.POST;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("groovysh")
 @Produces(MediaType.APPLICATION_JSON)
@@ -145,7 +147,14 @@ public class GroovyShellRest {
 	  if(!this.shells.containsKey(shellId)) {
 		  return;
 	  }
-	  this.shells.get(shellId).setShellOptions(classPath, imports, outDir);
+    try {
+      this.shells.get(shellId).setShellOptions(classPath, imports, outDir);
+    } catch (Throwable x) {
+      throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                                                .entity(x.getMessage())
+                                                .type(MediaType.TEXT_PLAIN)
+                                                .build());
+    }
   }
 
 }

--- a/plugin/javash/src/main/java/com/twosigma/beaker/javash/rest/JavashShellRest.java
+++ b/plugin/javash/src/main/java/com/twosigma/beaker/javash/rest/JavashShellRest.java
@@ -31,7 +31,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("javash")
 @Produces(MediaType.APPLICATION_JSON)
@@ -148,7 +150,14 @@ public class JavashShellRest {
     if(!this.shells.containsKey(shellId)) {
       return;
     }
-    this.shells.get(shellId).setShellOptions(classPath, imports, outDir);
+    try {
+      this.shells.get(shellId).setShellOptions(classPath, imports, outDir);
+    } catch (Throwable x) {
+      throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                                                .entity(x.getMessage())
+                                                .type(MediaType.TEXT_PLAIN)
+                                                .build());
+    }
   }
 
 }

--- a/plugin/scala/src/main/scala/com/twosigma/beaker/scala/rest/ScalaShellRest.java
+++ b/plugin/scala/src/main/scala/com/twosigma/beaker/scala/rest/ScalaShellRest.java
@@ -34,7 +34,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("scalash")
 @Produces(MediaType.APPLICATION_JSON)
@@ -159,7 +161,14 @@ public class ScalaShellRest {
     if(!this.shells.containsKey(shellId)) {
       return;
     }
-    this.shells.get(shellId).setShellOptions(classPath, imports, outDir);
+    try {
+      this.shells.get(shellId).setShellOptions(classPath, imports, outDir);
+    } catch (Throwable x) {
+      throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                                                .entity(x.getMessage())
+                                                .type(MediaType.TEXT_PLAIN)
+                                                .build());
+    }
   }
 
 }

--- a/plugin/sqlsh/src/main/java/com/twosigma/beaker/sqlsh/rest/SQLShellRest.java
+++ b/plugin/sqlsh/src/main/java/com/twosigma/beaker/sqlsh/rest/SQLShellRest.java
@@ -30,7 +30,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("sqlsh")
 @Produces(MediaType.APPLICATION_JSON)
@@ -146,7 +148,14 @@ public class SQLShellRest {
         if (!this.shells.containsKey(shellId)) {
             return;
         }
-        this.shells.get(shellId).setShellOptions(classPath, defaultDatasource, datasorces);
+        try {
+            this.shells.get(shellId).setShellOptions(classPath, defaultDatasource, datasorces);
+        } catch (Throwable x) {
+            throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
+                                                      .entity(x.getMessage())
+                                                      .type(MediaType.TEXT_PLAIN)
+                                                      .build());
+        }
     }
 
 }


### PR DESCRIPTION
I have done error's handling for all plugins (groovy, java, cpp, closure, scala, sql)

   try {
        //set shell option code
      } catch (Throwable x) {
        throw new WebApplicationException(Response.status(Response.Status.BAD_REQUEST)
                                                  .entity(x.getMessage())
                                                  .type(MediaType.TEXT_PLAIN)
                                                  .build());
      }

This is error's handling on a frontend

![image](https://cloud.githubusercontent.com/assets/13516511/12910031/e7d11ae0-cf17-11e5-882d-4d6527ed3fd4.png)
