### PR TITLE
Fixed iframe resizing

### DIFF
--- a/core/src/main/web/outputdisplay/bko-ggvis.js
+++ b/core/src/main/web/outputdisplay/bko-ggvis.js
@@ -68,15 +68,23 @@
         });
 
         var debouncedOnResize = _.debounce(onResize, 100);
-        var iframeEl = element.find('iframe').on('resize', debouncedOnResize);
+        var iframeEl = element.find('iframe').on('load', onLoad);
+        
+        function onLoad(e) {
+          var iframeContentWindow = iframeEl[0].contentWindow;
+          iframeContentWindow.addEventListener('resize', debouncedOnResize);
+          iframeEl.off('load', onLoad);
+          iframeEl = null;
+        
+          scope.$on('$destroy', function() {
+            iframeContentWindow.removeEventListener('resize', debouncedOnResize);
+            iframeContentWindow = null;
+          });
+        }
 
         function onResize() {
           $rootScope.$emit('beaker.resize');
         }
-        
-        scope.$on('$destroy', function() {
-          iframeEl.off('resize', debouncedOnResize);
-        });
       }
     };
   }]);

--- a/core/src/main/web/outputdisplay/bko-plotly.js
+++ b/core/src/main/web/outputdisplay/bko-plotly.js
@@ -51,15 +51,23 @@
         };
 
         var debouncedOnResize = _.debounce(onResize, 100);
-        var iframeEl = element.find('iframe').on('resize', debouncedOnResize);
+        var iframeEl = element.find('iframe').on('load', onLoad);
+        
+        function onLoad(e) {
+          var iframeContentWindow = iframeEl[0].contentWindow;
+          iframeContentWindow.addEventListener('resize', debouncedOnResize);
+          iframeEl.off('load', onLoad);
+          iframeEl = null;
+        
+          scope.$on('$destroy', function() {
+            iframeContentWindow.removeEventListener('resize', debouncedOnResize);
+            iframeContentWindow = null;
+          });
+        }
 
         function onResize() {
           $rootScope.$emit('beaker.resize');
         }
-        
-        scope.$on('$destroy', function() {
-          iframeEl.off('resize', debouncedOnResize);
-        });
       }
     };
   };


### PR DESCRIPTION
When user resizes manually ggvis or plotly plots (only in chrome), event to resize iframe is fired (didn't work previously).
