### PR TITLE
Tom/2831 - Improving autocomplete

### DIFF
--- a/core/src/main/web/app/app.scss
+++ b/core/src/main/web/app/app.scss
@@ -313,7 +313,7 @@ background-color: rgb(205, 223, 214);
   white-space: pre-wrap;
   max-height: 20em;
   overflow-y: auto;
-  max-width: 40em;
+  max-width: 50em;
   position: absolute;
   z-index: 10;
   -webkit-box-shadow: 2px 3px 5px rgba(0,0,0,.2);

--- a/core/src/main/web/app/helpers/autocomplete-parameters.service.js
+++ b/core/src/main/web/app/helpers/autocomplete-parameters.service.js
@@ -41,7 +41,7 @@
       }).map(function(p) {
         var start = _.merge({}, from, {ch: from.ch + p[0]});
         var end = _.merge({}, from, {ch: from.ch + p[1] + 1});
-        return cm.markText(start, end, {className: 'marked-parameter', clearWhenEmpty: false, inclusiveLeft: true, inclusiveRight: true});
+        return cm.markText(start, end, {className: 'marked-argument', clearWhenEmpty: false, inclusiveLeft: true, inclusiveRight: true});
       }).value();
     }
 
@@ -59,22 +59,42 @@
       selectNextParameter();
     }
 
+    function previousParameter() {
+      if (_.isEmpty(completedParams)) {
+        return endParameterCompletion();
+      }
+
+      if (! _.isUndefined(currentParam)) {
+        currentParam.argument = args[completedParams.length].find();
+        params.unshift(currentParam);
+      }
+
+      currentParam = completedParams.pop();
+      selectPreviousParameter();
+    }
+
     function isActive() {
       return !(_.isEmpty(params) && _.isEmpty(completedParams));
     }
 
     function endParameterCompletion() {
-      console.log(args);
-      cm.setCursor(_.last(args).find().to);
+      var lastArg = _.last(args).find();
+      cm.setCursor(_.merge({}, lastArg.to, {ch: lastArg.to.ch + 1}));
       clearMarks()
       cm = void 0;
       currentParam = void 0;
       scope = void 0;
       completedParams = [];
+      params = [];
       args = [];
     }
 
     function selectNextParameter() {
+      var arg = args[completedParams.length].find();
+      cm.setSelection(arg.from, arg.to);
+    }
+
+    function selectPreviousParameter() {
       var arg = args[completedParams.length].find();
       cm.setSelection(arg.from, arg.to);
     }
@@ -88,7 +108,9 @@
     return {
       startParameterCompletion: startParameterCompletion,
       isActive: isActive,
-      nextParameter: nextParameter
+      nextParameter: nextParameter,
+      previousParameter: previousParameter,
+      endCompletion: endParameterCompletion
     };
 
   });

--- a/core/src/main/web/app/helpers/autocomplete-parameters.service.js
+++ b/core/src/main/web/app/helpers/autocomplete-parameters.service.js
@@ -57,6 +57,7 @@
 
       currentParam = params.shift();
       selectNextParameter();
+      showParameterDocumentation(currentParam);
     }
 
     function previousParameter() {
@@ -71,6 +72,7 @@
 
       currentParam = completedParams.pop();
       selectPreviousParameter();
+      showParameterDocumentation(currentParam);
     }
 
     function isActive() {
@@ -78,6 +80,7 @@
     }
 
     function endParameterCompletion() {
+      hideParameterDocumentation();
       var lastArg = _.last(args).find();
       cm.setCursor(_.merge({}, lastArg.to, {ch: lastArg.to.ch + 1}));
       clearMarks()
@@ -103,6 +106,14 @@
       _.forEach(args, function(arg) {
         arg.clear();
       });
+    }
+
+    function showParameterDocumentation(param) {
+      scope.$broadcast('showParameterDocumentation', param.description);
+    }
+
+    function hideParameterDocumentation() {
+      scope.$broadcast('hideParameterDocumentation');
     }
 
     return {

--- a/core/src/main/web/app/helpers/autocomplete-parameters.service.js
+++ b/core/src/main/web/app/helpers/autocomplete-parameters.service.js
@@ -171,7 +171,8 @@
       isActive: isActive,
       nextParameter: nextParameter,
       previousParameter: previousParameter,
-      endCompletion: endCompletionAndMoveCursor
+      endCompletion: endCompletion,
+      endCompletionAndMoveCursor: endCompletionAndMoveCursor
     };
 
   });

