### PR TITLE
Tom/849 - Added checkboxes and radio buttons to evaluator spec

### DIFF
--- a/core/src/main/web/app/helpers/globals.js
+++ b/core/src/main/web/app/helpers/globals.js
@@ -39,6 +39,12 @@
         HTTP: "http",
         AJAX: "ajax"
       },
+      EVALUATOR_SPEC: {
+        PROPERTIES: {
+          STRING: "settableString"
+        },
+        ACTION: "action"
+      },
       THEMES: {
         DEFAULT: 'default',
         AMBIANCE: 'ambiance'

--- a/core/src/main/web/app/helpers/globals.js
+++ b/core/src/main/web/app/helpers/globals.js
@@ -41,7 +41,8 @@
       },
       EVALUATOR_SPEC: {
         PROPERTIES: {
-          STRING: "settableString"
+          STRING: "settableString",
+          BOOLEAN: "settableBoolean"
         },
         ACTION: "action"
       },

--- a/core/src/main/web/app/helpers/globals.js
+++ b/core/src/main/web/app/helpers/globals.js
@@ -42,7 +42,8 @@
       EVALUATOR_SPEC: {
         PROPERTIES: {
           STRING: "settableString",
-          BOOLEAN: "settableBoolean"
+          BOOLEAN: "settableBoolean",
+          ENUM: "settableEnum"
         },
         ACTION: "action"
       },

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager_evaluator_settings.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager_evaluator_settings.jst.html
@@ -20,13 +20,13 @@
   <textarea ng-if="property.type === availableProperties.STRING" ng-class="{'edited-property': property.edited && highlight}" class="form-control" ng-model="evaluator.settings[property.key]"></textarea>
   <button ng-if="property.type === availableProperties.STRING" class="btn btn-default pull-right set" ng-click="set(property)">Set</button>
 
-  <input class="afterCheckbox hidden" id="{{property.name}}-checkbox" ng-if="property.type === availableProperties.BOOLEAN" type="checkbox" ng-model="evaluator.settings[property.key]"/>
+  <input class="afterCheckbox hidden" id="{{property.name}}-checkbox" ng-if="property.type === availableProperties.BOOLEAN" type="checkbox" ng-model="evaluator.settings[property.key]" ng-change="set(property)"/>
   <label ng-if="property.type === availableProperties.BOOLEAN" for="{{property.name}}-checkbox">{{property.name}}</label>
 
   <label ng-if="property.type === availableProperties.ENUM">{{ property.name }}</label>
   <div>
     <!-- We need to generalize ambiance radio button that is specialized only for EasyForm and use it here -->
-    <input style="visibility: visible;" ng-if="property.type === availableProperties.ENUM" ng-repeat-start="value in property.values" id="{{property.name}}-{{value}}-radio" name="{{property.name}}" value="{{value}}" type="radio" ng-model="evaluator.settings[property.key]" />
+    <input style="visibility: visible;" ng-if="property.type === availableProperties.ENUM" ng-repeat-start="value in property.values" id="{{property.name}}-{{value}}-radio" name="{{property.name}}" value="{{value}}" type="radio" ng-model="evaluator.settings[property.key]" ng-change="set(property)" />
     <label ng-if="property.type === availableProperties.ENUM" ng-repeat-end for="{{property.name}}-{{value}}-radio">{{value}}</label>
   </div>
 

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager_evaluator_settings.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager_evaluator_settings.jst.html
@@ -15,9 +15,14 @@
 -->
 
 <div ng-repeat="property in properties" class="form-group language-option property clearfix">
