### PR TITLE
Enhanced plot styling

### DIFF
--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -176,6 +176,12 @@
 
           $(window).resize(scope.resizeFunction);
 
+          if(model['customStyles']) {
+              $("<style>"+model['customStyles'].map(function(s) { 
+                  return "#" + scope.id + ' ' + s; 
+              }).join('\n') + "\n</style>").prependTo(element.find('.plot-plotcontainer'));
+          }
+
           // set title
           scope.jqplottitle = element.find("#plotTitle");
           scope.jqplottitle.text(model.title).css("width", plotSize.width);
@@ -608,7 +614,7 @@
               var y = mapY(scope.focus.yl) + scope.labelPadding.y;
 							var rpipeText = {
                 "id": "label_x_" + i,
-                "class": "plot-label",
+                "class": "plot-label plot-label-x",
                 "text": labels[i],
                 "x": x,
                 "y": y,
@@ -645,7 +651,7 @@
 
 							var rpipeText = {
                 "id": "label_y_" + i,
-                "class": "plot-label",
+                "class": "plot-label plot-label-y",
                 "text": labels[i],
                 "x": x,
                 "y": y,
@@ -2080,7 +2086,11 @@
             width: plotTitle.width(),
             height: plotUtils.getActualCss(plotTitle, 'outerHeight')
           });
-          plotUtils.addInlineStyles(svg);
+
+          // Custom styles added by user
+          var cellModel = scope.getCellModel();
+          var extraStyles = cellModel['custom_styles'] ? cellModel['custom_styles'] : '';
+          plotUtils.addInlineStyles(svg, extraStyles);
 
           return svg;
         };

--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -137,6 +137,8 @@
 
         scope.id = 'bko-plot-' + bkUtils.generateId(6);
         element.find('.plot-plotcontainer').attr('id', scope.id);
