### PR TITLE
$rootScope emits event on dataTable init

### DIFF
--- a/core/src/main/web/outputdisplay/bko-tabledisplay/bko-tabledisplay.js
+++ b/core/src/main/web/outputdisplay/bko-tabledisplay/bko-tabledisplay.js
@@ -2530,6 +2530,7 @@
 
             scope.fixcols = new $.fn.dataTable.FixedColumns($(id), inits);
             scope.fixcols.fnRedrawLayout();
+            $rootScope.$emit('beaker.resize');
 
             setTimeout(function(){
               if (!scope.table) { return; }
@@ -2556,6 +2557,7 @@
               if (scope.showFilter) {
                 scope.doShowFilter(null, scope.columnSearchActive);
               }
+              $rootScope.$emit('beaker.resize');
 
             }, 0);
 


### PR DESCRIPTION
- required for embedding `beaker-notebook` in iframe to notice when to update
  notebook dimensions
