### PR TITLE
'SVGElement.offsetHeight' is deprecated #3621

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -611,12 +611,12 @@
               "id" : "xlabel",
               "class" : "plot-xylabel",
               "text" : model.xAxis.axisLabelWithCommon,
-              "x" : lMargin + (scope.jqsvg.get(0).clientWidth - lMargin) / 2,
-              "y" : scope.jqsvg.get(0).clientHeight - plotUtils.fonts.labelHeight
+              "x" : lMargin + (plotUtils.safeWidth(scope.jqsvg) - lMargin) / 2,
+              "y" : plotUtils.safeHeight(scope.jqsvg) - plotUtils.fonts.labelHeight
             });
           }
           if (model.yAxis.label != null) {
-            var x = plotUtils.fonts.labelHeight * 2, y = (scope.jqsvg.get(0).clientHeight - bMargin) / 2;
+            var x = plotUtils.fonts.labelHeight * 2, y = (plotUtils.safeHeight(scope.jqsvg) - bMargin) / 2;
             scope.rpipeTexts.push({
               "id" : "ylabel",
               "class" : "plot-xylabel",
@@ -627,7 +627,7 @@
             });
           }
           if (model.yAxisR && model.yAxisR.label != null) {
-            var x = scope.jqsvg.get(0).clientWidth - plotUtils.fonts.labelHeight, y = (scope.jqsvg.get(0).clientHeight - bMargin) / 2;
+            var x = plotUtils.safeWidth(scope.jqsvg) - plotUtils.fonts.labelHeight, y = (plotUtils.safeHeight(scope.jqsvg) - bMargin) / 2;
             scope.rpipeTexts.push({
               "id" : "yrlabel",
               "class" : "plot-xylabel",
@@ -693,7 +693,7 @@
 
         scope.renderCursor = function(e) {
           var x = e.offsetX, y = e.offsetY;
-          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
+          var W = plotUtils.safeWidth(scope.jqsvg), H = plotUtils.safeHeight(scope.jqsvg);
           var lMargin = scope.layout.leftLayoutMargin, bMargin = scope.layout.bottomLayoutMargin,
               rMargin = scope.layout.rightLayoutMargin, tMargin = scope.layout.topLayoutMargin;
           var model = scope.stdmodel;
@@ -968,7 +968,7 @@
             .attr("id", "plotLegend")
             .attr("class", "plot-legend")
             .draggable(draggable)
-            .css("max-height", scope.jqsvg.get(0).clientHeight - scope.layout.bottomLayoutMargin - scope.layout.topLayoutMargin);
+            .css("max-height", plotUtils.safeHeight(scope.jqsvg) - scope.layout.bottomLayoutMargin - scope.layout.topLayoutMargin);
 
           if (clazz != null) {
             legendContainer.addClass(clazz);
@@ -1363,7 +1363,7 @@
         };
 
         scope.renderCoverBox = function() {
-          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
+          var W = plotUtils.safeWidth(scope.jqsvg), H = plotUtils.safeHeight(scope.jqsvg);
           plotUtils.replotSingleRect(scope.labelg, {
             "id" : "coverboxYr",
             "class" : "plot-coverbox",
@@ -1464,7 +1464,7 @@
           if (scope.interactMode === "zoom") {
             // left click zoom
             var lMargin = scope.layout.leftLayoutMargin, bMargin = scope.layout.bottomLayoutMargin;
-            var W = scope.jqsvg.get(0).clientWidth - lMargin, H = scope.jqsvg.get(0).clientHeight - bMargin;
+            var W = plotUtils.safeWidth(scope.jqsvg) - lMargin, H = plotUtils.safeHeight(scope.jqsvg) - bMargin;
             var d3trans = d3.event.translate, d3scale = d3.event.scale;
             var dx = d3trans[0] - scope.lastx, dy = d3trans[1] - scope.lasty,
                 ds = this.lastscale / d3scale;
@@ -1508,7 +1508,7 @@
             } else {
               // scale only
               var level = scope.zoomLevel;
-              if (my <= scope.jqsvg.get(0).clientHeight - scope.layout.bottomLayoutMargin) {
+              if (my <= plotUtils.safeHeight(scope.jqsvg) - scope.layout.bottomLayoutMargin) {
                 // scale y
                 var ym = focus.yl + scope.scr2dataYp(my) * focus.yspan;
                 var nyl = ym - ds * (ym - focus.yl), nyr = ym + ds * (focus.yr - ym),
@@ -1593,7 +1593,7 @@
         scope.resetFocus = function() {
           var mx = d3.mouse(scope.svg[0][0])[0], my = d3.mouse(scope.svg[0][0])[1];
           var lMargin = scope.layout.leftLayoutMargin, bMargin = scope.layout.bottomLayoutMargin;
-          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
+          var W = plotUtils.safeWidth(scope.jqsvg), H = plotUtils.safeHeight(scope.jqsvg);
           if (mx < lMargin && my < H - bMargin) {
             _.extend(scope.focus, _.pick(scope.defaultFocus, "yl", "yr", "yspan"));
           } else if (my > H - bMargin && mx > lMargin) {
@@ -1674,7 +1674,7 @@
               tMargin = scope.layout.topLayoutMargin,
               rMargin = scope.layout.rightLayoutMargin;
           var model = scope.stdmodel;
-          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
+          var W = plotUtils.safeWidth(scope.jqsvg), H = plotUtils.safeHeight(scope.jqsvg);
           if (emitFocusUpdate == true && scope.model.updateFocus != null) {
             scope.model.updateFocus({
               "xl" : focus.xl,

--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -611,12 +611,12 @@
               "id" : "xlabel",
               "class" : "plot-xylabel",
               "text" : model.xAxis.axisLabelWithCommon,
-              "x" : lMargin + (scope.jqsvg.width() - lMargin) / 2,
-              "y" : scope.jqsvg.height() - plotUtils.fonts.labelHeight
+              "x" : lMargin + (scope.jqsvg.get(0).clientWidth - lMargin) / 2,
+              "y" : scope.jqsvg.get(0).clientHeight - plotUtils.fonts.labelHeight
             });
           }
           if (model.yAxis.label != null) {
-            var x = plotUtils.fonts.labelHeight * 2, y = (scope.jqsvg.height() - bMargin) / 2;
+            var x = plotUtils.fonts.labelHeight * 2, y = (scope.jqsvg.get(0).clientHeight - bMargin) / 2;
             scope.rpipeTexts.push({
               "id" : "ylabel",
               "class" : "plot-xylabel",
@@ -627,7 +627,7 @@
             });
           }
           if (model.yAxisR && model.yAxisR.label != null) {
-            var x = scope.jqsvg.width() - plotUtils.fonts.labelHeight, y = (scope.jqsvg.height() - bMargin) / 2;
+            var x = scope.jqsvg.get(0).clientWidth - plotUtils.fonts.labelHeight, y = (scope.jqsvg.get(0).clientHeight - bMargin) / 2;
             scope.rpipeTexts.push({
               "id" : "yrlabel",
               "class" : "plot-xylabel",
@@ -693,7 +693,7 @@
 
         scope.renderCursor = function(e) {
           var x = e.offsetX, y = e.offsetY;
-          var W = scope.jqsvg.width(), H = scope.jqsvg.height();
+          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
           var lMargin = scope.layout.leftLayoutMargin, bMargin = scope.layout.bottomLayoutMargin,
               rMargin = scope.layout.rightLayoutMargin, tMargin = scope.layout.topLayoutMargin;
           var model = scope.stdmodel;
@@ -968,7 +968,7 @@
             .attr("id", "plotLegend")
             .attr("class", "plot-legend")
             .draggable(draggable)
-            .css("max-height", scope.jqsvg.height() - scope.layout.bottomLayoutMargin - scope.layout.topLayoutMargin);
+            .css("max-height", scope.jqsvg.get(0).clientHeight - scope.layout.bottomLayoutMargin - scope.layout.topLayoutMargin);
 
           if (clazz != null) {
             legendContainer.addClass(clazz);
@@ -1363,7 +1363,7 @@
         };
 
         scope.renderCoverBox = function() {
-          var W = scope.jqsvg.width(), H = scope.jqsvg.height();
+          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
           plotUtils.replotSingleRect(scope.labelg, {
             "id" : "coverboxYr",
             "class" : "plot-coverbox",
@@ -1464,7 +1464,7 @@
           if (scope.interactMode === "zoom") {
             // left click zoom
             var lMargin = scope.layout.leftLayoutMargin, bMargin = scope.layout.bottomLayoutMargin;
-            var W = scope.jqsvg.width() - lMargin, H = scope.jqsvg.height() - bMargin;
+            var W = scope.jqsvg.get(0).clientWidth - lMargin, H = scope.jqsvg.get(0).clientHeight - bMargin;
             var d3trans = d3.event.translate, d3scale = d3.event.scale;
             var dx = d3trans[0] - scope.lastx, dy = d3trans[1] - scope.lasty,
                 ds = this.lastscale / d3scale;
@@ -1508,7 +1508,7 @@
             } else {
               // scale only
               var level = scope.zoomLevel;
-              if (my <= scope.jqsvg.height() - scope.layout.bottomLayoutMargin) {
+              if (my <= scope.jqsvg.get(0).clientHeight - scope.layout.bottomLayoutMargin) {
                 // scale y
                 var ym = focus.yl + scope.scr2dataYp(my) * focus.yspan;
                 var nyl = ym - ds * (ym - focus.yl), nyr = ym + ds * (focus.yr - ym),
@@ -1593,7 +1593,7 @@
         scope.resetFocus = function() {
           var mx = d3.mouse(scope.svg[0][0])[0], my = d3.mouse(scope.svg[0][0])[1];
           var lMargin = scope.layout.leftLayoutMargin, bMargin = scope.layout.bottomLayoutMargin;
-          var W = scope.jqsvg.width(), H = scope.jqsvg.height();
+          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
           if (mx < lMargin && my < H - bMargin) {
             _.extend(scope.focus, _.pick(scope.defaultFocus, "yl", "yr", "yspan"));
           } else if (my > H - bMargin && mx > lMargin) {
@@ -1674,7 +1674,7 @@
               tMargin = scope.layout.topLayoutMargin,
               rMargin = scope.layout.rightLayoutMargin;
           var model = scope.stdmodel;
-          var W = scope.jqsvg.width(), H = scope.jqsvg.height();
+          var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
           if (emitFocusUpdate == true && scope.model.updateFocus != null) {
             scope.model.updateFocus({
               "xl" : focus.xl,

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstband.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstband.js
@@ -123,8 +123,8 @@
           bMargin = scope.layout.bottomLayoutMargin,
           tMargin = scope.layout.topLayoutMargin,
           rMargin = scope.layout.rightLayoutMargin;
-      var W = scope.jqsvg.get(0).clientWidth,
-          H = scope.jqsvg.get(0).clientHeight;
+      var W = plotUtils.safeWidth(scope.jqsvg),
+          H = plotUtils.safeHeight(scope.jqsvg);
 
       eleprops.length = 0;
 

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstband.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstband.js
@@ -123,8 +123,8 @@
           bMargin = scope.layout.bottomLayoutMargin,
           tMargin = scope.layout.topLayoutMargin,
           rMargin = scope.layout.rightLayoutMargin;
-      var W = scope.jqsvg.width(),
-          H = scope.jqsvg.height();
+      var W = scope.jqsvg.get(0).clientWidth,
+          H = scope.jqsvg.get(0).clientHeight;
 
       eleprops.length = 0;
 

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstline.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstline.js
@@ -104,8 +104,8 @@
           mapY = scope.data2scrYi;
       var lMargin = scope.layout.leftLayoutMargin,
           bMargin = scope.layout.bottomLayoutMargin;
-      var W = scope.jqsvg.get(0).clientWidth,
-          H = scope.jqsvg.get(0).clientHeight;
+      var W = plotUtils.safeWidth(scope.jqsvg),
+          H = plotUtils.safeHeight(scope.jqsvg);
 
       eleprops.length = 0;
       this.labelpipe.length = 0;

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstline.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plotconstline.js
@@ -104,8 +104,8 @@
           mapY = scope.data2scrYi;
       var lMargin = scope.layout.leftLayoutMargin,
           bMargin = scope.layout.bottomLayoutMargin;
-      var W = scope.jqsvg.width(),
-          H = scope.jqsvg.height();
+      var W = scope.jqsvg.get(0).clientWidth,
+          H = scope.jqsvg.get(0).clientHeight;
 
       eleprops.length = 0;
       this.labelpipe.length = 0;

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plottreemapnode.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plottreemapnode.js
@@ -54,8 +54,8 @@
         return;
 
       var margin = {top: 0, right: 0, bottom: 0, left: 0},
-        width = (scope ? scope.jqsvg.width() : 300) - margin.left - margin.right,
-        height = (scope ? scope.jqsvg.height() : 200) - margin.top - margin.bottom;
+        width = (scope ? scope.jqsvg.get(0).clientWidth : 300) - margin.left - margin.right,
+        height = (scope ? scope.jqsvg.get(0).clientHeight : 200) - margin.top - margin.bottom;
 
       var treemap = d3.layout.treemap()
         .round(false)

--- a/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plottreemapnode.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotitems/std/plottreemapnode.js
@@ -54,8 +54,8 @@
         return;
 
       var margin = {top: 0, right: 0, bottom: 0, left: 0},
-        width = (scope ? scope.jqsvg.get(0).clientWidth : 300) - margin.left - margin.right,
-        height = (scope ? scope.jqsvg.get(0).clientHeight : 200) - margin.top - margin.bottom;
+        width = (scope ? plotUtils.safeWidth(scope.jqsvg) : 300) - margin.left - margin.right,
+        height = (scope ? plotUtils.safeHeight(scope.jqsvg) : 200) - margin.top - margin.bottom;
 
       var treemap = d3.layout.treemap()
         .round(false)

--- a/core/src/main/web/outputdisplay/bko-plot/plotutils.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotutils.js
@@ -54,12 +54,18 @@
         222	: "SINGLE_QUOTE"
       };
     return {
+      safeWidth: function(e){
+        return e.get(0).clientWidth;
+      },
+      safeHeight: function(e){
+        return e.get(0).clientHeight;
+      },
       outsideScr: function(scope, x, y) {
-        var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
+        var W = this.safeWidth(scope.jqsvg), H = this.safeHeight(scope.jqsvg);
         return x < 0 || x > W || y < 0 || y > H;
       },
       outsideScrBox: function(scope, x, y, w, h) {
-        var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
+        var W = this.safeWidth(scope.jqsvg), H = this.safeHeight(scope.jqsvg);
         return x > W || x + w < 0 || y > H || y + h < 0;
       },
       updateRange : function(datarange, itemrange) {

--- a/core/src/main/web/outputdisplay/bko-plot/plotutils.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotutils.js
@@ -55,11 +55,11 @@
       };
     return {
       outsideScr: function(scope, x, y) {
-        var W = scope.jqsvg.width(), H = scope.jqsvg.height();
+        var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
         return x < 0 || x > W || y < 0 || y > H;
       },
       outsideScrBox: function(scope, x, y, w, h) {
-        var W = scope.jqsvg.width(), H = scope.jqsvg.height();
+        var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
         return x > W || x + w < 0 || y > H || y + h < 0;
       },
       updateRange : function(datarange, itemrange) {


### PR DESCRIPTION
I will try to use
var W = scope.jqsvg.get(0).clientWidth, H = scope.jqsvg.get(0).clientHeight;
instead
var W = scope.jqsvg.width(), H = scope.jqsvg.height();

All works fine.

I think that this is solution for all jquery elements contains SVGElements. It will be fixed in the 3.0.0 jquery version. But 3.0.0-beta1 doesn't work correctly with our application.
