### PR TITLE
use beakerConfig instead of beakerConfigPref

### DIFF
--- a/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/BeakerConfig.java
@@ -225,5 +225,8 @@ public interface BeakerConfig {
   public String getPluginPath(String plugin);
 
   public Object getPluginPrefs();
+
   public void setPluginPrefs(JSONObject prefs);
+
+  public Boolean getShowZombieLogging();
 }

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -83,6 +83,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
   private final Boolean requirePassword;
   private final String listenInterface;
   private SecureRandom random;
+  private Boolean showZombieLogging;
 
   private String hash(String password) {
     return DigestUtils.sha512Hex(password + getPasswordSalt());
@@ -182,6 +183,7 @@ public class DefaultBeakerConfig implements BeakerConfig {
     this.useHttpsKey = pref.getUseHttpsKey();
     this.requirePassword = pref.getRequirePassword();
     this.listenInterface = pref.getListenInterface();
+    this.showZombieLogging = pref.getShowZombieLogging();
     
     this.random = new SecureRandom();
     // protect the core server
@@ -446,6 +448,11 @@ public class DefaultBeakerConfig implements BeakerConfig {
 
   public void setPluginPrefs(JSONObject newPrefs) {
     this.prefs = newPrefs;
+  }
+
+  @Override
+  public Boolean getShowZombieLogging() {
+    return this.showZombieLogging;
   }
 
   private void addOption(String plugin, String option) {

--- a/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
+++ b/core/src/main/java/com/twosigma/beaker/core/rest/PluginServiceLocatorRest.java
@@ -172,7 +172,6 @@ public class PluginServiceLocatorRest {
   private int portSearchStart;
   private BeakerConfig config;
   private String authToken;
-  private BeakerConfigPref bkConfigPref;
 
   private static String[] listToArray(List<String> lst) {
     return lst.toArray(new String[lst.size()]);
@@ -181,7 +180,6 @@ public class PluginServiceLocatorRest {
   @Inject
   private PluginServiceLocatorRest(
       BeakerConfig bkConfig,
-      BeakerConfigPref bkConfigPref,
       WebServerConfig webServerConfig,
       OutputLogService outputLogService,
       GeneralUtils utils) throws IOException {
@@ -242,7 +240,7 @@ public class PluginServiceLocatorRest {
     this.nginxRestartCommand[8] = "reload";
     
     this.corePassword = webServerConfig.getPassword();
-    this.showZombieLogging = bkConfigPref.getShowZombieLogging();
+    this.showZombieLogging = bkConfig.getShowZombieLogging();
 
     // record plugin options from cli and to pass through to individual plugins
     for (Map.Entry<String, List<String>> e: bkConfig.getPluginOptions().entrySet()) {


### PR DESCRIPTION
beakerConfigPref is used only to generate beakerConfig. We shouldn't read values directly from beakerConfPref but rather from beakerConf.
