### PR TITLE
Spark integration

### DIFF
--- a/core/src/main/web/app/mainapp/components/spark/sparkcontextmanager.js
+++ b/core/src/main/web/app/mainapp/components/spark/sparkcontextmanager.js
@@ -42,7 +42,7 @@
     $rootScope.jobsPerCell = {};
     $rootScope.activeCell = null;
 
-    $rootScope.jobIds = [];
+    $rootScope.executorIds = [];
 
     function ConfigurationString(id, value, name, customSerializer) {
       this.id = id;
@@ -246,7 +246,7 @@
             }
             $rootScope.jobsPerCell[$rootScope.activeCell] = jobs;
           }          
-          $rootScope.jobIds = progress.data.jobIds;
+          $rootScope.executorIds = progress.data.executorIds;
           $rootScope.$digest();
         });
 
@@ -344,20 +344,20 @@
           }
           $rootScope.connecting = false;
           $rootScope.running = 0;
-          $rootScope.jobIds = [];
+          $rootScope.executorIds = [];
           bkHelper.clearStatus("Creating Spark context");
 
-          // get Spark job IDs
+          // get Spark executor IDs
           bkHelper
-            .httpGet(bkHelper.serverUrl(serviceBase + "/rest/scalash/sparkJobIds"))
+            .httpGet(bkHelper.serverUrl(serviceBase + "/rest/scalash/sparkExecutorIds"))
             .success(function(ret) {
               if (ret instanceof Array)
-                $rootScope.jobIds = ret;
+                $rootScope.executorIds = ret;
               else
-                console.warn("Error while deserializing Spark job IDs. Given:", ret);
+                console.warn("Error while deserializing Spark executor IDs. Given:", ret);
             })
             .error(function(ret) {
-              console.warn("Error while retrieving Spark job IDs:", ret);
+              console.warn("Error while retrieving Spark executor IDs:", ret);
             });
         }).error(function(ret) {
           if (ret == null) {
@@ -376,7 +376,7 @@
           bkHelper.clearStatus("Creating Spark context");
           $rootScope.connecting = false;
           $rootScope.running = 0;
-          $rootScope.jobIds = [];
+          $rootScope.executorIds = [];
         });
       },
       disconnect: function() {
@@ -469,8 +469,8 @@
         $rootScope.jobsPerCell[cellId] = [];
         $rootScope.activeCell = cellId;
       },
-      jobIds: function() {
-        return $rootScope.jobIds;
+      executorIds: function() {
+        return $rootScope.executorIds;
       }
     };
   });

--- a/core/src/main/web/app/mainapp/components/spark/sparkcontextmanager.js
+++ b/core/src/main/web/app/mainapp/components/spark/sparkcontextmanager.js
@@ -31,18 +31,18 @@
     var uiPort = 4040;
     var shellId = undefined;
 
-    $rootScope.connected = false;
-    $rootScope.connecting = false;
-    $rootScope.disconnecting = false;
-    $rootScope.error = '';
-    $rootScope.running = 0;
+    var connected = false;
+    var connecting = false;
+    var disconnecting = false;
+    var error = '';
+    var running = 0;
 
-    $rootScope.sparkConf = null;
+    var sparkConf = null;
 
-    $rootScope.jobsPerCell = {};
-    $rootScope.activeCell = null;
+    var jobsPerCell = {};
+    var activeCell = null;
 
-    $rootScope.executorIds = [];
+    var executorIds = [];
 
     function ConfigurationString(id, value, name, customSerializer) {
       this.id = id;
@@ -85,7 +85,7 @@
       return typeof response === "string" && response.toLowerCase().indexOf('error') >= 0;
     }
 
