### PR TITLE
vim mode cmd box partially obscured by line numbers #4283

### DIFF
--- a/core/src/main/web/app/app.scss
+++ b/core/src/main/web/app/app.scss
@@ -333,6 +333,10 @@ background-color: rgb(205, 223, 214);
 .CodeMirror.cm-fat-cursor {
   padding-bottom: 25px;
   margin-bottom: -15px;
+  .advanced-mode & {
+    padding-bottom: 28px;
+    margin-bottom: -8px;
+  }
 }
 
 .vertical-align {

--- a/core/src/main/web/app/app.scss
+++ b/core/src/main/web/app/app.scss
@@ -330,6 +330,11 @@ background-color: rgb(205, 223, 214);
   opacity: 0.5;
 }
 
+.CodeMirror.cm-fat-cursor {
+  padding-bottom: 25px;
+  margin-bottom: -15px;
+}
+
 .vertical-align {
   display: flex;
   align-items: center;

--- a/core/src/main/web/app/app.scss
+++ b/core/src/main/web/app/app.scss
@@ -330,15 +330,6 @@ background-color: rgb(205, 223, 214);
   opacity: 0.5;
 }
 
-.CodeMirror.cm-fat-cursor {
-  padding-bottom: 25px;
-  margin-bottom: -15px;
-  .advanced-mode & {
-    padding-bottom: 28px;
-    margin-bottom: -8px;
-  }
-}
-
 .vertical-align {
   display: flex;
   align-items: center;

--- a/core/src/main/web/app/styles/vendor_overrides.scss
+++ b/core/src/main/web/app/styles/vendor_overrides.scss
@@ -76,11 +76,10 @@ div.CodeMirror {
   }
 }
 
-.CodeMirror-dialog {
-   .advanced-mode & {
-     margin-right: 230px;
-   }
- }
+.CodeMirror-dialog-bottom {
+  position: static;
+  margin-left: calc(23px - .8em)
+}
 
 /* This is for datatables customization */
 tbody tr {

--- a/core/src/main/web/app/styles/vendor_overrides.scss
+++ b/core/src/main/web/app/styles/vendor_overrides.scss
@@ -76,6 +76,12 @@ div.CodeMirror {
   }
 }
 
+.CodeMirror-dialog {
+   .advanced-mode & {
+     margin-right: 230px;
+   }
+ }
+
 /* This is for datatables customization */
 tbody tr {
   &, &.odd, &.even {

--- a/core/src/main/web/app/vendor.scss
+++ b/core/src/main/web/app/vendor.scss
@@ -19,6 +19,7 @@
 @import "../vendor/bower_components/codemirror/lib/codemirror.css";
 @import "../vendor/bower_components/codemirror/addon/hint/show-hint.css";
 @import "../vendor/bower_components/codemirror/addon/scroll/simplescrollbars.css";
+@import "../vendor/bower_components/codemirror/addon/dialog/dialog.css";
 
 @import "../vendor/bower_components/codemirror/theme/ambiance.css";
 @import "../vendor/bower_components/codemirror/theme/ambiance-mobile.css";


### PR DESCRIPTION
i included CodeMirror's css used in vim mode. so now search box looks like:

![image](https://cloud.githubusercontent.com/assets/12935591/16194980/29a2a812-3700-11e6-9f08-9e0948e19d25.png)
