### PR TITLE
#5726: use pypi instead of github

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ conda install -c beakerx beakerx
 Using conda:
 
 ```
-conda install -c conda-forge beakerx
+conda install -c beakerx beakerx
 ```
 
 Using pip:

--- a/README.md
+++ b/README.md
@@ -40,14 +40,6 @@ Using [conda](https://conda.io/docs/install/quick.html) (except on Windows, see 
 conda install -c beakerx beakerx
 ```
 
-## Install
-
-Using conda:
-
-```
-conda install -c beakerx beakerx
-```
-
 Using pip:
 
 ```
@@ -57,33 +49,29 @@ jupyter nbextension enable beakerx --py --sys-prefix
 ```
 And then follow the guide on [Issue #5720](https://github.com/twosigma/beakerx/issues/5720).
 
-## Usage
-
-Start the Jupyter Notebook server: `jupyter notebook`
-
 ## Developer Install
 
-Dependencies:
+### Dependencies:
 
 * [yarn](https://yarnpkg.com/lang/en/docs/install/)
 * [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment should be fine, but our documentation assumes conda).
 
+### Install
+
 ```
 conda create -y -n beakerx python=3.5 jupyter openjdk yarn
 source activate beakerx
-(cd beakerx; python setup.py install --single-version-externally-managed --record record.txt && python setup.py kernels)
+(cd beakerx; pip install -e . --verbose)
 jupyter nbextension install beakerx --py --sys-prefix
 jupyter nbextension enable beakerx --py --sys-prefix
-
 ```
-
 
 ### Update after Java change
 
 The kernels are installed to run out of the repo, so just a build should update the java code.
 
 ```
-(cd kernel; ./gradlew build)
+(cd beakerx; python setup.py java)
 ```
 
 Note this is currently broken and you need to do a complete rebuild
@@ -93,23 +81,25 @@ after a java change. See
 ### Update after JS change
 
 ```
-(cd beakerx/js; yarn webpack)
+(cd beakerx; python setup.py js)
 ```
 
 ## Beaker Notebooks Converter
 
 ```
-python -m beakerx.bkr2ipynb *.bkr
+(cd beakerx; python -m beakerx.bkr2ipynb *.bkr)
 ```
 
 ## Groovy with Interactive Plotting and Tables:
 <img width="900" alt="screen shot" src="https://user-images.githubusercontent.com/963093/28300136-585f9f7c-6b4b-11e7-8827-b5807d3fc9a8.png">
 
-## Autotranslation from Python to JavaScript:
+### Autotranslation from Python to JavaScript
+
 <img width="900" alt="screen shot" src="https://cloud.githubusercontent.com/assets/963093/21077947/261def64-bf2a-11e6-8518-4845caf75690.png">
 
 ## Running with Docker
-In root project call
+
+From project root:
 
 `(cd kernel; gradle clean)`
 

--- a/README.md
+++ b/README.md
@@ -32,20 +32,7 @@ The [documentation](https://github.com/twosigma/beakerx/blob/master/doc/StartHer
 BeakerX is the successor to the [Beaker
 Notebook (source code archive)](https://github.com/twosigma/beaker-notebook-archive).
 
-## Getting started
-
-### Dependencies
-
-* [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment with Jupyter Notebook installed should be fine, but our documentation assumes conda)
-
-### Create conda environment
-
-```
-conda create -y -n beakerx python=3.5 jupyter
-source activate beakerx
-```
-
-### Install beakerx
+## Install
 
 Install using [conda](https://conda.io/docs/install/quick.html):
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ Notebook (source code archive)](https://github.com/twosigma/beaker-notebook-arch
 
 ## Install
 
-Using [conda](https://conda.io/docs/install/quick.html) (except on Windows, see [Issue #5720](https://github.com/twosigma/beakerx/issues/5720)).
+### Dependencies:
+
+* [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment should be fine, but our documentation assumes conda)
+
+Set up conda environment:
+
+```
+conda create -y -n beakerx python=3.5 jupyter openjdk nodejs yarn
+source activate beakerx
+```
+
+
+Install using [conda](https://conda.io/docs/install/quick.html):
 
 ```
 conda install -c beakerx beakerx

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ Using [conda](https://conda.io/docs/install/quick.html) (except on Windows, see 
 conda install -c beakerx beakerx
 ```
 
-Using [pip](https://pip.pypa.io/en/stable/):
+## Install
+
+Using conda:
+
+```
+conda install -c conda-forge beakerx
+```
+
+Using pip:
 
 ```
 pip install beakerx
@@ -61,7 +69,7 @@ Dependencies:
 * [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment should be fine, but our documentation assumes conda).
 
 ```
-conda create -y -n beakerx python=3.5 jupyter openjdk pandas
+conda create -y -n beakerx python=3.5 jupyter openjdk yarn
 source activate beakerx
 (cd beakerx; python setup.py install --single-version-externally-managed --record record.txt && python setup.py kernels)
 jupyter nbextension install beakerx --py --sys-prefix

--- a/README.md
+++ b/README.md
@@ -32,19 +32,20 @@ The [documentation](https://github.com/twosigma/beakerx/blob/master/doc/StartHer
 BeakerX is the successor to the [Beaker
 Notebook (source code archive)](https://github.com/twosigma/beaker-notebook-archive).
 
-## Install
+## Getting started
 
-### Dependencies:
+### Dependencies
 
-* [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment should be fine, but our documentation assumes conda)
+* [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment with Jupyter Notebook installed should be fine, but our documentation assumes conda)
 
-Set up conda environment:
+### Create conda environment
 
 ```
-conda create -y -n beakerx python=3.5 jupyter openjdk nodejs yarn
+conda create -y -n beakerx python=3.5 jupyter
 source activate beakerx
 ```
 
+### Install beakerx
 
 Install using [conda](https://conda.io/docs/install/quick.html):
 
@@ -52,26 +53,25 @@ Install using [conda](https://conda.io/docs/install/quick.html):
 conda install -c beakerx beakerx
 ```
 
-Using pip:
+Using [pip](https://pypi.python.org/pypi/pip):
 
 ```
 pip install beakerx
 jupyter nbextension install beakerx --py --sys-prefix
 jupyter nbextension enable beakerx --py --sys-prefix
 ```
-And then follow the guide on [Issue #5720](https://github.com/twosigma/beakerx/issues/5720).
 
 ## Developer Install
 
 ### Dependencies:
 
+* [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment with [Jupyter Notebook](https://pypi.python.org/pypi/notebook), [Node.js](https://nodejs.org/en/), and [JDK](http://jdk.java.net/8/) installed should be fine, but our documentation assumes conda)
 * [yarn](https://yarnpkg.com/lang/en/docs/install/)
-* [conda](https://conda.io/docs/install/quick.html) (any Python 3 environment should be fine, but our documentation assumes conda).
 
 ### Install
 
 ```
-conda create -y -n beakerx python=3.5 jupyter openjdk yarn
+conda create -y -n beakerx python=3.5 jupyter openjdk nodejs
 source activate beakerx
 (cd beakerx; pip install -e . --verbose)
 jupyter nbextension install beakerx --py --sys-prefix

--- a/beakerx/setup.py
+++ b/beakerx/setup.py
@@ -91,7 +91,8 @@ setup_args = dict(
     )],
     install_requires    = [
         'notebook >=4.3.1',
-        'ipywidgets >=5.1.5, <=6.0.0'
+        'ipywidgets >=5.1.5, <=6.0.0',
+        'pandas'
     ],
     zip_safe            = False,
     include_package_data= True,

--- a/beakerx/setup.py
+++ b/beakerx/setup.py
@@ -52,7 +52,7 @@ cmdclass['js'] = install_node_modules(
     source_dir=pjoin(here, 'js', 'src')
 )
 cmdclass['java'] = run_gradle(cmd='build')
-cmdclass['kernels'] = install_kernels(pjoin(os.environ['CONDA_PREFIX'], 'lib', 'python3.5', 'site-packages', 'beakerx', 'static', 'kernel'))
+cmdclass['kernels'] = install_kernels(kernels_dir=pjoin(here, 'beakerx', 'static', 'kernel'))
 cmdclass['kernelspec_class'] = update_kernelspec_class(prefix=os.environ['CONDA_PREFIX'])
 cmdclass['custom_css'] = copy_files(
     src=pjoin(here,  'beakerx', 'static', 'custom'), 

--- a/beakerx/setup.py
+++ b/beakerx/setup.py
@@ -16,10 +16,6 @@
 # limitations under the License.
 
 from setuptools import setup, find_packages
-# from setuptools.command.build_py import build_py
-from setuptools.command.develop import develop
-from setuptools.command.sdist import sdist
-from setuptools.command.bdist_egg import bdist_egg
 from setupbase import (
     create_cmdclass,
     install_node_modules, 

--- a/beakerx/setup.py
+++ b/beakerx/setup.py
@@ -35,9 +35,13 @@ import os
 from os.path import join as pjoin
 
 
-cmdclass = create_cmdclass([
+cmdclass = create_cmdclass(develop_wrappers=[
     'js',
     'java',
+    'kernels',
+    'kernelspec_class',
+    'custom_css'
+], install_wrappers=[
     'kernels',
     'kernelspec_class',
     'custom_css'

--- a/beakerx/setupbase.py
+++ b/beakerx/setupbase.py
@@ -326,7 +326,6 @@ def install_kernels(kernels_dir=pjoin(here, 'beakerx', 'static', 'kernel')):
                 run(['jupyter', 'kernelspec', 'install', '--sys-prefix', '--replace', '--name', name, kernelspec_path])
                 
             for dir, subdirs, files in os.walk(kernels_dir):
-                print('walking {}'.format(dir))
                 if 'kernel.json' in files:
                     install_kernel(dir)
                 else:


### PR DESCRIPTION
This separate our wrappers (wraps  default setuptools commands/tasks with custom commands) into develop (for developers) and install (for users) so that js and java builds are only run for develop and the kernel, kernelspec, and custom_css commands are run for all. With this, we can remove the post-link scripts from the conda recipe (as this serves the same function). This will allow users to install beakerx as follows:

```
pip install beakerx
jupyter nbextension install beakerx --py --sys-prefix
jupyter nbextension enable beakerx --py --sys-prefix
```
