### PR TITLE
#5508 Generate useful error output when the input is incomplete

### DIFF
--- a/kernel/scala/src/main/scala/com/twosigma/beaker/scala/evaluator/ScalaEvaluatorGlue.scala
+++ b/kernel/scala/src/main/scala/com/twosigma/beaker/scala/evaluator/ScalaEvaluatorGlue.scala
@@ -22,7 +22,7 @@ import com.twosigma.beakerx.jvm.`object`.SimpleEvaluationObject
 import scala.tools.jline_embedded.console.completer.Completer
 import scala.tools.nsc.Settings
 import scala.tools.nsc.interpreter.Completion.Candidates
-import scala.tools.nsc.interpreter.Results.Success
+import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 import scala.tools.nsc.interpreter.{Completion, IMain, JList, PresentationCompilerCompleter}
 
 case class ResetState(val state: String);
@@ -88,7 +88,8 @@ class ScalaEvaluatorGlue(val cl: ClassLoader, var cp: String, val replClassdir: 
     try {
       interpreter.interpret(code) match {
         case Success => "";
-        case _ => baos.toString();
+        case Incomplete => "input is incomplete"
+        case Error => baos.toString();
       }
     } catch {
       case ex: Throwable => ex.toString();
@@ -102,7 +103,8 @@ class ScalaEvaluatorGlue(val cl: ClassLoader, var cp: String, val replClassdir: 
     try {
       interpreter.interpret(code) match {
         case Success => out.finished(getOut.asInstanceOf[java.lang.Object]);
-        case _ => out.error(baos.toString());
+        case Incomplete => out.error("input is incomplete")
+        case Error => out.error(baos.toString());
       }
     } catch {
       case ex: Throwable => out.error(ex);

--- a/kernel/scala/src/test/java/com/twosigma/beakerx/scala/evaluator/ScalaEvaluatorTest.java
+++ b/kernel/scala/src/test/java/com/twosigma/beakerx/scala/evaluator/ScalaEvaluatorTest.java
@@ -108,4 +108,17 @@ public class ScalaEvaluatorTest {
     //then
     Assertions.assertThat(seo.getStatus()).isEqualTo(FINISHED);
   }
+
+  @Test
+  public void incompleteInput_shouldBeDetected() throws Exception {
+    //given
+    String code = "1 to 10 map { i => i * 2";
+    SimpleEvaluationObject seo = new SimpleEvaluationObject(code, new ExecuteCodeCallbackTest());
+    //when
+    scalaEvaluator.evaluate(seo, code);
+    waitForResult(seo);
+    //then
+    Assertions.assertThat(seo.getStatus()).isEqualTo(ERROR);
+    Assertions.assertThat((String)seo.getPayload()).contains("incomplete");
+  }
 }


### PR DESCRIPTION
This addresses #5508 by producing an error message for the interpreter's `Incomplete` return state.