### PR TITLE
#5318 - build loses focus

### DIFF
--- a/kernel/base/build.gradle
+++ b/kernel/base/build.gradle
@@ -74,4 +74,8 @@ task prepareBuildVerion() {
   }
 }
 
+test {
+    systemProperties 'java.awt.headless': "true"
+}
+
 compileJava.dependsOn prepareBuildVerion


### PR DESCRIPTION
This java icon shows up only on OS X and reason was that one class of unit tests (ImageIconSerializerTest) used ImageIcon from javax.swing.

To resolve that i setup awt (Which i8s subclass of swing) to headless mode and right now there's no  extra process.