### PR TITLE
Added exporting ImageIcon in node transformation

### DIFF
--- a/plugin/node/src/dist/app/transformation.js
+++ b/plugin/node/src/dist/app/transformation.js
@@ -417,6 +417,7 @@ function isCircularObject(node, parents) {
 // end of copy-pasted code
 
 exports.DataFrame = DataFrame;
+exports.ImageIcon = ImageIcon;
 exports.transform = transform;
 exports.transformBack = transformBack;
 exports.isCircularObject = isCircularObject;

--- a/test/protractorWithoutRestartBrowserConf.js
+++ b/test/protractorWithoutRestartBrowserConf.js
@@ -54,7 +54,7 @@ var config = {
     'tests/tutorials/language_demos/python-tutorial.js',
     'tests/tutorials/language_demos/jscript-tutorial.js',
     'tests/tutorials/language_demos/R-tutorial.js',
-    // 'tests/tutorials/language_demos/nodejs-tutorial.js',
+    'tests/tutorials/language_demos/nodejs-tutorial.js',
     'tests/tutorials/standard_visual_api/d3js-tutorial.js',
     'tests/tutorials/standard_visual_api/p5js-tutorial.js',
    // 'tests/tutorials/automate/progress-reporting-tutorial.js',


### PR DESCRIPTION
transformation.js is used in bunsen to get init cells working in publications
and blog entries. To omit code duplication, this exact file is used to get
`transform`, `transformBack`, `DataFrame` etc, and `ImageIcon` is only missing
requirement (it has to be added to `beaker` object).
