### PR TITLE
Expose public-server password to environment variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN chown -R beaker:beaker /home/beaker/.beaker
 ###################
 
 # Password for public-server authentication.
-# Set to "<random>" for randomy generated password.
+# Set to "<random>" for randomly generated password.
 ENV BEAKERPASSWD "<random>"
 
 EXPOSE 8800

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,10 @@ RUN chown -R beaker:beaker /home/beaker/.beaker
 #       Run       #
 ###################
 
+# Password for public-server authentication.
+# Set to "<random>" for randomy generated password.
+ENV BEAKERPASSWD "<random>"
+
 EXPOSE 8800
 WORKDIR /home/beaker/src
 CMD su -m beaker -c "export PATH=$PATH:/usr/sbin && /home/beaker/src/core/beaker.command --public-server"

--- a/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
+++ b/core/src/main/java/com/twosigma/beaker/core/module/config/DefaultBeakerConfig.java
@@ -175,7 +175,8 @@ public class DefaultBeakerConfig implements BeakerConfig {
     this.random = new SecureRandom();
     // protect the core server
     this.authCookie = randomString(255);
-    String password = randomString(100);
+    String password = System.getenv("BEAKERPASSWD");
+    password = (null == password || password.equals("<random>")) ? randomString(100) : password;
     this.passwordHash = hash(password);
     this.password = password;
 


### PR DESCRIPTION
I edited the Dockerfile and DefaultBeakerConfig to add the opportunity to start the server with a static password. If you set the `BEAKERPASSWD` environment variable to `<random>` (which is the default in the Dockerfile) or delete it, the password will be generated randomly as before.