-    $rootScope.configurationObjects = {
+    var configurationObjects = {
       executorCores: new ConfigurationString(
         'spark.executor.cores',
         '10',
@@ -124,7 +124,7 @@
 
     function readConfiguration(config, applyOnSuccess) {
       var r = {
-        configurationObjects: jQuery.extend(true, {}, $rootScope.configurationObjects),
+        configurationObjects: jQuery.extend(true, {}, configurationObjects),
         uiPort: null,
         sparkConf: null,
         success: false
@@ -140,9 +140,9 @@
         r.uiPort = parseInt(r.sparkConf["spark.ui.port"]);
 
         if (applyOnSuccess) {
-          $rootScope.configurationObjects = r.configurationObjects;
+          configurationObjects = r.configurationObjects;
           uiPort = r.uiPort;
-          $rootScope.sparkConf = r.sparkConf;
+          sparkConf = r.sparkConf;
         }
 
         r.success = true;
@@ -220,11 +220,11 @@
           console.log("Spark app progress", progress);
         });
         jobSubscription = $.cometd.subscribe('/sparkJobProgress', function(progress) {
-          $rootScope.running = 0;
+          running = 0;
           for (var index in progress.data.jobs) {
-            $rootScope.running += progress.data.jobs[index].running ? 1 : 0;
+            running += progress.data.jobs[index].running ? 1 : 0;
           }
-          if ($rootScope.activeCell != null) {
+          if (activeCell != null) {
             var jobs = [];
             for (var jindex in progress.data.jobs) {
               var j = progress.data.jobs[jindex];
@@ -244,9 +244,9 @@
                 j.stages,
                 j.running));
             }
-            $rootScope.jobsPerCell[$rootScope.activeCell] = jobs;
+            jobsPerCell[activeCell] = jobs;
           }          
-          $rootScope.executorIds = progress.data.executorIds;
+          executorIds = progress.data.executorIds;
           $rootScope.$digest();
         });
 
@@ -259,19 +259,19 @@
             return;
           var confReadResult = readConfiguration(ret, true);
           if (confReadResult.success) {
-            $rootScope.connecting = false;
-            $rootScope.connected = true;
-            $rootScope.running = 0;
+            connecting = false;
+            connected = true;
+            running = 0;
             console.log("SparkContext already started, port:", uiPort);
           } else {
-            $rootScope.connecting = false;
-            $rootScope.connected = false;
-            $rootScope.running = 0;
+            connecting = false;
+            connected = false;
+            running = 0;
 
             if (responseContainsError(ret))
-              $rootScope.error = ret;
+              error = ret;
             else
-              $rootScope.error = 'Error during configuration deserialization';
+              error = 'Error during configuration deserialization';
           }
           bkHelper.clearStatus("Creating Spark context");
         });