--- a/core/src/main/web/app/helpers/autocomplete-parameters.service.js
+++ b/core/src/main/web/app/helpers/autocomplete-parameters.service.js
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2014 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+(function() {
+  'use strict';
+  angular.module('bk.core').factory('autocompleteParametersService', function() {
+
+    var params = [];
+    var completedParams = [];
+    var cm;
+    var scope;
+    var currentParam;
+    var args = [];
+
+    function startParameterCompletion(codeMirror, documentation, selectionStart, selectionEnd, $scope) {
+      cm = codeMirror;
+      params = documentation.parameters;
+      scope = $scope;
+      markParameters(selectionStart, selectionEnd);
+      nextParameter();
+    }
+
+    function markParameters(from, to) {
+      var paramsString = cm.getRange(from, to);
+      args = _(params).map(function(p) {
+        var position = paramsString.indexOf(p.name);
+        return [position, position + p.name.length - 1];
+      }).map(function(p) {
+        var start = _.merge({}, from, {ch: from.ch + p[0]});
+        var end = _.merge({}, from, {ch: from.ch + p[1] + 1});
+        return cm.markText(start, end, {className: 'marked-parameter', clearWhenEmpty: false, inclusiveLeft: true, inclusiveRight: true});
+      }).value();
+    }
+
+    function nextParameter() {
+      if (_.isEmpty(params)) {
+        return endParameterCompletion();
+      }
+
+      if (! _.isUndefined(currentParam)) {
+        currentParam.argument = args[completedParams.length].find();
+        completedParams.push(currentParam);
+      }
+
+      currentParam = params.shift();
+      selectNextParameter();
+    }
+
+    function isActive() {
+      return !(_.isEmpty(params) && _.isEmpty(completedParams));
+    }
+
+    function endParameterCompletion() {
+      console.log(args);
+      cm.setCursor(_.last(args).find().to);
+      clearMarks()
+      cm = void 0;
+      currentParam = void 0;
+      scope = void 0;
+      completedParams = [];
+      args = [];
+    }
+
+    function selectNextParameter() {
+      var arg = args[completedParams.length].find();
+      cm.setSelection(arg.from, arg.to);
+    }
+
+    function clearMarks() {
+      _.forEach(args, function(arg) {
+        arg.clear();
+      });
+    }
+
+    return {
+      startParameterCompletion: startParameterCompletion,
+      isActive: isActive,
+      nextParameter: nextParameter
+    };
+
+  });
+})();

