### PR TITLE
returning scala import errors out #4272

### DIFF
--- a/plugin/scala/src/main/scala/com/twosigma/beaker/scala/util/ScalaEvaluatorGlue.scala
+++ b/plugin/scala/src/main/scala/com/twosigma/beaker/scala/util/ScalaEvaluatorGlue.scala
@@ -66,10 +66,20 @@ class ScalaEvaluatorGlue(val cl: ClassLoader, var cp: String, val replClassdir: 
     var b: ArgumentCompleter =new ArgumentCompleter(new JLineDelimiter, scalaToJline(c.completer));
     b.setStrict(false);
     b;
-  } 
-  
+  }
+
   private def getOut: Any = {
-    interpreter.lastRequest.lineRep.call("$result")
+    try {
+      interpreter.lastRequest.lineRep.call("$result")
+    } catch {
+      case e: Exception =>
+        val lvo = interpreter.valueOfTerm(interpreter.mostRecentVar)
+        lvo match {
+          case None => baos.toString();
+          case Some(ResetState("reset")) => baos.toString();
+          case Some(value) => value;
+        }
+    }
   }
   
   def addImport(name : String): Boolean = {


### PR DESCRIPTION
Problem was in the 'interpreter.lastRequest.lineRep.call("$result")' line because method "$result" doesn' exist. I have added exception handler with old working functionality