@@ -291,35 +291,35 @@
         return serviceBase != null;
       },
       isConnecting: function() {
-        return $rootScope.connecting;
+        return connecting;
       },
       isDisconnecting: function() {
-        return $rootScope.disconnecting;
+        return disconnecting;
       },
       isFailing: function() {
-        return $rootScope.error.length > 0;
+        return error.length > 0;
       },
       isConnected: function() {
-        return $rootScope.connected;
+        return connected;
       },
       runningJobs: function() {
-        return $rootScope.running;
+        return running;
       },
       isRunning: function() {
-        return $rootScope.running > 0;
+        return running > 0;
       },
       getError: function() {
-        return $rootScope.error;
+        return error;
       },
       connect: function() {
-        if ($rootScope.connected)
+        if (connected)
           return;
 
         bkHelper.showStatus(
           "Creating Spark context",
           bkHelper.serverUrl(serviceBase + "/rest/scalash/startSparkContext")
         );
-        $rootScope.connecting = true;
+        connecting = true;
         
         console.log('Setting up SparkContext using configuration', this.configuration());
         bkHelper.httpPost(
@@ -332,19 +332,19 @@
           var confReadResult = readConfiguration(ret, true);
           if (confReadResult.success) {
             console.log("done startSparkContext, port:", uiPort);
-            $rootScope.connected = true;
-            $rootScope.error = '';
-            $rootScope.jobsPerCell = {};
+            connected = true;
+            error = '';
+            jobsPerCell = {};
           } else {
-            $rootScope.connected = false;
+            connected = false;
             if (responseContainsError(ret))
-              $rootScope.error = ret;
+              error = ret;
             else
-              $rootScope.error = 'Error during configuration deserialization';
+              error = 'Error during configuration deserialization';
           }
-          $rootScope.connecting = false;
-          $rootScope.running = 0;
-          $rootScope.executorIds = [];
+          connecting = false;
+          running = 0;
+          executorIds = [];
           bkHelper.clearStatus("Creating Spark context");
 
           // get Spark executor IDs
@@ -352,7 +352,7 @@
             .httpGet(bkHelper.serverUrl(serviceBase + "/rest/scalash/sparkExecutorIds"))
             .success(function(ret) {
               if (ret instanceof Array)
-                $rootScope.executorIds = ret;
+                executorIds = ret;
               else
                 console.warn("Error while deserializing Spark executor IDs. Given:", ret);
             })
@@ -363,114 +363,114 @@
           if (ret == null) {
             // connection issue, Spark is just not available
             serviceBase = null;
-            $rootScope.error = '';
+            error = '';
           }
           else {
             // something erroneous happened
             console.error("SparkContext could not be started.", ret);
             if (responseContainsError(ret))
-              $rootScope.error = ret;
+              error = ret;
             else
-              $rootScope.error = 'Error: SparkContext could not be started.';
+              error = 'Error: SparkContext could not be started.';
           }
           bkHelper.clearStatus("Creating Spark context");
-          $rootScope.connecting = false;
-          $rootScope.running = 0;
-          $rootScope.executorIds = [];
+          connecting = false;
+          running = 0;
+          executorIds = [];
         });
       },
       disconnect: function() {
-        if (!$rootScope.connected)
+        if (!connected)
           return;
 
         bkHelper.showStatus("Stopping Spark context");
-        $rootScope.disconnecting = true;
+        disconnecting = true;
 
         bkHelper.httpPost(
           bkHelper.serverUrl(serviceBase + "/rest/scalash/stopSparkContext"),
           {shellId: shellId}
         ).success(function(ret) {
           console.log("done stopSparkContext", ret);
-          $rootScope.disconnecting = false;
-          $rootScope.connected = false;
-          $rootScope.running = 0;
-          $rootScope.error = '';
+          disconnecting = false;
+          connected = false;
+          running = 0;
+          error = '';
           bkHelper.clearStatus("Stopping Spark context");
         }).error(function(ret) {
           if (ret == null) {
             // connection issue, Spark is just not available
             serviceBase = null;
-            $rootScope.error = '';
+            error = '';
           }
           else {
             // something erroneous happened
             console.error("SparkContext could not be stopped.", ret);
             if (responseContainsError(ret))
-              $rootScope.error = ret;
+              error = ret;
             else
-              $rootScope.error = 'Error: SparkContext could not be stopped.';
+              error = 'Error: SparkContext could not be stopped.';
           }
           bkHelper.clearStatus("Stopping Spark context");
-          $rootScope.disconnecting = false;
-          $rootScope.running = 0;
+          disconnecting = false;
+          running = 0;
         });
       },
       sparkUiUrl: function() {
         return 'http://' + window.location.hostname + ':' + uiPort;
       },
       openSparkUi: function() {
-        if (!$rootScope.connected)
+        if (!connected)
           return;
         var win = window.open(this.sparkUiUrl(), '_blank');
         win.focus();
       },
       configurationObjects: function() {
-        return $rootScope.configurationObjects;
+        return configurationObjects;
       },
       setConfigurationObjects: function(config) {
-        $rootScope.configurationObjects = config;
+        configurationObjects = config;
       },
       configuration: function() {
         // serialize configuration objects to plain string dictionary
         var config = {};
-        for (var key in $rootScope.configurationObjects) {
+        for (var key in configurationObjects) {
           if (key === 'advanced')
             continue;
-          var obj = $rootScope.configurationObjects[key];
+          var obj = configurationObjects[key];
           config[obj.id] = obj.serializedValue();
         }
-        for (var key in $rootScope.configurationObjects.advanced) {
-          var obj = $rootScope.configurationObjects.advanced[key];
+        for (var key in configurationObjects.advanced) {
+          var obj = configurationObjects.advanced[key];
           config[obj.id] = obj.serializedValue();
         }
-        for (var key in $rootScope.sparkConf) {
-          config[key] = $rootScope.sparkConf[key];
+        for (var key in sparkConf) {
+          config[key] = sparkConf[key];
         }
         return config;
       },
       sparkConf: function() {
-        return $rootScope.sparkConf;
+        return sparkConf;
       },
       setSparkConf: function(conf) {
-        $rootScope.sparkConf = conf;
+        sparkConf = conf;
       },
       setSparkConfProperty: function(key, value) {
-        $rootScope.sparkConf[key] = value;
+        sparkConf[key] = value;
       },
       getJobsPerCell: function(cellId) {
-        if (cellId in $rootScope.jobsPerCell)
-          return $rootScope.jobsPerCell[cellId];
+        if (cellId in jobsPerCell)
+          return jobsPerCell[cellId];
         return null;
       },
       setJobsPerCell: function(cellId, jobs) {
-        $rootScope.jobsPerCell[cellId] = jobs;
+        jobsPerCell[cellId] = jobs;
       },
       registerCell: function(cellId) {
-        $rootScope.jobsPerCell[cellId] = [];
-        $rootScope.activeCell = cellId;
+        jobsPerCell[cellId] = [];
+        activeCell = cellId;
       },
       executorIds: function() {
-        return $rootScope.executorIds;
+        return executorIds;
       }
     };
   });

