### PR TITLE
Revert "#4515 long file name breaks start page"

### DIFF
--- a/core/src/main/web/app/styles/dashboard.scss
+++ b/core/src/main/web/app/styles/dashboard.scss
@@ -73,7 +73,6 @@
 
   .path {
     margin-bottom: 6px;
-    word-wrap: break-word;
   }
 
   .session {
@@ -101,11 +100,5 @@
   .notebook-link {
     display: block;
     color: #333333;
-    word-wrap: break-word;
   }
-}
-
-.pull-left{
-  float: left !important;
-  width: 95%;
 }


### PR DESCRIPTION
Reverts twosigma/beaker-notebook#4521
