### PR TITLE
tables in R show up as text #4108

### DIFF
--- a/plugin/r/src/dist/beaker/R/beaker.r
+++ b/plugin/r/src/dist/beaker/R/beaker.r
@@ -339,7 +339,7 @@ convertToJSON <- function(val, collapse) {
   else if (class(val) == "data.table") {
     o = convertToJSON(as.data.frame(val))
   }
-  else if (class(val) == "data.frame") {
+  else if ('data.frame' %in% class(val)) {
     p = "{ \"type\":\"TableDisplay\",\"subtype\":\"TableDisplay\",\"hasIndex\":\"true\",\"columnNames\":"
     colNames = c('Index')
     colNames = c(colNames,names(val))


### PR DESCRIPTION
see https://cran.r-project.org/doc/manuals/R-lang.html#Classes

R has an elaborate class system1, principally controlled via the class attribute. This attribute is a character vector containing the list of classes that an object inherits from. This forms the basis of the “generic methods” functionality in R.

in this case code ' else if (class(val) == "data.frame") {' doesn't accepted because class(val)  returns vertor  "tbl_df"     "tbl"        "data.frame".

I have used ''data.frame' %in% class(val)'
