### PR TITLE
Add the pomegranate library, allowing for dependency management in Clojure.

### DIFF
--- a/plugin/clojure/build.gradle
+++ b/plugin/clojure/build.gradle
@@ -34,7 +34,8 @@ sourceSets.main {
 
 dependencies {
   provided project(':plugin:jvm')
-  compile group: 'org.clojure', name: 'clojure', version: '1.7.0'
+  compile group: 'org.clojure', name: 'clojure', version: '1.8.0'
+  compile group: 'com.cemerick', name: 'pomegranate', version: '0.3.1'
 }
 
 compileJava {


### PR DESCRIPTION
cemerick's pomegranate library is the same one used in the popular Leiningen package manager (https://github.com/technomancy/leiningen/blob/master/leiningen-core/project.clj#L10)

This provides functionality similar to Groovy's `@Grab` allowing for code like:

```
(require '[cemerick.pomegranate :as pom])
(pom/add-dependencies :coordinates '[[funimage "0.1.94"]]
                     :repositories (merge cemerick.pomegranate.aether/maven-central
                                          {"imagej-releases" "http://maven.imagej.net/content/repositories/releases/"}))
```

This fetches the target artifact, the required dependencies, and configures the classpath respectively.

This does not provide full Leiningen support; however, it replaces the need for the javascript hacks presented in issue https://github.com/twosigma/beaker-notebook/issues/3471 and the mention for leiningen support in https://github.com/twosigma/beaker-notebook/issues/1311. 