### PR TITLE
#4950  Javascript evaluation: when returned a function nothing is shown as output

### DIFF
--- a/core/src/main/web/plugin/evaluator/javaScript.js
+++ b/core/src/main/web/plugin/evaluator/javaScript.js
@@ -329,9 +329,9 @@ define(function(require, exports, module) {
               beakerObj.clearOutput();
             }
           } else {
-              if(typeof output === 'function') {
-                  output = output.toString();
-              }
+            if(typeof output === 'function') {
+                output = output.toString();
+            }
             bkHelper.receiveEvaluationUpdate(modelOutput, {status: "FINISHED", payload: output}, PLUGIN_NAME);
             deferred.resolve(output);
             beakerObj.clearOutput();

--- a/core/src/main/web/plugin/evaluator/javaScript.js
+++ b/core/src/main/web/plugin/evaluator/javaScript.js
@@ -329,6 +329,9 @@ define(function(require, exports, module) {
               beakerObj.clearOutput();
             }
           } else {
+              if(typeof output === 'function') {
+                  output = output.toString();
+              }
             bkHelper.receiveEvaluationUpdate(modelOutput, {status: "FINISHED", payload: output}, PLUGIN_NAME);
             deferred.resolve(output);
             beakerObj.clearOutput();


### PR DESCRIPTION
If the javascript to evaluate is a function, the result of the evaluation is an object (containing basically the body of such function). The output field resolver expects a string and is not able to handle properly an object. The solution proposed tranforms the function in a string containing its body.