### PR TITLE
PR for issue #5098 "interrupt should not query kernel"

### DIFF
--- a/beakerx/js/src/extension.js
+++ b/beakerx/js/src/extension.js
@@ -87,7 +87,7 @@ define([
   /**
    * In Python there is no any callback, only beakerx kernels response to this message.
    */
-  function getControllCommandList(callBack) {
+  function getControlCommandList(callBack) {
     var kernel_control_target_name = "kernel.control.channel";
     var comm = Jupyter.notebook.kernel.comm_manager.new_comm(kernel_control_target_name, null, null, null, utils.uuid());
     comm.on_msg(function(resp) {
@@ -100,7 +100,7 @@ define([
   }
 
   function interrupt() {
-    getControllCommandList(function(resp) {
+    getControlCommandList(function(resp) {
       if (undefined != resp.content.data) {
         if (_.contains(resp.content.data.kernel_control_response, "kernel_interrupt")) {
           console.log("beakerx kernel detected, kernel interrupt");
@@ -123,7 +123,7 @@ define([
   
 
   function setImportsAndClasspath() {
-    getControllCommandList(function(resp) {
+    getControlCommandList(function(resp) {
       if (undefined != resp.content.data) {
         if (_.contains(resp.content.data.kernel_control_response, "get_default_shell") &&
             _.contains(resp.content.data.kernel_control_response, "classpath") &&

--- a/kernel/groovy/src/main/java/com/twosigma/beaker/groovy/handler/GroovyKernelInfoHandler.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beaker/groovy/handler/GroovyKernelInfoHandler.java
@@ -57,6 +57,7 @@ public class GroovyKernelInfoHandler extends KernelHandler<Message> {
     map1.put("nbconverter_exporter", "");
     map.put("language_info", map1);
     map.put("banner", "BeakerX kernel for Apache Groovy");
+    map.put("beakerx", true);
     map.put("help_links", new ArrayList<String>());
     reply.setContent(map);
     reply.setHeader(new Header(KERNEL_INFO_REPLY, message.getHeader().getSession()));

--- a/kernel/java/src/main/java/com/twosigma/beaker/javash/handler/JavaKernelInfoHandler.java
+++ b/kernel/java/src/main/java/com/twosigma/beaker/javash/handler/JavaKernelInfoHandler.java
@@ -54,6 +54,7 @@ public class JavaKernelInfoHandler extends KernelHandler<Message> {
     map1.put("nbconverter_exporter", "");
     map.put("language_info", map1);
     map.put("banner", "BeakerX kernel for Java");
+    map.put("beakerx", true);
     map.put("help_links", new ArrayList<String>());
     reply.setContent(map);
     reply.setHeader(new Header(KERNEL_INFO_REPLY, message.getHeader().getSession()));

--- a/kernel/scala/src/main/java/com/twosigma/beaker/scala/handler/ScalaKernelInfoHandler.java
+++ b/kernel/scala/src/main/java/com/twosigma/beaker/scala/handler/ScalaKernelInfoHandler.java
@@ -54,6 +54,7 @@ public class ScalaKernelInfoHandler extends KernelHandler<Message> {
     map1.put("nbconverter_exporter", "");
     map.put("language_info", map1);
     map.put("banner", "BeakerX kernel for Scala");
+    map.put("beakerx", true);
     map.put("help_links", new ArrayList<String>());
     reply.setContent(map);
     reply.setHeader(new Header(KERNEL_INFO_REPLY, message.getHeader().getSession()));


### PR DESCRIPTION
Fixed. 
But one problem stay :
if we have our "beakerx" kernel then no problem.
But on python like this : I ask for "control commands" and do not get any answer.
And I can not define does I already asked for  "control commands" or not.
So on python kernels I asked for them everytime when I push interrupt.

To fix this we need to add callback handler with empty command list in python kernel. 