### PR TITLE
groovy output control fails #4003

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
+++ b/core/src/main/web/app/mainapp/components/notebook/codecell-directive.js
@@ -153,7 +153,7 @@
 
           var result = $scope.cellmodel.output.result;
 
-          if (!result || result.hidden) {
+          if (result === null || typeof result === "undefined" || result.hidden) {
             return false;
           }
 

--- a/core/src/main/web/app/mainapp/components/notebook/outputdisplay/outputdisplayfactory-service.js
+++ b/core/src/main/web/app/mainapp/components/notebook/outputdisplay/outputdisplayfactory-service.js
@@ -238,7 +238,7 @@
           return /^<[a-z][\s\S]*>/i.test(value);
         };
         return function(result) {
-          if (!result) {
+          if (result === null || typeof result === "undefined") {
             return ["Hidden"];
           }
           if (!result.type) {


### PR DESCRIPTION
Problen not in the beaker.prefs.useOutputPanel = false

Try to use only in the any code cell 'false'. Output will be hidden.

Problem was in the not correct check:

```
if (!result|| result.hidden) {
```

Output was hidden for the result === false.

Check has been improved

```
 if (result === null || typeof result === "undefined" || result.hidden) {
```
