### PR TITLE
#5579 Convert error payload to string safely

### DIFF
--- a/kernel/base/src/main/java/com/twosigma/beakerx/kernel/msg/MessageCreator.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/kernel/msg/MessageCreator.java
@@ -210,7 +210,7 @@ public class MessageCreator {
     map4.put("ename", ename);
     map4.put("evalue", evalue);
     map4.put("traceback", markRed(errorMessage));
-    map4.put(ERROR_MESSAGE, (String) seo.getPayload());
+    map4.put(ERROR_MESSAGE, seo.getPayload().toString());
     reply.setContent(map4);
     return new MessageHolder(SocketEnum.IOPUB_SOCKET, reply);
   }

--- a/kernel/base/src/test/java/com/twosigma/beakerx/jupyter/msg/MessageCreatorTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/jupyter/msg/MessageCreatorTest.java
@@ -182,4 +182,16 @@ public class MessageCreatorTest {
     assertThat(messages.get(1).getSocketType()).isEqualTo(SocketEnum.SHELL_SOCKET);
     assertThat(messages.get(1).getMessage().type()).isEqualTo(JupyterMessages.EXECUTE_REPLY);
   }
+
+  @Test
+  public void createMessageWithError_whenException() throws Exception {
+    //given
+    seo.error(new RuntimeException("oops"));
+    //when
+    List<MessageHolder> messages = messageCreator.createMessage(seo);
+    //then
+    assertThat(messages).isNotEmpty();
+    assertThat(messages.get(1).getSocketType()).isEqualTo(SocketEnum.SHELL_SOCKET);
+    assertThat(messages.get(1).getMessage().type()).isEqualTo(JupyterMessages.EXECUTE_REPLY);
+  }
 }


### PR DESCRIPTION
Address issue #5579 using toString instead of cast.