### PR TITLE
Avoid warnings running Scala tests by supplying non-empty string

### DIFF
--- a/kernel/scala/src/test/java/com/twosigma/beakerx/scala/evaluator/NoBeakerxObjectTestFactory.java
+++ b/kernel/scala/src/test/java/com/twosigma/beakerx/scala/evaluator/NoBeakerxObjectTestFactory.java
@@ -19,6 +19,6 @@ public class NoBeakerxObjectTestFactory implements BeakerxObjectFactory {
 
   @Override
   public String create(String sessionId) {
-    return "";
+    return "()";
   }
 }


### PR DESCRIPTION
The change in PR #5581 uses an empty string, which makes the tests issue (harmless but annoying) warnings (at run-time) from the compiler.  Substituting a trivial, valid expression silences the warnings.