### PR TITLE
#3502. running cell before evaluator is ready

### DIFF
--- a/core/src/main/web/app/mainapp/services/evaluatormanager.js
+++ b/core/src/main/web/app/mainapp/services/evaluatormanager.js
@@ -86,9 +86,11 @@
           deferred.resolve(evaluators[evaluatorId]);
         } else {
           var i;
-          for ( i = 0; i < loadingInProgressEvaluators.length; i ++ ) {
-            if (loadingInProgressEvaluators[i].name === evaluatorId) {
-              loadingInProgressEvaluators[i].deferred = deferred;
+          for (i = 0; i < loadingInProgressEvaluators.length; i++) {
+            var loadingEvaluator = loadingInProgressEvaluators[i];
+            if (loadingEvaluator.name === evaluatorId
+                || (_.isEmpty(loadingEvaluator.name) && loadingEvaluator.plugin === evaluatorId)) {
+              loadingEvaluator.deferred = deferred;
               break;
             }
           }


### PR DESCRIPTION
Cause: when I add evaluator by click in Language Manager, evaluator object has empty `name` field. And when evaluator is ready and it's time to execute waiting cell, manager can't find evaluator by name.

P.S. The same scenario is fine in Tutorials, because all evaluators are loaded from .bkr file and there `name` field contains evaluator name.

Solution: if `name` field is empty, then compare with `plugin` field which contains actual evalutorId.
