### PR TITLE
Support to set histogram legend text via displayNames prop

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/plotconverter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotconverter.js
@@ -586,8 +586,13 @@
                 item.bases = [];
               }
 
-              if(list.length > 1){
-                item.display_name = "dataset" + (i + 1);
+              if(list.length > 1) {
+                if(model.displayNames && model.displayNames.length>0) {
+                    item.display_name = model.displayNames[i]
+                }
+                else {
+                    item.display_name = "dataset" + (i + 1);
+                }
               }
 
               var histvalues = plotUtils.histogram().

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/histogram/Histogram.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/histogram/Histogram.java
@@ -40,6 +40,7 @@ public class Histogram extends AbstractChart {
   private   List<Color>        colors;
   protected List<Number>       data;
   private   List<List<Number>> listData;
+  private List<String> displayNames;
 
 
   private DisplayMode displayMode = DisplayMode.OVERLAP;
@@ -168,5 +169,13 @@ public class Histogram extends AbstractChart {
 
   public List<List<Number>> getListData() {
     return listData;
+  }
+
+  public List<String> getDisplayNames() {
+        return displayNames;
+  }
+
+  public void setDisplayNames(List<String> displayNames) {
+        this.displayNames = displayNames;
   }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/HistogramSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/HistogramSerializer.java
@@ -56,6 +56,7 @@ public class HistogramSerializer extends AbstractChartSerializer<Histogram> {
     jgen.writeObjectField("normed", histogram.getNormed());
     jgen.writeObjectField("log", histogram.getLog());
     jgen.writeObjectField("displayMode", histogram.getDisplayMode());
+    jgen.writeObjectField("displayNames", histogram.getDisplayNames());
 
     jgen.writeEndObject();
 


### PR DESCRIPTION
Currently the Histogram labels data in the legend with hard coded labels, "dataset-1", "dataset-2" etc. This change allows the user to set the labels via a "displayNames" property. Example:

```groovy
r = new Random()
new Histogram(
  data: [ 
          (1..1000).collect { r.nextGaussian() * 10.0d },
          (1..1000).collect { r.nextGaussian() * 20.0d } 
        ],
  binCount:100,
  displayNames: ["stddev=10","stddev=20"]
)
```