### PR TITLE
clicking big run button moves cursor #3799

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -121,7 +121,9 @@
         };
 
         $scope.backgroundClick = function(event) {
-          if (!$scope.isShowInput() || $(event.toElement).parents().hasClass('code-cell-output')) {
+          if (!$scope.isShowInput() ||
+              $(event.toElement).parents().hasClass('code-cell-output') ||
+              $(event.toElement).hasClass('evaluate-script')) {
             return;
           }
           var top = $(event.delegateTarget).offset().top;


### PR DESCRIPTION
focus is removed from the editor when clicking on the big run btn (similarly to the run button in cell menu)
