### PR TITLE
Removed JDK 8 API and replaced it with a for loop

### DIFF
--- a/plugin/javash/src/main/java/org/abstractmeta/toolbox/compilation/compiler/impl/JavaSourceCompilerImpl.java
+++ b/plugin/javash/src/main/java/org/abstractmeta/toolbox/compilation/compiler/impl/JavaSourceCompilerImpl.java
@@ -194,7 +194,13 @@ public class JavaSourceCompilerImpl implements JavaSourceCompiler {
     }
 
     private long getDiagnosticCountByType(DiagnosticCollector<JavaFileObject> diagnostics, Diagnostic.Kind kind) {
-        return diagnostics.getDiagnostics().stream().filter(d -> d.getKind().equals(kind)).count();
+        long result = 0;
+        for (Diagnostic<? extends JavaFileObject> e : diagnostics.getDiagnostics()) {
+            if (e.getKind().equals(kind)) {
+                result += 1;
+            }
+        }
+        return result;
     }
 
     public void persistCompiledClasses(CompilationUnit compilationUnit) {


### PR DESCRIPTION
We cannot use Java 8 because of internal reasons.