+        element.find('.plot-title').attr('class', 'plot-title ' + 'plot-title-' + scope.id);
+
         if (!scope.model.disableContextMenu) {
           $.contextMenu({
             selector: '#' + scope.id,
@@ -176,6 +178,7 @@
 
           $(window).resize(scope.resizeFunction);
 
+          // Apply  advanced custom styles set directly by user
           if(model['customStyles']) {
               $("<style>"+model['customStyles'].map(function(s) { 
                   return "#" + scope.id + ' ' + s; 
@@ -185,6 +188,23 @@
           // set title
           scope.jqplottitle = element.find("#plotTitle");
           scope.jqplottitle.text(model.title).css("width", plotSize.width);
+
+          // Apply any specific element styles (labelStyle,elementStyle, etc)
+          if(model['elementStyles']) {
+              var styles = [];
+              for(var style in model['elementStyles']) {
+                  styles.push('#' + scope.id + ' ' + style + ' { ' + model['elementStyles'][style] + '}');
+              }
+              $("<style>\n" + styles.join('\n') + "\n</style>").prependTo(element.find('.plot-plotcontainer'));
+
+              // Title style has to be handlded separately because it sits in a separate
+              // div outside the hierachy the rest of the plot is in
+              if(model['elementStyles']['.plot-title']) {
+                  $("<style>\n" + '.plot-title-' + scope.id + ' { ' + 
+                          model['elementStyles']['.plot-title'] + 
+                          "}\n</style>").prependTo(element.find('.plot-title-' + scope.id));
+              }
+          }
 
           scope.maing = d3.select(element[0]).select("#maing");
           scope.gridg = d3.select(element[0]).select("#gridg");
@@ -2084,12 +2104,21 @@
           plotUtils.translateChildren(svg, 0, titleOuterHeight);
           plotUtils.addTitleToSvg(svg, plotTitle, {
             width: plotTitle.width(),
-            height: plotUtils.getActualCss(plotTitle, 'outerHeight')
+            height: plotUtils.getActualCss(plotTitle, 'outerHeight') 
           });
 
           // Custom styles added by user
           var cellModel = scope.getCellModel();
-          var extraStyles = cellModel['custom_styles'] ? cellModel['custom_styles'] : '';
+          var extraStyles = [];
+          if(cellModel.elementStyles) {
+              for(var style in cellModel.elementStyles) {
+                  elementStyles.push(style + ' {' + cellModel.elementStyles[style] + '}');
+              }
+          }
+
+          if(cellModel.custom_styles) 
+              extraStyles.append(customStyles);
+
           plotUtils.addInlineStyles(svg, extraStyles);
 
           return svg;

--- a/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
+++ b/core/src/main/web/outputdisplay/bko-plot/bko-plot.js
@@ -2117,7 +2117,7 @@
           }
 
           if(cellModel.custom_styles) 
-              extraStyles.append(customStyles);
+              extraStyles = extraStyles.concat(cellModel.custom_styles);
 
           plotUtils.addInlineStyles(svg, extraStyles);
 

--- a/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
@@ -37,8 +37,9 @@
             "width": model.init_width != null ? model.init_width : 1200,
             "height": model.init_height != null ? model.init_height : 350
           },
-          customStyles: model.custom_styles ? model.custom_styles : ''
-        };
+          customStyles: model.custom_styles ? model.custom_styles : '',
+          elementStyles: model.element_styles ? model.element_styles : ''
+        }
       } else {
         newmodel = {
           showLegend: model.showLegend,

--- a/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotformatter.js
@@ -36,7 +36,8 @@
           plotSize: {
             "width": model.init_width != null ? model.init_width : 1200,
             "height": model.init_height != null ? model.init_height : 350
-          }
+          },
+          customStyles: model.custom_styles ? model.custom_styles : ''
         };
       } else {
         newmodel = {

--- a/core/src/main/web/outputdisplay/bko-plot/plotutils.js
+++ b/core/src/main/web/outputdisplay/bko-plot/plotutils.js
@@ -574,7 +574,7 @@
         return elementStyles;
       },
 
-      addInlineStyles: function(element) {
+      addInlineStyles: function(element, extraStyles) {
         var styleEl = document.createElement('style');
         styleEl.setAttribute('type', 'text/css');
         var elementStyles = this.getElementStyles(element);
@@ -590,8 +590,13 @@
           fontWeight: 'bold',
           fontStyle: 'normal'
         });
+        
+        var extraStylesCss = '';
+        if(extraStyles) {
+            extraStylesCss = extraStyles.join('\n');
+        }
 
-        styleEl.innerHTML = '<![CDATA[\n' + elementStyles + '\n]]>';
+        styleEl.innerHTML = '<![CDATA[\n' + elementStyles + '\n' + extraStylesCss + '\n]]>';
         var defsEl = document.createElement('defs');
         defsEl.appendChild(styleEl);
         element.insertBefore(defsEl, element.firstChild);

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/Chart.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/Chart.java
@@ -16,12 +16,17 @@
 
 package com.twosigma.beaker.chart;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.twosigma.beaker.chart.legend.LegendLayout;
 import com.twosigma.beaker.chart.legend.LegendPosition;
 
 public class Chart extends ObservableChart{
   protected int initWidth  = 640;
   protected int initHeight = 480;
+  protected List<String> customStyles = new ArrayList();
+
   protected String  title;
   protected Boolean showLegend;
   protected boolean        useToolTip     = true;
@@ -90,4 +95,13 @@ public class Chart extends ObservableChart{
     this.legendLayout = legendLayout;
     return this;
   }
+  
+  public List<String> getCustomStyles() {
+    return customStyles;
+  }
+
+  public void setCustomStyles(List<String> customStyle) {
+        this.customStyles = customStyle;
+  }
+
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/Chart.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/Chart.java
@@ -17,7 +17,9 @@
 package com.twosigma.beaker.chart;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.twosigma.beaker.chart.legend.LegendLayout;
 import com.twosigma.beaker.chart.legend.LegendPosition;
@@ -26,6 +28,7 @@ public class Chart extends ObservableChart{
   protected int initWidth  = 640;
   protected int initHeight = 480;
   protected List<String> customStyles = new ArrayList();
+  protected Map<String,String> elementStyles = new HashMap<>();
 
   protected String  title;
   protected Boolean showLegend;
@@ -101,7 +104,50 @@ public class Chart extends ObservableChart{
   }
 
   public void setCustomStyles(List<String> customStyle) {
-        this.customStyles = customStyle;
+    this.customStyles = customStyle;
   }
 
+  public String getLabelStyle() {
+      return this.elementStyles.get(".plot-label");
+  }
+  
+  public void setLabelStyle(String style) {
+      this.elementStyles.put(".plot-label", style);
+  }
+  
+  public String getLabelXStyle() {
+      return this.elementStyles.get(".plot-label-x");
+  }
+  
+  public void setLabelXStyle(String style) {
+      this.elementStyles.put(".plot-label-x", style);
+  }
+  
+  public String getLabelYStyle() {
+      return this.elementStyles.get(".plot-label-y");
+  }
+  
+  public void setLabelYStyle(String style) {
+      this.elementStyles.put(".plot-label-y", style);
+  }
+
+  public String getGridLineStyle() {
+      return this.elementStyles.get(".plot-gridline");
+  }
+
+  public void setGridLineStyle(String style) {
+      this.elementStyles.put(".plot-gridline", style);
+  }
+  
+  public String getTitleStyle() {
+      return this.elementStyles.get(".plot-title");
+  }
+
+  public void setTitleStyle(String style) {
+      this.elementStyles.put(".plot-title", style);
+  }
+  
+  public Map<String,String> getElementStyles() {
+      return this.elementStyles;
+  }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/ChartSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/ChartSerializer.java
@@ -43,5 +43,6 @@ public abstract class ChartSerializer<T extends Chart> extends ObservableChartSe
     jgen.writeObjectField("use_tool_tip", chart.getUseToolTip());
     jgen.writeObjectField("legend_position", chart.getLegendPosition());
     jgen.writeObjectField("legend_layout", chart.getLegendLayout());
+    jgen.writeObjectField("custom_styles", chart.getCustomStyles());
   }
 }

--- a/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/ChartSerializer.java
+++ b/plugin/jvm/src/main/java/com/twosigma/beaker/chart/serializer/ChartSerializer.java
@@ -44,5 +44,6 @@ public abstract class ChartSerializer<T extends Chart> extends ObservableChartSe
     jgen.writeObjectField("legend_position", chart.getLegendPosition());
     jgen.writeObjectField("legend_layout", chart.getLegendLayout());
     jgen.writeObjectField("custom_styles", chart.getCustomStyles());
+    jgen.writeObjectField("element_styles", chart.getElementStyles());
   }
 }