--- a/core/src/main/web/app/helpers/autocomplete-parameters.service.js
+++ b/core/src/main/web/app/helpers/autocomplete-parameters.service.js
@@ -94,18 +94,11 @@
     }
 
     function nextParameter() {
-      if (currentParam === params.length - 1) {
-        return endCompletionAndMoveCursor();
-      }
-      toParam(_.isUndefined(currentParam) ? 0 : currentParam + 1);
+      toParam(_.isUndefined(currentParam) || currentParam === params.length - 1? 0 : currentParam + 1);
     }
 
     function previousParameter() {
-      if (currentParam === 0) {
-        return endCompletionAndMoveCursor();
-      }
-
-      toParam(_.isUndefined(currentParam) ? params.length - 1 : currentParam - 1);
+      toParam(_.isUndefined(currentParam) || currentParam === 0 ? params.length - 1 : currentParam - 1);
     }
 
     function toParam(index) {

--- a/core/src/main/web/app/helpers/autocomplete.service.js
+++ b/core/src/main/web/app/helpers/autocomplete.service.js
@@ -16,11 +16,16 @@
 
 (function() {
   'use strict';
-  angular.module('bk.core').factory('autocompleteService', function(codeMirrorExtension, bkEvaluatorManager, $q) {
+  angular.module('bk.core').factory('autocompleteService', function(codeMirrorExtension, autocompleteParametersService, bkEvaluatorManager, $q) {
 
   var completionActive = false;
+  var currentDocumentation = {};
 
   var showAutocomplete = function(cm, scope) {
+    if (autocompleteParametersService.isActive()) {
+      autocompleteParametersService.nextParameter();
+    }
+
     var getToken = function(editor, cur) {
       return editor.getTokenAt(cur);
     };
@@ -100,7 +105,7 @@
   var attachAutocompleteListeners = function(hintData, evaluator, scope, cm, matchedText) {
     CodeMirror.on(hintData, 'select', onSelect.bind(null, evaluator, scope, cm, matchedText));
     CodeMirror.on(cm, 'endCompletion', onEndCompletion.bind(null, scope));
-    CodeMirror.on(hintData, 'pick', onPick.bind(null, cm, matchedText));
+    CodeMirror.on(hintData, 'pick', onPick.bind(null, cm, matchedText, scope));
   };
 
   function writeCompletion(funcName, params, cm, matchedText) {
@@ -131,11 +136,13 @@
 
   function onSelect(evaluator, scope, cm, matchedText, selectedWord, selectedListItem) {
     completionActive = true;
+    currentDocumentation = {};
 
     evaluator.getAutocompleteDocumentation(selectedWord, function(documentation) {
       scope.$broadcast('showDocumentationForAutocomplete', documentation.description, true);
 
       if (documentation.parameters) {
+        currentDocumentation = documentation;
         writeCompletion(selectedWord, documentation.parameters, cm, matchedText);
       } else {
         var index = selectedWord.indexOf(matchedText) + matchedText.length;
@@ -144,12 +151,17 @@
     });
   }
 
-  function onPick(cm, matchedText, completion) {
+  function onPick(cm, matchedText, scope, completion) {
     // Removing duplicate completion since we already have it from when we wrote the parameters
     var lengthToRemove = completion.length - matchedText.length;
-    var cursorPos = cm.getCursor('from');
-    cm.doc.replaceRange('', {line: cursorPos.line, ch: cursorPos.ch - lengthToRemove}, cursorPos);
+    var cursorPosBegin = cm.getCursor('from');
+    var cursorPosEnd = cm.getCursor('to');
+    cm.doc.replaceRange('', {line: cursorPosBegin.line, ch: cursorPosBegin.ch - lengthToRemove}, cursorPosBegin);
     cm.setCursor(cm.getCursor());
+    if (_.isEmpty(currentDocumentation) || _.isEmpty(currentDocumentation.parameters)) {
+      return;
+    }
+    autocompleteParametersService.startParameterCompletion(cm, currentDocumentation, cursorPosBegin, cursorPosEnd, scope);
   }
 
   function onEndCompletion(scope) {

--- a/core/src/main/web/app/helpers/autocomplete.service.js
+++ b/core/src/main/web/app/helpers/autocomplete.service.js
@@ -161,7 +161,9 @@
     if (_.isEmpty(currentDocumentation) || _.isEmpty(currentDocumentation.parameters)) {
       return;
     }
-    autocompleteParametersService.startParameterCompletion(cm, currentDocumentation, cursorPosBegin, cursorPosEnd, scope);
+    _.defer(function() {
+      autocompleteParametersService.startParameterCompletion(cm, currentDocumentation, cursorPosBegin, cursorPosEnd, scope);
+    });
   }
 
   function onEndCompletion(scope) {

--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -645,7 +645,7 @@
 
         var enter = function(cm) {
           if (autocompleteParametersService.isActive()) {
-            return autocompleteParametersService.endCompletion();
+            return autocompleteParametersService.endCompletionAndMoveCursor();
           }
           cm.execCommand("newlineAndIndent");
         }

--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -589,6 +589,9 @@
         };
 
         var shiftTab = function(cm) {
+          if (autocompleteParametersService.isActive()) {
+            return autocompleteParametersService.previousParameter();
+          }
           var cursor = cm.getCursor();
           var leftLine = cm.getRange({line: cursor.line, ch: 0}, cursor);
           if (leftLine.match(/^\s*$/)) {
@@ -640,6 +643,13 @@
           }
         };
 
+        var enter = function(cm) {
+          if (autocompleteParametersService.isActive()) {
+            return autocompleteParametersService.endCompletion();
+          }
+          cm.execCommand("newlineAndIndent");
+        }
+
         var backspace = function(cm) {
           var cursor, anchor,
               toKill = [],
@@ -672,6 +682,7 @@
             "Alt-J": moveFocusDown,
             "Alt-Up": moveFocusUp,
             "Alt-K": moveFocusUp,
+            "Enter": enter,
             "Ctrl-Enter": evaluate,
             "Cmd-Enter": evaluate,
             "Shift-Enter": evaluateAndGoDown,

--- a/core/src/main/web/app/helpers/core.js
+++ b/core/src/main/web/app/helpers/core.js
@@ -52,6 +52,7 @@
       modalDialogOp,
       Upload,
       autocompleteService,
+      autocompleteParametersService,
       codeMirrorExtension,
       GLOBALS) {
 
@@ -621,6 +622,9 @@
         };
 
         var tab = function(cm) {
+          if (autocompleteParametersService.isActive()) {
+            return autocompleteParametersService.nextParameter();
+          }
           var cursor = cm.getCursor();
           var lineLen = cm.getLine(cursor.line).length;
           var rightLine = cm.getRange(cursor, {line: cursor.line, ch: lineLen});

--- a/core/src/main/web/app/mainapp/components/notebook/celltooltip-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/celltooltip-directive.js
@@ -60,6 +60,17 @@
           tooltip.removeClass('CodeMirror-hints');
         });
 
+        scope.$on('showParameterDocumentation', function(event, doc) {
+          tooltip.empty();
+          unbindEvents();
+          displayTooltip(doc);
+          setTooltipPosition(calculateTooltipPosition());
+        });
+
+        scope.$on('hideParameterDocumentation', function() {
+          hideTooltip();
+        });
+
         function getDocContent(doc) {
           if (doc.ansiHtml) {
             return ansi_up.ansi_to_html(doc.ansiHtml, {use_classes: true});

--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -47,7 +47,8 @@
       bkPublicationHelper,
       GLOBALS,
       $rootScope,
-      $timeout) {
+      $timeout,
+      autocompleteParametersService) {
 
     var notebookCellOp = bkSessionManager.getNotebookCellOp();
     var getBkNotebookWidget = function() {
@@ -358,6 +359,9 @@
         var codeMirrorOptions = bkCoreManager.codeMirrorOptions(scope, notebookCellOp);
         _.extend(codeMirrorOptions.extraKeys, {
           'Esc' : function(cm) {
+            if (autocompleteParametersService.isActive()) {
+              return autocompleteParametersService.endCompletion();
+            }
             cm.execCommand('singleSelection');
             if (cm.state.vim && cm.state.vim.insertMode) {
               return;

--- a/core/src/main/web/app/styles/theme/ambiance.scss
+++ b/core/src/main/web/app/styles/theme/ambiance.scss
@@ -74,7 +74,10 @@ $markdown-heading-color: #aac6e3;
 $scrollbar-width: 8px; // default size scrollbar looks ugly in this theme
 $text-cursor: url('../images/ambiance/ambiance-i-beam.png') 5 9, text;
 
-$marked-argument-border: inset 0 0 5px #0f0;
+$marked-argument-unchanged-border: inset 0 0 5px #158d76;
+$marked-argument-unchanged-color: #1c96be;
+
+$marked-argument-changed-border: inset 0 0 5px #285d95;
 
 @import "base-theme";
 

--- a/core/src/main/web/app/styles/theme/ambiance.scss
+++ b/core/src/main/web/app/styles/theme/ambiance.scss
@@ -74,6 +74,8 @@ $markdown-heading-color: #aac6e3;
 $scrollbar-width: 8px; // default size scrollbar looks ugly in this theme
 $text-cursor: url('../images/ambiance/ambiance-i-beam.png') 5 9, text;
 
+$marked-argument-border: inset 0 0 5px #0f0;
+
 @import "base-theme";
 
 .beaker-theme-ambiance { @extend .base-theme; }

--- a/core/src/main/web/app/styles/theme/base-theme.scss
+++ b/core/src/main/web/app/styles/theme/base-theme.scss
@@ -682,3 +682,7 @@
     color: $markdown-heading-color;
   }
 }
+
+.marked-argument {
+  box-shadow: $marked-argument-border;
+}

--- a/core/src/main/web/app/styles/theme/base-theme.scss
+++ b/core/src/main/web/app/styles/theme/base-theme.scss
@@ -681,8 +681,15 @@
   .cm-header {
     color: $markdown-heading-color;
   }
+
+  .marked-argument-unchanged {
+    box-shadow: $marked-argument-unchanged-border;
+    color: $marked-argument-unchanged-color;
+    font-style: italic;
+  }
+
+  .marked-argument-changed {
+    box-shadow: $marked-argument-changed-border;
+  }
 }
 
-.marked-argument {
-  box-shadow: $marked-argument-border;
-}

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -17,7 +17,11 @@
 /* Our typeface makes vertical alignment... well, not so good,
 so let's help it along a little bit by adjusting padding. */
 
-$marked-argument-border: inset 0 0 5px #7f7f7f;
+
+$marked-argument-unchanged-border: inset 0 0 5px #285d95;
+$marked-argument-unchanged-color: #a1a1a1;
+
+$marked-argument-changed-border: inset 0 0 5px #7f7f7f;
 
 .btn-xs {
   padding-top: $padding-xs-vertical + 1;
@@ -120,7 +124,13 @@ ul {
   margin-right: 12.5px;
 }
 
-.marked-argument {
-  box-shadow: $marked-argument-border;
+.marked-argument-unchanged {
+  box-shadow: $marked-argument-unchanged-border;
+  color: $marked-argument-unchanged-color;
+  font-style: italic;
+}
+
+.marked-argument-changed {
+  box-shadow: $marked-argument-changed-border;
 }
 

--- a/core/src/main/web/app/styles/ui.scss
+++ b/core/src/main/web/app/styles/ui.scss
@@ -16,6 +16,9 @@
 
 /* Our typeface makes vertical alignment... well, not so good,
 so let's help it along a little bit by adjusting padding. */
+
+$marked-argument-border: inset 0 0 5px #7f7f7f;
+
 .btn-xs {
   padding-top: $padding-xs-vertical + 1;
   padding-bottom: $padding-xs-vertical - 1;
@@ -116,3 +119,8 @@ ul {
   margin-left: 1.5px;
   margin-right: 12.5px;
 }
+
+.marked-argument {
+  box-shadow: $marked-argument-border;
+}
+

--- a/core/src/main/web/app/template/index_template.html
+++ b/core/src/main/web/app/template/index_template.html
@@ -130,6 +130,7 @@
   <script src="app/helpers/core.js"></script>
   <script src="app/helpers/code-mirror-extension.service.js"></script>
   <script src="app/helpers/autocomplete.service.js"></script>
+  <script src="app/helpers/autocomplete-parameters.service.js"></script>
   <script src="app/helpers/debug.js"></script>
   <script src="app/helpers/evaluatepluginmanager.js"></script>
   <script src="app/helpers/helper.js"></script>

--- a/plugin/ipythonPlugins/src/dist/ipython/ipython.js
+++ b/plugin/ipythonPlugins/src/dist/ipython/ipython.js
@@ -520,7 +520,7 @@ define(function(require, exports, module) {
     var paramArray = documentationSection.substring(documentationSection.indexOf('(') + 1, documentationSection.indexOf(')')).split(',');
     return _(paramArray).filter(function(param) {
       // filtering out *args and **kwargs parameters
-      return !_.includes(['*args', '**kwargs'], param);
+      return !_.includes(['*args', '**kwargs'], param.trim());
     }).map(function(param) {
       return {name: param.trim()};
     }).value();

--- a/plugin/ipythonPlugins/src/dist/python3/python3.js
+++ b/plugin/ipythonPlugins/src/dist/python3/python3.js
@@ -507,7 +507,7 @@ define(function(require, exports, module) {
     var paramArray = documentationSection.substring(documentationSection.indexOf('(') + 1, documentationSection.indexOf(')')).split(',');
     return _(paramArray).filter(function(param) {
       // filtering out *args and **kwargs parameters
-      return !_.includes(['*args', '**kwargs'], param);
+      return !_.includes(['*args', '**kwargs'], param.trim());
     }).map(function(param) {
       return {name: param.trim()};
     }).value();


### PR DESCRIPTION
This improves autocomplete for Ipython/Python3 and provides interface for other language plugins to do the same.

Pressing Tab or Ctrl+Space starts autocompletion. Once the user selects the completion, argument completion starts.
Switch between arguments using Tab to go forward or Shift + Tab to go back. Switching is cyclical so the way to end completion is by pressing Enter or Escape. Or simply move the cursor outside of function call range.

Also added some UI tips during completion, such as, borders around arguments, italics and color change for unfilled arguments vs filled.
