### PR TITLE
#5259: add autotranslation comm back in js

### DIFF
--- a/beakerx/js/src/extension.js
+++ b/beakerx/js/src/extension.js
@@ -82,6 +82,12 @@ define([
           window.beaker[msg.content.data.name] = JSON.parse(msg.content.data.value);
         });
       });
+    kernel.comm_manager.register_target('beaker.autotranslation',
+      function(comm, msg) {
+        comm.on_msg(function(msg) {
+          window.beaker[msg.content.data.name] = JSON.parse(msg.content.data.value);
+        });
+      });
     setBeakerxKernelParameters();
   });
 


### PR DESCRIPTION
My bad. When doing getCodeCells, I simply changed the comm name on lasha's change. Actually should make a copy.