### PR TITLE
#5287 Adjust scala imports

### DIFF
--- a/kernel/scala/src/main/java/com/twosigma/beaker/scala/evaluator/ScalaEvaluator.java
+++ b/kernel/scala/src/main/java/com/twosigma/beaker/scala/evaluator/ScalaEvaluator.java
@@ -346,10 +346,7 @@ public class ScalaEvaluator implements Evaluator {
       if (!imports.isEmpty()) {
         for (int i = 0; i < imports.size(); i++) {
           String imp = imports.get(i).trim();
-          if (imp.startsWith("import"))
-            imp = imp.substring(6).trim();
-          if (imp.endsWith(".*"))
-            imp = imp.substring(0,imp.length()-1) + "_";
+          imp = adjustImport(imp);
           if(!imp.isEmpty()) {
             logger.debug("importing : {}", imp);
             if(!shell.addImport(imp))
@@ -386,7 +383,22 @@ public class ScalaEvaluator implements Evaluator {
     }
   }
 
-  
+  private String adjustImport(String imp) {
+    if (imp.startsWith("import"))
+      imp = imp.substring(6).trim();
+    // Scala doesn't need "static"
+    if (imp.startsWith("static"))
+      imp = imp.substring(6).trim();
+    // May need more of these, but all Scala keywords that aren't Java keywords is probably overkill
+    if (imp.contains(".object.")) {
+      imp = imp.replace(".object.", ".`object`.");
+    }
+    if (imp.endsWith(".*"))
+      imp = imp.substring(0,imp.length()-1) + "_";
+    return imp;
+  }
+
+
   protected ClassLoader newAutoCompleteClassLoader() throws MalformedURLException
   {
     logger.debug("creating new autocomplete loader");
@@ -412,10 +424,7 @@ public class ScalaEvaluator implements Evaluator {
     if (!imports.isEmpty()) {
       for (int i = 0; i < imports.size(); i++) {
         String imp = imports.get(i).trim();
-        if (imp.startsWith("import"))
-          imp = imp.substring(6).trim();
-        if (imp.endsWith(".*"))
-          imp = imp.substring(0,imp.length()-1) + "_";
+        imp = adjustImport(imp);
         if(!imp.isEmpty()) {
           if(!acshell.addImport(imp))
             logger.warn("ERROR: cannot add import '{}'", imp);

--- a/kernel/scala/src/test/java/com/twosigma/beaker/scala/evaluator/object/ImportTestHelper.java
+++ b/kernel/scala/src/test/java/com/twosigma/beaker/scala/evaluator/object/ImportTestHelper.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright 2017 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.twosigma.beaker.scala.evaluator.object;
+
+/**
+ * This class exists solely for testing the Scala import functionality.
+ * The package name (containing "object") is significant.
+ *
+ * @see com.twosigma.beaker.scala.evaluator.ScalaEvaluatorTest
+ */
+
+public class ImportTestHelper {
+  public static void staticMethod() {
+  }
+}


### PR DESCRIPTION
The unit test is a little indirect, because failed imports log a message but don't otherwise change the visible state of the evaluator.