--- a/core/src/main/web/app/mainapp/components/spark/sparkproperties.js
+++ b/core/src/main/web/app/mainapp/components/spark/sparkproperties.js
@@ -33,7 +33,7 @@
       $uibModalInstance.close("ok");
     };
 
-    $scope.jobIds = bkSparkContextManager.jobIds();
-    $scope.jobIdSectionTitle = window.beakerRegister.sparkJobSectionTitle || "Spark Job IDs";
+    $scope.executorIds = bkSparkContextManager.executorIds();
+    $scope.executorIdSectionTitle = window.beakerRegister.sparkExecutorSectionTitle || "Executor IDs";
   }]);
 })();

--- a/core/src/main/web/app/mainapp/components/spark/sparkproperties.jst.html
+++ b/core/src/main/web/app/mainapp/components/spark/sparkproperties.jst.html
@@ -31,13 +31,13 @@
 
   <hr />
 
-  <div class="spark-jobids">
-    <h3>{{jobIdSectionTitle}}</h3>
-    <div ng-if="jobIds.length === 0" class="alert alert-info">
-      No job IDs are available.
+  <div class="spark-executorids">
+    <h3>{{executorIdSectionTitle}}</h3>
+    <div ng-if="executorIds.length === 0" class="alert alert-info">
+      No executor IDs are available.
     </div>
