### PR TITLE
#5637 fix sorted column breaks selecting

### DIFF
--- a/beakerx/js/src/tableDisplay/css/datatables.scss
+++ b/beakerx/js/src/tableDisplay/css/datatables.scss
@@ -105,7 +105,11 @@ table.dataTable {
     > .selected,
     > .ui-selected,
     > .ui-selecting {
-      background-color: #B0BED9;
+        background-color: #B0BED9;
+
+      &[class*="sorting_"] {
+        background-color: #bec9e0 !important;
+      }
     }
   }
 }


### PR DESCRIPTION
Selection works ok but the selection styles are overwritten by the `sorting_1` styles. This PR fixes that overwrite.