### PR DESCRIPTION
This change lets the user style plot elements directly using CSS.

Note: this is an updated version of https://github.com/twosigma/beaker-notebook/pull/4895 and supercedes it.

There are two levels of styling this allows - the "normal" level and "advanced".

## Normal Level Styling

The normal level offers three new plot properties for setting styles:

 * labelStyle (and also labelXStyle and labelYStyle)
 * titleStyle
 * gridLineStyle

These can be set to any CSS styles applicable to the relevant plot elements. For example, `font-style: bold` or `font-size: 32px`, etc.

Example code:

```groovy
r = new Random()
new Plot(title: "Random Gaussian Points",
         labelStyle: "font-size:32px; font-weight: bold; font-family: courier; fill: green;",
         gridLineStyle:  "stroke: purple; stroke-width: 3;",
         titleStyle: "color: green;"
        ) \
  << new Points(
                x: (1..1000).collect { r.nextGaussian() * 10.0d },
                y: (1..1000).collect { r.nextGaussian() * 20.0d }
               )
```

**Result**:

![image](https://cloud.githubusercontent.com/assets/138868/19992043/fe59931a-a210-11e6-8064-8aa445f52ae1.png)

## Advanced level styling

This level injects complete CSS style blocks into the code with minimal support to scope the styles to the plot at hand. Using this feature is not recommended because the styles can escape and affect other elements of the page or other plots if not used carefully. However I left this in as it does allow a level of flexibility that can help in situations where no other solution will do.

Example code:

```groovy
r = new Random()
new Plot(title: "Random Gaussian Points",
         customStyles: [
           ".plot-label { font-size:32px; font-weight: bold; font-family: courier; fill: green;}",
           ".plot-gridline { stroke: purple; stroke-width: 3; }",
         ]
        ) \
  << new Points(
                x: (1..1000).collect { r.nextGaussian() * 10.0d },
                y: (1..1000).collect { r.nextGaussian() * 20.0d }
               )
```


Result:

![image](https://cloud.githubusercontent.com/assets/138868/19949451/1f93c116-a128-11e6-80e0-2a9aea152fd0.png)