-  <label>{{ property.name }}</label>
-  <textarea ng-class="{'edited-property': property.edited && highlight}" class="form-control" ng-model="evaluator.settings[property.key]"></textarea>
-  <button class="btn btn-default pull-right set" ng-click="set(property)">Set</button>
+  
+  <label ng-if="property.type === availableProperties.STRING">{{ property.name }} - {{property.type}}</label>
+  <textarea ng-if="property.type === availableProperties.STRING" ng-class="{'edited-property': property.edited && highlight}" class="form-control" ng-model="evaluator.settings[property.key]"></textarea>
+  <button ng-if="property.type === availableProperties.STRING" class="btn btn-default pull-right set" ng-click="set(property)">Set</button>
+
+  <input class="afterCheckbox hidden" id="{{property.name}}-checkbox" ng-if="property.type === availableProperties.BOOLEAN" type="checkbox" ng-model="evaluator.settings[property.key]" ng-change="set(property)"/>
+  <label ng-if="property.type === availableProperties.BOOLEAN" for="{{property.name}}-checkbox">{{property.name}}</label>
+
 </div>
 <div ng-repeat="action in actions" class="action language-option clearfix">
   <button class="btn btn-default" ng-click="evaluator.perform(action.key)">{{ action.name }}</button>

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager_evaluator_settings.jst.html
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanager_evaluator_settings.jst.html
@@ -16,12 +16,19 @@
 
 <div ng-repeat="property in properties" class="form-group language-option property clearfix">
   
-  <label ng-if="property.type === availableProperties.STRING">{{ property.name }} - {{property.type}}</label>
+  <label ng-if="property.type === availableProperties.STRING">{{ property.name }}</label>
   <textarea ng-if="property.type === availableProperties.STRING" ng-class="{'edited-property': property.edited && highlight}" class="form-control" ng-model="evaluator.settings[property.key]"></textarea>
   <button ng-if="property.type === availableProperties.STRING" class="btn btn-default pull-right set" ng-click="set(property)">Set</button>
 
-  <input class="afterCheckbox hidden" id="{{property.name}}-checkbox" ng-if="property.type === availableProperties.BOOLEAN" type="checkbox" ng-model="evaluator.settings[property.key]" ng-change="set(property)"/>
+  <input class="afterCheckbox hidden" id="{{property.name}}-checkbox" ng-if="property.type === availableProperties.BOOLEAN" type="checkbox" ng-model="evaluator.settings[property.key]"/>
   <label ng-if="property.type === availableProperties.BOOLEAN" for="{{property.name}}-checkbox">{{property.name}}</label>
+
+  <label ng-if="property.type === availableProperties.ENUM">{{ property.name }}</label>
+  <div>
+    <!-- We need to generalize ambiance radio button that is specialized only for EasyForm and use it here -->
+    <input style="visibility: visible;" ng-if="property.type === availableProperties.ENUM" ng-repeat-start="value in property.values" id="{{property.name}}-{{value}}-radio" name="{{property.name}}" value="{{value}}" type="radio" ng-model="evaluator.settings[property.key]" />
+    <label ng-if="property.type === availableProperties.ENUM" ng-repeat-end for="{{property.name}}-{{value}}-radio">{{value}}</label>
+  </div>
 
 </div>
 <div ng-repeat="action in actions" class="action language-option clearfix">

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
@@ -41,7 +41,9 @@
         });
 
         $scope.set = function(property) {
-          $scope.evaluator.perform(property.key);
+          if (property.action) {
+            $scope.evaluator.perform(property.key);
+          }
           bkSessionManager.setNotebookModelEdited(true);
           property.edited = false;
           var noMoreUnsavedProperties = true;

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
@@ -69,7 +69,9 @@
         });
 
         scope.properties = _.filter(spec, function(option) {
-          return option.type === "settableString";
+          return _(GLOBALS.EVALUATOR_SPEC.PROPERTIES)
+            .values()
+            .contains(option.type);
         });
 
         var getEditedListener = function (property) {

--- a/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
+++ b/core/src/main/web/app/mainapp/components/pluginmanager/pluginmanagerevaluatorsettings-directive.js
@@ -64,6 +64,8 @@
         };
       },
       link: function(scope, element, attrs) {
+        scope.availableProperties = GLOBALS.EVALUATOR_SPEC.PROPERTIES;
+
         var spec = _.map(scope.evaluator.spec, function(value, key) {
           return _.extend({ name: key, key: key }, value);
         });


### PR DESCRIPTION
Checkbox:

```
settingName:  {type: "settableBoolean", name: "Displayed Name", action: "callbackName" }
```

Radio:

```
settingName: {type: "settableEnum", name: "Displayed Name", values: ["A", "B"], action: "callbackName"}
```

action callbacks are optional.

Defaults are not handled automatically. Plugin implementor has to handle defaults as part of the plugin initialization.
