### PR TITLE
portable windows version fails #4091

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -256,6 +256,8 @@ task (copyNginx, type: Exec) {
 
 task doRemove() {
   doLast {
+      delete fileTree(dir: "build/scripts")
+      delete "build/scripts"
       delete fileTree(dir: "node_modules")
       delete "node_modules"
       delete fileTree(dir: "src/main/web/app/genweb")
@@ -317,6 +319,10 @@ if (mac() || windows()) {
   run.dependsOn copyNginx
   startScripts {
     defaultJvmOpts=['-Dbeaker.nginx.bin.dir=' + './nginx/bin']
+    doLast {
+      // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+      windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
+    }
   }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -318,7 +318,7 @@ if (mac() || windows()) {
   builddebug.dependsOn copyNginx
   run.dependsOn copyNginx
   startScripts {
-    defaultJvmOpts=['-Dbeaker.nginx.bin.dir=' + './nginx/bin']
+    defaultJvmOpts=['-Dbeaker.nginx.bin.dir=' + './nginx/bin', '-Djava.awt.headless=' + 'true']
     doLast {
       // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
       windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')

--- a/core/config/tutorials/scala-spark.bkr
+++ b/core/config/tutorials/scala-spark.bkr
@@ -60,7 +60,8 @@
                 "Beaker supports using [Spark](http://spark.apache.org/) with its native language, Scala.",
                 "",
                 "You must use a Spark version compatible with Scala 2.11 (to be compatible with the Scala in Beaker).  We have one prebuilt you can [download](https://s3.amazonaws.com/beaker-distributions/spark-1.5.0-bin-custom-spark.tgz).",
-                "Just add `lib/spark-assembly-1.5.0-hadoop2.4.0.jar` to your class path (with the Language Manager) and then try the following demos."
+                "Just add `lib/spark-assembly-1.5.0-hadoop2.4.0.jar` to your class path (with the Language Manager) and then try the following demos.",
+                "For a Windows OS you must download [hadoop](http://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-2.6.4/hadoop-2.6.4.tar.gz), extract downloaded file and add path to extracted folder as HADOOP_HOME property to the system variable. Also you can download winutils.exe here: http://public-repo-1.hortonworks.com/hdp-win-alpha/winutils.exe. Then copy it to your HADOOP_HOME/bin directory."
             ],
             "evaluatorReader": false
         },

--- a/core/config/tutorials/scala-spark.bkr
+++ b/core/config/tutorials/scala-spark.bkr
@@ -60,8 +60,7 @@
                 "Beaker supports using [Spark](http://spark.apache.org/) with its native language, Scala.",
                 "",
                 "You must use a Spark version compatible with Scala 2.11 (to be compatible with the Scala in Beaker).  We have one prebuilt you can [download](https://s3.amazonaws.com/beaker-distributions/spark-1.5.0-bin-custom-spark.tgz).",
-                "Just add `lib/spark-assembly-1.5.0-hadoop2.4.0.jar` to your class path (with the Language Manager) and then try the following demos.",
-                "For a Windows OS you must download [hadoop](http://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-2.6.4/hadoop-2.6.4.tar.gz), extract downloaded file and add path to extracted folder as HADOOP_HOME property to the system variable. Also you can download winutils.exe here: http://public-repo-1.hortonworks.com/hdp-win-alpha/winutils.exe. Then copy it to your HADOOP_HOME/bin directory."
+                "Just add `lib/spark-assembly-1.5.0-hadoop2.4.0.jar` to your class path (with the Language Manager) and then try the following demos."
             ],
             "evaluatorReader": false
         },

--- a/plugin/clojure/build.gradle
+++ b/plugin/clojure/build.gradle
@@ -39,28 +39,12 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-// Fix command-length issue in windows startscript
-task pathingJar(type: Jar) {
-  appendix = 'pathing'
-  manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
-  }
-}
-
-applicationDistribution.from(pathingJar) {
-  into "lib"
-}
 
 startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
   doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
   }
 }
 

