### PR TITLE
Added emitting scope event on iframe resize

### DIFF
--- a/core/src/main/web/outputdisplay/bko-ggvis.js
+++ b/core/src/main/web/outputdisplay/bko-ggvis.js
@@ -18,8 +18,8 @@
  */
 (function() {
   'use strict';
-  beakerRegister.bkoDirective("GGVis", ["$interval", "$compile", "$sce", "bkOutputDisplayFactory", function(
-      $interval, $compile, $sce, bkOutputDisplayFactory) {
+  beakerRegister.bkoDirective("GGVis", ["$interval", "$compile", "$sce", "$rootScope", "bkOutputDisplayFactory", function(
+      $interval, $compile, $sce, $rootScope, bkOutputDisplayFactory) {
     return {
       template: '<div><iframe srcdoc="{{getStuff()}}" style="height: 450px; width: 650px; resize: both; overflow: auto; border: 0;"></iframe></div>',
       link: function(scope, element, attrs) {
@@ -67,6 +67,16 @@
           scope.showoutput = newval;
         });
 
+        var debouncedOnResize = _.debounce(onResize, 100);
+        var iframeEl = element.find('iframe').on('resize', debouncedOnResize);
+
+        function onResize() {
+          $rootScope.$emit('beaker.resize');
+        }
+        
+        scope.$on('$destroy', function() {
+          iframeEl.off('resize', debouncedOnResize);
+        });
       }
     };
   }]);

--- a/core/src/main/web/outputdisplay/bko-plotly.js
+++ b/core/src/main/web/outputdisplay/bko-plotly.js
@@ -20,7 +20,7 @@
  */
 ( function() {
   'use strict';
-  var retfunc = function($sce) {
+  var retfunc = function($sce, $rootScope) {
     var CELL_TYPE = "bko-plotly";
     return {
       template: '<div><iframe srcdoc="{{getHtml()}}" ' +
@@ -49,10 +49,22 @@
         scope.getHtml = function() {
           return $sce.trustAsHtml(scope.html);
         };
+
+        var debouncedOnResize = _.debounce(onResize, 100);
+        var iframeEl = element.find('iframe').on('resize', debouncedOnResize);
+
+        function onResize() {
+          $rootScope.$emit('beaker.resize');
+        }
+        
+        scope.$on('$destroy', function() {
+          iframeEl.off('resize', debouncedOnResize);
+        });
       }
     };
   };
   beakerRegister.bkoDirective("Plotly", [
     '$sce',
+    '$rootScope',
     retfunc]);
 })();


### PR DESCRIPTION
When iframe containing either plotly or ggvis is resized (by user) it emits on $rootScope 'beaker.resize' event
