### PR TITLE
output line breaks should be on word boundaries if possible #4280

### DIFF
--- a/core/src/main/web/app/mainapp/components/notebook/outputdisplay/outputdisplayfactory-service.js
+++ b/core/src/main/web/app/mainapp/components/notebook/outputdisplay/outputdisplayfactory-service.js
@@ -27,7 +27,7 @@
 
     var impls = {
         "Text": {
-          template: "<pre>{{getText()}}</pre>",
+          template: "<pre style='word-break: keep-all;'>{{getText()}}</pre>",
           controller: function($scope) {
             $scope.getText = function() {
               var model = $scope.model.getCellModel();


### PR DESCRIPTION
I added style='word-break: keep-all;' for output

see
![image](https://cloud.githubusercontent.com/assets/13516511/16151193/561a9566-34a4-11e6-89a5-7f488e941bdd.png)
