### PR TITLE
PR for issue #5247 "make repr of null configurable"

### DIFF
--- a/demoFiles/showNullExecutionResult.ipynb
+++ b/demoFiles/showNullExecutionResult.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "true"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "com.twosigma.beakerx.kernel.Kernel.showNullExecutionResult\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "null"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "com.twosigma.beakerx.kernel.Kernel.showNullExecutionResult = true;\n",
+    "String seeNullString = null;\n",
+    "seeNullString"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "com.twosigma.beakerx.kernel.Kernel.showNullExecutionResult = false;\n",
+    "String noNullString = null;\n",
+    "noNullString"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Groovy",
+   "language": "groovy",
+   "name": "groovy"
+  },
+  "language_info": {
+   "codemirror_mode": "groovy",
+   "file_extension": ".groovy",
+   "mimetype": "",
+   "name": "Groovy",
+   "nbconverter_exporter": "",
+   "version": "2.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/kernel/base/src/main/java/com/twosigma/beakerx/SerializeToString.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/SerializeToString.java
@@ -20,6 +20,7 @@ import com.github.lwhite1.tablesaw.api.Table;
 import com.twosigma.beakerx.chart.xychart.Plot;
 import com.twosigma.beakerx.chart.xychart.plotitem.XYGraphics;
 import com.twosigma.beakerx.fileloader.CsvPlotReader;
+import com.twosigma.beakerx.kernel.Kernel;
 import com.twosigma.beakerx.mimetype.MIMEContainer;
 import com.twosigma.beakerx.table.TableDisplay;
 import com.twosigma.beakerx.widgets.DisplayableWidget;
@@ -34,10 +35,17 @@ import static com.twosigma.beakerx.mimetype.MIMEContainer.Text;
 public class SerializeToString {
 
   public static MIMEContainer doit(final Object input) {
+    MIMEContainer ret = null;
     if (input == null) {
-      return Text("null");
+      if(Kernel.showNullExecutionResult){
+        ret = Text("null");
+      }else{
+        ret = HIDDEN;
+      }
+    }else{
+      ret = getMimeContainer(input);
     }
-    return getMimeContainer(input);
+    return ret;
   }
 
   private static MIMEContainer getMimeContainer(final Object input) {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/kernel/Kernel.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/kernel/Kernel.java
@@ -41,6 +41,7 @@ public abstract class Kernel implements KernelFunctionality {
   private static final Logger logger = LoggerFactory.getLogger(Kernel.class);
 
   public static String OS = System.getProperty("os.name").toLowerCase();
+  public static boolean showNullExecutionResult = true;
 
   private String sessionId;
   private KernelSocketsFactory kernelSocketsFactory;


### PR DESCRIPTION
In the example offered by Hadim, in `Kernel` uses `parameter`from some 3rd party lib.
`org.scijava.plugin.Parameter` 
Our libs do not have it. So, I implement it like `static` variable :

`com.twosigma.beakerx.kernel.Kernel.showNullExecutionResult` default value is `true`