--- a/plugin/cpp/build.gradle
+++ b/plugin/cpp/build.gradle
@@ -111,28 +111,12 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-// Fix command-length issue in windows startscript
-task pathingJar(type: Jar) {
-  appendix = 'pathing'
-  manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
-  }
-}
-
-applicationDistribution.from(pathingJar) {
-  into "lib"
-}
 
 startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
   doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
   }
 }
 

--- a/plugin/groovy/build.gradle
+++ b/plugin/groovy/build.gradle
@@ -66,28 +66,12 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-// Fix command-length issue in windows startscript
-task pathingJar(type: Jar) {
-  appendix = 'pathing'
-  manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
-  }
-}
-
-applicationDistribution.from(pathingJar) {
-  into "lib"
-}
 
 startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
   doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
   }
 }
 

--- a/plugin/javash/build.gradle
+++ b/plugin/javash/build.gradle
@@ -48,28 +48,12 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-// Fix command-length issue in windows startscript
-task pathingJar(type: Jar) {
-  appendix = 'pathing'
-  manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
-  }
-}
-
-applicationDistribution.from(pathingJar) {
-  into "lib"
-}
 
 startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
   doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
   }
 }
 

--- a/plugin/kdb/build.gradle
+++ b/plugin/kdb/build.gradle
@@ -40,28 +40,11 @@ compileJava {
   options.compilerArgs << '-Xlint:unchecked'
 }
 
-// Fix command-length issue in windows startscript
-task pathingJar(type: Jar) {
-  appendix = 'pathing'
-  manifest {
-    attributes("Class-Path": configurations.runtime.collect { it.getName() }.join(' ') + ' ' + jar.archiveName )
-  }
-}
-
-applicationDistribution.from(pathingJar) {
-  into "lib"
-}
-
 startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
   doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
   }
 }
 

--- a/plugin/r/build.gradle
+++ b/plugin/r/build.gradle
@@ -53,14 +53,8 @@ applicationDistribution.from(pathingJar) {
 startScripts {
   defaultJvmOpts=['-Djava.awt.headless=' + 'true']
   doLast {
-    def winScriptFile  = file getWindowsScript()
-    def winFileText = winScriptFile.text
-
-    // Remove too-long-classpath and use pathing jar instead
-    winFileText = winFileText.replaceAll('set CLASSPATH=.*', 'rem CLASSPATH declaration removed.')
-    winFileText = winFileText.replaceAll('("%JAVA_EXE%" .* -classpath ")%CLASSPATH%(" .*)', '$1%APP_HOME%\\\\lib\\\\' + pathingJar.archiveName + '$2')
-
-    winScriptFile.text = winFileText
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
   }
 }
 

--- a/plugin/scala/build.gradle
+++ b/plugin/scala/build.gradle
@@ -61,5 +61,13 @@ if (hasProperty('includeDepsInJar')) {
   }
 }
 
+startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
+  doLast {
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
+  }
+}
+
 task realclean
 realclean.dependsOn(clean)

--- a/plugin/sqlsh/build.gradle
+++ b/plugin/sqlsh/build.gradle
@@ -64,6 +64,14 @@ if (hasProperty('includeDepsInJar')) {
   }
 }
 
+startScripts {
+  defaultJvmOpts=['-Djava.awt.headless=' + 'true']
+  doLast {
+    // Remove too-long-classpath and use wildcard ( works for java 6 and above only)
+    windowsScript.text = windowsScript.text.replaceAll('set CLASSPATH=.*', 'set CLASSPATH=.;%APP_HOME%/lib/*')
+  }
+}
+
 task realclean
 realclean.dependsOn(clean)
 // should also remove 


### PR DESCRIPTION
I found problem. It was in the file 'core.bat'. See line

