### PR TITLE
Enable jitpack building

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@
  */
 import org.apache.tools.ant.taskdefs.condition.Os
 
+
 task wrapper(type: Wrapper) {
   gradleVersion = '3.5'
 }
@@ -22,6 +23,8 @@ task wrapper(type: Wrapper) {
 project("kernel").subprojects {
   apply plugin: 'jacoco'
   apply plugin: 'java'
+  apply plugin: 'maven'
+
   jacoco {
     toolVersion = "0.7.8"
   }


### PR DESCRIPTION
According to https://jitpack.io/docs/BUILDING/, this PR should be sufficient to allow people to consume BeakerX dependency with Maven and/or Gradle.