-    <ul ng-if="jobIds.length > 0">
-      <li ng-repeat="jobId in jobIds">{{jobId}}</li>
+    <ul ng-if="executorIds.length > 0">
+      <li ng-repeat="executorId in executorIds">{{executorId}}</li>
     </ul>
   </div>
 </div>

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/jvm/object/SparkProgressService.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/jvm/object/SparkProgressService.java
@@ -61,7 +61,7 @@ public class SparkProgressService {
   private List<Integer> jobs = new ArrayList<>();
   private Map<Integer, List<Integer>> stagesPerJob = new HashMap<>();
 
-  private List<String> jobIds = new ArrayList<String>();
+  private List<String> executorIds = new ArrayList<String>();
 
   @Inject
   public SparkProgressService(BayeuxServer bayeuxServer) {
@@ -89,7 +89,7 @@ public class SparkProgressService {
     }
 
     if (channel != null) {
-      progress.setJobIds(jobIds);
+      progress.setExecutorIds(executorIds);
       channel.publish(this.localSession, progress, null);
     }
   }
@@ -129,25 +129,25 @@ public class SparkProgressService {
   }
 
 
-  public void jobStart(int jobId, List<String> jobIds) {
+  public void jobStart(int jobId, List<String> executorIds) {
     activeJobId = jobId;
     if (!jobs.contains(jobId)) {
       jobs.add(jobId);
       stagesPerJob.put(jobId, new ArrayList<Integer>());
     }
-    if (!jobIds.isEmpty()) {
-      this.jobIds.clear();
-      this.jobIds.addAll(jobIds);
+    if (!executorIds.isEmpty()) {
+      this.executorIds.clear();
+      this.executorIds.addAll(executorIds);
     }
   }
 
-  public void jobEnd(int jobId, List<String> jobIds) {
+  public void jobEnd(int jobId, List<String> executorIds) {
     if (jobId != activeJobId)
       logger.warning(String.format("Spark job %d was not registered as active.", jobId));
 
-    if (!jobIds.isEmpty()) {
-      this.jobIds.clear();
-      this.jobIds.addAll(jobIds);
+    if (!executorIds.isEmpty()) {
+      this.executorIds.clear();
+      this.executorIds.addAll(executorIds);
     }
   }
 
@@ -288,7 +288,7 @@ public class SparkProgressService {
     private int id;
     private boolean running;
     private ArrayList<StageProgress> stages;
-    private ArrayList<String> jobIds;
+    private ArrayList<String> executorIds;
 
     public boolean isRunning() {
       return running;
@@ -314,17 +314,17 @@ public class SparkProgressService {
       this.stages = stages;
     }
 
-    public ArrayList<String> getJobIds() {
-      return this.jobIds;
+    public ArrayList<String> getExecutorIds() {
+      return this.executorIds;
     }
 
-    public void setJobIds(ArrayList<String> jobIds) {
-      this.jobIds = jobIds;
+    public void setExecutorIds(ArrayList<String> executorIds) {
+      this.executorIds = executorIds;
     }
 
     public JobProgress() {
       this.stages = new ArrayList<StageProgress>();
-      this.jobIds = new ArrayList<String>();
+      this.executorIds = new ArrayList<String>();
     }
 
     public JobProgress(
@@ -334,7 +334,7 @@ public class SparkProgressService {
       this.id = id;
       this.running = running;
       this.stages = new ArrayList<StageProgress>();
-      this.jobIds = new ArrayList<String>();
+      this.executorIds = new ArrayList<String>();
     }
   }
 
@@ -436,7 +436,7 @@ public class SparkProgressService {
   public static class SparkProgress {
 
     private List<JobProgress> jobs;
-    private List<String> jobIds;
+    private List<String> executorIds;
 
     public List<JobProgress> getJobs() {
       return this.jobs;
@@ -446,32 +446,32 @@ public class SparkProgressService {
       this.jobs = jobs;
     }
 
-    public List<String> getJobIds() {
-      return this.jobIds;
+    public List<String> getExecutorIds() {
+      return this.executorIds;
     }
 
-    public void setJobIds(List<String> jobIds) {
-      this.jobIds.clear();
-      this.jobIds.addAll(jobIds);
+    public void setExecutorIds(List<String> executorIds) {
+      this.executorIds.clear();
+      this.executorIds.addAll(executorIds);
     }
 
     public void clear() {
       this.jobs.clear();
-      this.jobIds.clear();
-      this.jobIds.add("Cleared progress");
+      this.executorIds.clear();
+      this.executorIds.add("Cleared progress");
     }
 
     public SparkProgress() {
       this.jobs = new ArrayList<>();
-      this.jobIds = new ArrayList<>();
+      this.executorIds = new ArrayList<>();
     }
 
     public SparkProgress(
         List<JobProgress> jobs,
-        List<String> jobIds) {
+        List<String> executorIds) {
 
       this.jobs = jobs;
-      this.jobIds = jobIds;
+      this.executorIds = executorIds;
     }
   }
 }


### PR DESCRIPTION
- renamed "Spark job IDs" to "Spark _executor_ IDs"
- sparkcontextmanager.js doesn't clutter up $rootScope anymore, instead uses local variables
