### PR TITLE
5356 Fix scala and clojure autocompletion

### DIFF
--- a/kernel/clojure/src/main/java/com/twosigma/beaker/clojure/ClojureEvaluator.java
+++ b/kernel/clojure/src/main/java/com/twosigma/beaker/clojure/ClojureEvaluator.java
@@ -336,6 +336,6 @@ public class ClojureEvaluator implements Evaluator {
 
     }
 
-    return new AutocompleteResult(result, caretPosition);
+    return new AutocompleteResult(result, i);
   }
 }

--- a/kernel/clojure/src/test/java/com/twosigma/beaker/clojure/ClojureAutocompleteTest.java
+++ b/kernel/clojure/src/test/java/com/twosigma/beaker/clojure/ClojureAutocompleteTest.java
@@ -49,6 +49,7 @@ public class ClojureAutocompleteTest {
     AutocompleteResult autocomplete = clojureEvaluator.autocomplete("def", 3);
     //then
     Assertions.assertThat(autocomplete.getMatches()).isNotEmpty();
+    Assertions.assertThat(autocomplete.getStartIndex()).isEqualTo(0);
   }
 
 }

--- a/kernel/groovy/src/test/java/com/twosigma/beaker/groovy/evaluator/GroovyEvaluatorAutocompleteTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beaker/groovy/evaluator/GroovyEvaluatorAutocompleteTest.java
@@ -36,6 +36,7 @@ public class GroovyEvaluatorAutocompleteTest {
                     "System.out.printl",17);
     //then
     Assertions.assertThat(autocomplete.getMatches()).isNotEmpty();
+    Assertions.assertThat(autocomplete.getStartIndex()).isEqualTo(11);
   }
 
   @Test
@@ -46,5 +47,6 @@ public class GroovyEvaluatorAutocompleteTest {
             "System.out.printl",27);
     //then
     Assertions.assertThat(autocomplete.getMatches()).isNotEmpty();
+    Assertions.assertThat(autocomplete.getStartIndex()).isEqualTo(21);
   }
 }

--- a/kernel/scala/src/main/java/com/twosigma/beaker/scala/evaluator/ScalaEvaluator.java
+++ b/kernel/scala/src/main/java/com/twosigma/beaker/scala/evaluator/ScalaEvaluator.java
@@ -205,17 +205,15 @@ public class ScalaEvaluator implements Evaluator {
   @Override
   public AutocompleteResult autocomplete(String code, int caretPosition) {
     if(acshell != null) {
+      int lineStart = 0;
       String [] sv = code.substring(0, caretPosition).split("\n");
       for ( int i=0; i<sv.length-1; i++) {
         acshell.evaluate2(sv[i]);
         caretPosition -= sv[i].length()+1;
+        lineStart += sv[i].length()+1;
       }
-      ArrayList<CharSequence> ret = acshell.autocomplete(sv[sv.length-1], caretPosition);
-      ArrayList<String> r2 = new ArrayList<String>();
-      for(CharSequence c : ret)
-        r2.add(c.toString());
-        logger.debug("return: {}", r2);
-      return new AutocompleteResult(r2, caretPosition);
+      AutocompleteResult lineCompletion = acshell.autocomplete(sv[sv.length-1], caretPosition);
+      return new AutocompleteResult(lineCompletion.getMatches(), lineCompletion.getStartIndex() + lineStart);
     }
     return null;
   }

--- a/kernel/scala/src/main/scala/com/twosigma/beaker/scala/evaluator/ScalaEvaluatorGlue.scala
+++ b/kernel/scala/src/main/scala/com/twosigma/beaker/scala/evaluator/ScalaEvaluatorGlue.scala
@@ -16,8 +16,10 @@
  
 package com.twosigma.beaker.scala.evaluator;
 
-import java.util.ArrayList
+import java.util
+import java.util.{ArrayList, function}
 
+import com.twosigma.beaker.autocomplete.AutocompleteResult
 import com.twosigma.beaker.jvm.`object`.SimpleEvaluationObject
 
 import scala.tools.jline_embedded.console.completer.Completer
@@ -112,10 +114,12 @@ class ScalaEvaluatorGlue(val cl: ClassLoader, var cp: String, val replClassdir: 
     }
     out.clrOutputHandler();
   }
-  
-  def autocomplete(buf: String, len : Integer): ArrayList[CharSequence] = {
+
+  def autocomplete(buf: String, len : Integer): AutocompleteResult = {
     val maybes = new java.util.ArrayList[CharSequence];
-    completer.complete(buf,  len, maybes);
-    maybes;
+    val offset = completer.complete(buf,  len, maybes);
+    // There must be a better way to do this
+    import scala.collection.JavaConverters._
+    new AutocompleteResult(maybes.asScala.map(_.toString).asJava, offset)
   }
 }

--- a/kernel/scala/src/test/java/com/twosigma/beaker/scala/evaluator/ScalaAutocompleteTest.java
+++ b/kernel/scala/src/test/java/com/twosigma/beaker/scala/evaluator/ScalaAutocompleteTest.java
@@ -60,6 +60,16 @@ public class ScalaAutocompleteTest {
     AutocompleteResult autocomplete = scalaEvaluator.autocomplete("val numbers = Li", 16);
     //then
     Assertions.assertThat(autocomplete.getMatches()).isNotEmpty();
+    Assertions.assertThat(autocomplete.getStartIndex()).isEqualTo(14);
+  }
+
+  @Test
+  public void autocomplete_multiLineOffsetCorrect() throws Exception {
+    //when
+    AutocompleteResult autocomplete = scalaEvaluator.autocomplete("val x = 3\nval numbers = Li", 26);
+    //then
+    Assertions.assertThat(autocomplete.getMatches()).isNotEmpty();
+    Assertions.assertThat(autocomplete.getStartIndex()).isEqualTo(24);
   }
 
   private static KernelParameters kernelParameters() {


### PR DESCRIPTION
Proposed fixes for #5356.

I think this fixes the most egregious problems.  The clojure completer is very broad.  I'm not a clojure user so I don't know if this is desirable.  The scala completer has a feature where it returns type information when you ask it to complete an already complete method name again (automatically raises the verbosity).  That's useful information but not actually a valid replacement, so maybe it should be suppressed or displayed by some other means.