> set CLASSPATH=%APP_HOME%\lib\core.jar;%APP_HOME%\lib\json-simple-1.1.1.jar;%APP_HOME%\lib\jersey-servlet-1.17.1.jar;%APP_HOME%\lib\jersey-server-1.17.1.jar;%APP_HOME%\lib\jersey-core-1.17.1.jar;%APP_HOME%\lib\commons-cli-1.2.jar;%APP_HOME%\lib\commons-lang3-3.3.jar;%APP_HOME%\lib\fluent-hc-4.5.1.jar;%APP_HOME%\lib\jetty-servlet-8.1.13.v20130916.jar;%APP_HOME%\lib\winp-1.18.jar;%APP_HOME%\lib\jcifs-1.3.3.jar;%APP_HOME%\lib\shared.jar;%APP_HOME%\lib\slf4j-simple-1.7.6.jar;%APP_HOME%\lib\junit-4.10.jar;%APP_HOME%\lib\asm-3.1.jar;%APP_HOME%\lib\httpclient-4.5.1.jar;%APP_HOME%\lib\commons-logging-1.2.jar;%APP_HOME%\lib\jetty-security-8.1.13.v20130916.jar;%APP_HOME%\lib\cometd-java-annotations-2.7.0.jar;%APP_HOME%\lib\jackson-jaxrs-1.9.13.jar;%APP_HOME%\lib\cxf-bundle-jaxrs-2.7.7.jar;%APP_HOME%\lib\jersey-guice-1.17.1.jar;%APP_HOME%\lib\cometd-websocket-jetty-2.7.0.jar;%APP_HOME%\lib\slf4j-api-1.7.6.jar;%APP_HOME%\lib\hamcrest-core-1.1.jar;%APP_HOME%\lib\httpcore-4.4.3.jar;%APP_HOME%\lib\commons-codec-1.9.jar;%APP_HOME%\lib\jetty-server-8.1.13.v20130916.jar;%APP_HOME%\lib\javax.inject-1.jar;%APP_HOME%\lib\jsr250-api-1.0.jar;%APP_HOME%\lib\bayeux-api-2.7.0.jar;%APP_HOME%\lib\cometd-java-server-2.7.0.jar;%APP_HOME%\lib\jackson-core-asl-1.9.13.jar;%APP_HOME%\lib\jackson-mapper-asl-1.9.13.jar;%APP_HOME%\lib\woodstox-core-asl-4.2.0.jar;%APP_HOME%\lib\stax2-api-3.1.1.jar;%APP_HOME%\lib\xmlschema-core-2.0.3.jar;%APP_HOME%\lib\geronimo-javamail_1.4_spec-1.7.1.jar;%APP_HOME%\lib\wsdl4j-1.6.3.jar;%APP_HOME%\lib\jaxb-impl-2.1.13.jar;%APP_HOME%\lib\geronimo-servlet_3.0_spec-1.0.jar;%APP_HOME%\lib\javax.ws.rs-api-2.0-m10.jar;%APP_HOME%\lib\guice-3.0.jar;%APP_HOME%\lib\guice-servlet-3.0.jar;%APP_HOME%\lib\cometd-java-client-2.7.0.jar;%APP_HOME%\lib\jetty-websocket-7.6.13.v20130916.jar;%APP_HOME%\lib\cometd-java-common-2.7.0.jar;%APP_HOME%\lib\jetty-jmx-7.6.13.v20130916.jar;%APP_HOME%\lib\aopalliance-1.0.jar;%APP_HOME%\lib\cglib-2.2.1-v20090111.jar;%APP_HOME%\lib\jetty-client-7.6.13.v20130916.jar;%APP_HOME%\lib\javax.servlet-3.0.0.v201112011016.jar;%APP_HOME%\lib\jetty-continuation-8.1.13.v20130916.jar;%APP_HOME%\lib\jetty-http-8.1.13.v20130916.jar;%APP_HOME%\lib\jetty-io-8.1.13.v20130916.jar;%APP_HOME%\lib\jetty-util-8.1.13.v20130916.jar

In some cases this path is too long. I have used wildcard for a classpath setting. see 'Understanding class path wildcards' in the https://docs.oracle.com/javase/6/docs/technotes/tools/windows/classpath.html . 

My solution is

> set CLASSPATH=.;%APP_HOME%/lib/*

Pay attention that you can run 'gradle clean  build' from root project directory before running 'gradle makePortableZip'
