### PR TITLE
Scala interfaces: List to Seq

### DIFF
--- a/doc/contents/scala/EasyFormScalaDemos.ipynb
+++ b/doc/contents/scala/EasyFormScalaDemos.ipynb
@@ -10,9 +10,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val form : EasyForm = new com.twosigma.beakerx.scala.easyform.EasyForm(\"Form and Run\")\n",
@@ -27,7 +25,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
     "tags": [
      "run"
     ]
@@ -40,9 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val h = new EasyForm(\"Form and Run\")\n",
@@ -54,13 +49,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val g2 = new com.twosigma.beakerx.scala.easyform.EasyForm(\"Field Types\")\n",
-    "val options = List(\"a\", \"b\", \"c\", \"d\")\n",
+    "val options = Seq(\"a\", \"b\", \"c\", \"d\")\n",
     "g2.addList(\"List Single\", options, false)\n",
     "g2"
    ]
@@ -68,9 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "//You can use onInit and onChange to handle component events. For button events use actionPerfromed or addAction.\n",
@@ -98,9 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "//All Kinds of Fields\n",
@@ -110,7 +99,7 @@
     "g.addTextField(\"Text Field\")\n",
     "g.addTextArea(\"Text Area\")\n",
     "g.addCheckBox(\"Check Box\")\n",
-    "val options = List(\"a\", \"b\", \"c\", \"d\")\n",
+    "val options = Seq(\"a\", \"b\", \"c\", \"d\")\n",
     "g.addComboBox(\"Combo Box\", options)\n",
     "g.addComboBox(\"Editable Combo\", options, true)\n",
     "\n",
@@ -133,9 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val gdp = new EasyForm(\"Field Types\")\n",
@@ -146,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "date.getValue()"
@@ -157,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "form.put(\"First\", \"Micheal\")\n",
@@ -174,9 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "EasyForm.HORIZONTAL"

--- a/doc/contents/scala/plotScalaDemo.ipynb
+++ b/doc/contents/scala/plotScalaDemo.ipynb
@@ -11,43 +11,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "10f5dbf2-4ff1-40f4-b30b-368bc94a6518"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot();\n",
-    "val y1 = List(1.5, 1, 6, 5, 2, 8)\n",
-    "val cs = List(Color.black, Color.red, Color.gray, Color.green, Color.blue, Color.pink)\n",
-    "val ss = List(StrokeType.SOLID, StrokeType.SOLID, StrokeType.DASH, StrokeType.DOT, StrokeType.DASHDOT, StrokeType.LONGDASH)\n",
+    "val y1 = Seq(1.5, 1, 6, 5, 2, 8)\n",
+    "val cs = Seq(Color.black, Color.red, Color.gray, Color.green, Color.blue, Color.pink)\n",
+    "val ss = Seq(StrokeType.SOLID, StrokeType.SOLID, StrokeType.DASH, StrokeType.DOT, StrokeType.DASHDOT, StrokeType.LONGDASH)\n",
     "plot.add(new Stems(y1, cs, ss, 5))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f2a609f3-068b-48a2-b0e4-83d4e6151f41"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot(\"Elo\")\n",
     "var cs = new Color(255, 0, 0, 128)// transparent bars\n",
     "//cs[3] = Color.red // set color of a single bar, solid colored bar\n",
-    "plot.add(new Bars(List(1, 2, 3, 4), List(3, 5, 2, 3, 7), cs, Color.black, 0.3))"
+    "plot.add(new Bars(Seq(1, 2, 3, 4), Seq(3, 5, 2, 3, 7), cs, Color.black, 0.3))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "229c19cf-9d65-4402-b124-ad5008866331"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot(\"Changing Point Size, Color, Shape\")\n",
-    "val y1 = List(6, 7, 12, 11, 8, 14)\n",
+    "val y1 = Seq(6, 7, 12, 11, 8, 14)\n",
     "val y2 = y1.map(x => x - 1)\n",
     "val y3 = y1.map(x => x - 2)\n",
     "val y4 = y1.map(x => x - 3)\n",
@@ -59,64 +83,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "78bc96c8-0412-4f23-83df-d01f4ba8e301"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot(\"Changing point properties with list\")\n",
-    "val cs = List(Color.black, Color.red, Color.orange, Color.green, Color.blue, Color.pink)\n",
-    "val ss = List(6.0, 9.0, 12.0, 15.0, 18.0, 21.0)\n",
-    "val fs = List(false, false, false, true, false, false)\n",
+    "val cs = Seq(Color.black, Color.red, Color.orange, Color.green, Color.blue, Color.pink)\n",
+    "val ss = Seq(6.0, 9.0, 12.0, 15.0, 18.0, 21.0)\n",
+    "val fs = Seq(false, false, false, true, false, false)\n",
     "\n",
-    "val list = List(new Points(List(5,5,5,5,5,5), 12.0, cs), \n",
-    "                new Points(List(4,4,4,4,4,4), 12.0, Color.gray, cs),\n",
-    "                new Points(List(3,3,3,3,3,3), 12, Color.red),\n",
-    "                new Points(List(2,2,2,2,2,2), 12.0, Color.black, fs, Color.black))\n",
+    "val list = List(new Points(Seq(5,5,5,5,5,5), 12.0, cs), \n",
+    "                new Points(Seq(4,4,4,4,4,4), 12.0, Color.gray, cs),\n",
+    "                new Points(Seq(3,3,3,3,3,3), 12, Color.red),\n",
+    "                new Points(Seq(2,2,2,2,2,2), 12.0, Color.black, fs, Color.black))\n",
     "\n",
     "plot.add(list)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e23ab37-45ae-4926-9d59-30c7f97208ca"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot()\n",
-    "val y = List(3, 5, 2, 3)\n",
-    "val x0 = List(0, 1, 2, 3)\n",
-    "val x1 = List(3, 4, 5, 8)\n",
+    "val y = Seq(3, 5, 2, 3)\n",
+    "val x0 = Seq(0, 1, 2, 3)\n",
+    "val x1 = Seq(3, 4, 5, 8)\n",
     "plot.add(new Area(x0, y))\n",
     "plot.add(new Area(x1, y, new Color(128, 128, 128, 50), 0))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b5a2d8ac-9746-4976-8cad-110d02185d26"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val p = new Plot()\n",
-    "p.add(new Line(List(3, 6, 12, 24), \"Median\"))\n",
-    "p.add(new Area(List(4, 8, 16, 32), List(2, 4, 8, 16), new Color(255, 0, 0, 50), \"Q1 to Q3\"))"
+    "p.add(new Line(Seq(3, 6, 12, 24), \"Median\"))\n",
+    "p.add(new Area(Seq(4, 8, 16, 32), Seq(2, 4, 8, 16), new Color(255, 0, 0, 50), \"Q1 to Q3\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0fad36fb-b0d3-4ce1-81d4-16172a4319da"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "val y1 = List(1,5,3,2,3)\n",
-    "val y2 = List(7,2,4,1,3)\n",
+    "val y1 = Seq(1,5,3,2,3)\n",
+    "val y2 = Seq(7,2,4,1,3)\n",
     "val p = new Plot(\"Plot with XYStacker\", 200)\n",
     "val a1 = new Area(y1, \"y1\")\n",
     "val a2 = new Area(y2, \"y2\")\n"
@@ -124,14 +180,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "04d7ba26-d03d-4004-8f29-e3bad2cb6f9d"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val p = new Plot ()\n",
-    "p.add(new Line(List(-1, 1)))\n",
+    "p.add(new Line(Seq(-1, 1)))\n",
     "p.add(new ConstantLine(0, 0.65, StrokeType.DOT, Color.blue))\n",
     "p.add(new ConstantLine(0, 1, StrokeType.DASHDOT, Color.blue))\n",
     "p.add(new ConstantLine(1, 0.4, Color.gray, 5, true))"
@@ -139,14 +203,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9035e0ba-f910-41bb-a081-545b3a8abaae"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "val constBand = new ConstantBand(List(1, 2), List(1, 3))\n",
-    "val lineVal = new Line(List(-3, 1, 3, 4, 5))\n",
+    "val constBand = new ConstantBand(Seq(1, 2), Seq(1, 3))\n",
+    "val lineVal = new Line(Seq(-3, 1, 3, 4, 5))\n",
     "val plot = new Plot()\n",
     "plot.add(lineVal)\n",
     "plot.add(constBand)\n"
@@ -154,30 +226,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fd1b8496-92e5-40d7-9fe8-8f12cf3b646a"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val p = new Plot() \n",
-    "p.add(new Line(List(-3, 1, 2, 4, 5), List(4, 2, 6, 1, 5)))\n",
-    "p.add(new ConstantBand(List(Double.NegativeInfinity, 1), new Color(128, 128, 128, 50)))\n",
-    "p.add(new ConstantBand(List(1, 2)))\n",
-    "p.add(new ConstantBand(List(4, Double.PositiveInfinity)))"
+    "p.add(new Line(Seq(-3, 1, 2, 4, 5), Seq(4, 2, 6, 1, 5)))\n",
+    "p.add(new ConstantBand(Seq(Double.NegativeInfinity, 1), new Color(128, 128, 128, 50)))\n",
+    "p.add(new ConstantBand(Seq(1, 2)))\n",
+    "p.add(new ConstantBand(Seq(4, Double.PositiveInfinity)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f4d0e3ab-6027-44b5-8d9a-fb4259cd4d7f"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot()\n",
-    "val xs = List(1,2,3,4,5,6,7,8,9,10)\n",
-    "val ys = List(8.6, 6.1, 7.4, 2.5, 0.4, 0.0, 0.5, 1.7, 8.4, 1)\n",
+    "val xs = Seq(1,2,3,4,5,6,7,8,9,10)\n",
+    "val ys = Seq(8.6, 6.1, 7.4, 2.5, 0.4, 0.0, 0.5, 1.7, 8.4, 1)\n",
+    "\n",
+    "plot.add(new Line(xs, ys))\n",
     "\n",
     "def label(i: Int) : String = { \n",
     "  if (ys(i) > ys(i+1) && ys(i) > ys(i-1)) return \"max\"\n",
@@ -198,95 +288,84 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "val plot = new Plot()\n",
-    "val xs = List(1,2,3,4,5,6,7,8,9,10)\n",
-    "val ys = List(8.6, 6.1, 7.4, 2.5, 0.4, 0.0, 0.5, 1.7, 8.4, 1)\n",
-    "def label(i: Int) : String = { \n",
-    "  if (ys(i) > ys(i+1) && ys(i) > ys(i-1)) return \"max\"\n",
-    "  if (ys(i) < ys(i+1) && ys(i) < ys(i-1)) return \"min\"\n",
-    "  if (ys(i) > ys(i-1)) return \"rising\"\n",
-    "  if (ys(i) < ys(i-1)) return \"falling\"\n",
-    "  return \"\"\n",
-    "}\n",
-    "\n",
-    "for (i <- 0 to xs.length) {\n",
-    "    if (i > 0 && i < (xs.length-1)) {\n",
-    "        plot.add(new Text(xs(i), ys(i), label(i), -i/3.0))\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "plot"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b0ce34ce-dab9-4def-9c5a-227d81f3dd1b"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val ch = new Crosshair(new Color(255, 128, 5), 2, StrokeType.DOT)\n",
     "val pp = new Plot(ch, true, LegendLayout.HORIZONTAL, LegendPosition.TOP)\n",
-    "def x = List(1, 4, 6, 8, 10)\n",
-    "def y = List(3, 6, 4, 5, 9)\n",
+    "def x = Seq(1, 4, 6, 8, 10)\n",
+    "def y = Seq(3, 6, 4, 5, 9)\n",
     "pp.add(new Line(\"Line\", x, y, 3))\n",
-    "pp.add(new Bars(\"Bar\", List(1,2,3,4,5,6,7,8,9,10), List(2, 2, 4, 4, 2, 2, 0, 2, 2, 4), 0.5))\n",
-    "pp.add(new Points(x, y, 10, List(\"x = \",\"y = \")))"
+    "pp.add(new Bars(\"Bar\", Seq(1,2,3,4,5,6,7,8,9,10), Seq(2, 2, 4, 4, 2, 2, 0, 2, 2, 4), 0.5))\n",
+    "pp.add(new Points(x, y, 10, Seq(\"x = \",\"y = \")))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "99124a78-610b-4906-b2c6-1cf4ecd25ede"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "import com.twosigma.beakerx.fileloader.CsvPlotReader\n",
-    "import java.util\n",
+    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
     "\n",
-    "val rates = new CsvPlotReader().read(\"../tableRows.csv\").asInstanceOf[util.List[util.Map[String, AnyRef]]]\n",
+    "val rates = new CsvPlotReader().read(\"../demoResources/interest-rates.csv\")\n",
     "\n",
-    "new SimpleTimePlot(rates, List(\"y1\", \"y10\"), \"Price\", List(\"All\", \"1 Year\", \"10 Year\"))"
+    "new SimpleTimePlot(rates, Seq(\"y1\", \"y10\"), \"Price\", Seq(\"All\", \"1 Year\", \"10 Year\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "44b49da6-b351-4340-aaba-eec62f02bc94"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "import scala.collection.mutable.ListBuffer\n",
-    "\n",
     "val points = 100\n",
     "val logBase = 10\n",
-    "var expys = new ListBuffer[Double]()\n",
-    "var xs = new ListBuffer[Double]()\n",
     "\n",
-    "for (i <- 0 to points) {\n",
-    "    xs += i / 15.0\n",
-    "    expys += Math.exp(xs(i))\n",
-    "}\n",
+    "val xs = for (i <- 0 to points) yield i / 15.0\n",
+    "val expys = for (x <- xs) yield Math.exp(x)\n",
     "\n",
-    "val cplot = new CombinedPlot();\n",
-    "val logYPlot = new Plot(\"Linear x, Log y\", \"Log\",\"\", false, 0.0, true, logBase);\n",
-    "logYPlot.add(new Line(\"f(x) = exp(x)\", xs.toList, expys.toList, 3.0f))\n",
-    "logYPlot.add(new Line(\"g(x) = x\", xs.toList, xs.toList, 3.0f))\n",
+    "val cplot = new CombinedPlot()\n",
+    "val logYPlot = new Plot(\"Linear x, Log y\", \"Log\",\"\", logX=false, 0.0, logY=true, logBase);\n",
+    "logYPlot.add(new Line(\"f(x) = exp(x)\", xs, expys, 3.0f))\n",
+    "logYPlot.add(new Line(\"g(x) = x\", xs, xs, 3.0f))\n",
     "\n",
     "cplot.add(logYPlot, 3)\n",
     "\n",
-    "val linearYPlot = new Plot(\"Linear x, Linear y\", \"Linear\", \"\", false, 0.0, true, logBase)\n",
-    "linearYPlot.add(new Line(\"f(x) = exp(x)\", xs.toList, expys.toList, 3.0f))\n",
-    "linearYPlot.add(new Line(\"g(x) = x\", xs.toList, xs.toList, 3.0f))\n",
+    "val linearYPlot = new Plot(\"Linear x, Linear y\", \"Linear\", \"\", logX=false, 0.0, logY=false, logBase)\n",
+    "linearYPlot.add(new Line(\"f(x) = exp(x)\", xs, expys, 3.0f))\n",
+    "linearYPlot.add(new Line(\"g(x) = x\", xs, xs, 3.0f))\n",
     "cplot.add(linearYPlot, 3);\n",
     "\n",
     "cplot"
@@ -294,38 +373,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f3187af2-ef55-4f93-8cb3-632d0ac3cc2a"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
-    "import scala.collection.mutable.ListBuffer\n",
-    "\n",
     "val points = 100\n",
     "val logBase = 10\n",
-    "var expys = new ListBuffer[Double]()\n",
-    "var xs = new ListBuffer[Double]()\n",
+    "val xs = for (i <- 0 to points) yield i / 15.0\n",
+    "val expys = for (x <- xs) yield Math.exp(x)\n",
     "\n",
-    "for (i <- 0 to points) {\n",
-    "    xs += i / 15.0\n",
-    "    expys += Math.exp(xs(i))\n",
-    "}\n",
+    "val plot = new Plot(\"Log x, Log y\", \"Log\",\"Log\", logX=true, logBase, logY=true, logBase);\n",
     "\n",
-    "val plot = new Plot(\"Log x, Log y\", \"Log\",\"Log\", true, logBase, true, logBase);\n",
-    "\n",
-    "plot.add(new Line(\"f(x) = exp(x)\", xs.toList, expys.toList, 3.0f))\n",
-    "plot.add(new Line(\"g(x) = x\", xs.toList, xs.toList, 3.0f))\n",
+    "plot.add(new Line(\"f(x) = exp(x)\", xs, expys, 3.0f))\n",
+    "plot.add(new Line(\"g(x) = x\", xs, xs, 3.0f))\n",
     "plot"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fccdca7d-5fae-464a-bb72-7df636424807"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import java.util.{Calendar, Date}\n",
     "import java.util.SimpleTimeZone\n",
@@ -340,13 +428,13 @@
     "val plot = new TimePlot(new SimpleTimeZone(10800000, \"America/New_York\"))\n",
     "\n",
     "//list of milliseconds\n",
-    "plot.add(new Points((0 to 10).map(x => millis + hour * x).toList, \n",
-    "                    (0 to 10).toList,\n",
+    "plot.add(new Points((0 to 10).map(x => millis + hour * x), \n",
+    "                    (0 to 10),\n",
     "                    10,\n",
     "                    \"milliseconds\"));\n",
     "\n",
-    "plot.add(new Points((0 to 10).map(x => {cal.add(Calendar.HOUR, 1); cal.getTime()}).toList,\n",
-    "                    (0 to 10).toList,\n",
+    "plot.add(new Points((0 to 10).map(x => {cal.add(Calendar.HOUR, 1); cal.getTime()}),\n",
+    "                    (0 to 10),\n",
     "                    5,\n",
     "                    \"date objects\"));\n",
     "\n",
@@ -355,11 +443,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bb736680-b8b7-47e6-a24a-453acc812835"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import java.util.Date\n",
     "\n",
@@ -368,17 +464,25 @@
     "val nanos  = millis * 1000 * 1000// g makes it arbitrary precision\n",
     "val np = new NanoPlot()\n",
     "\n",
-    "np.add(new Points((0 to 10).map(x => nanos + 7 * x).toList, \n",
-    "                  (0 to 10).toList))"
+    "np.add(new Points((0 to 10).map(x => nanos + 7 * x), \n",
+    "                  (0 to 10)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "11723781-ca99-4016-9f00-0c10620e1ebb"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import scala.util.Random\n",
     "\n",
@@ -388,17 +492,25 @@
     "                 \"stroke: purple; stroke-width: 3;\",\n",
     "                 \"color: green;\")\n",
     "\n",
-    "p.add(new Points((1 to 1000).map(x => r.nextGaussian() * 10.0d).toList,\n",
-    "                 (1 to 1000).map(x => r.nextGaussian() * 20.0d).toList))"
+    "p.add(new Points((1 to 1000).map(x => r.nextGaussian() * 10.0d),\n",
+    "                 (1 to 1000).map(x => r.nextGaussian() * 20.0d)))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c860b0b1-1e64-42c9-a865-2afe405a2c84"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "import java.nio.file.Files\n",
     "import java.io.File\n",
@@ -423,11 +535,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "69fb5199-efc9-4393-8f1a-5ab7e545cb9e"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "val plot = new Plot(\"Setting 2nd Axis bounds\")\n",
     "val ys = List(0, 2, 4, 6, 15, 10)\n",

--- a/doc/contents/scala/tableApiScala.ipynb
+++ b/doc/contents/scala/tableApiScala.ipynb
@@ -12,22 +12,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val table = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
     "\n",
-    "table.display"
+    "table.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -46,28 +42,24 @@
     "display.setAlignmentProviderForType(ColumnType.Double, TableDisplayAlignmentProvider.RIGHT_ALIGNMENT)\n",
     "display.setAlignmentProviderForColumn(\"m3\", TableDisplayAlignmentProvider.CENTER_ALIGNMENT)\n",
     "\n",
-    "display.display"
+    "display.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "display.setStringFormatForTimes(TimeUnit.HOURS)\n",
     "\n",
-    "display.display"
+    "display.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -82,15 +74,13 @@
     "//use the false parameter to hide the String value\n",
     "display2.setRendererForColumn(\"y10\", TableDisplayCellRenderer.getDataBarsRenderer(false))\n",
     "\n",
-    "display2.display"
+    "display2.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -109,15 +99,13 @@
     "\n",
     "//explicitly set column order/visiblity\n",
     "display3.setColumnOrder(List(\"m3\", \"y1\", \"y5\", \"time\", \"y2\")) //Columns in the list will be shown in the provided order. Columns not in the list will be hidden.\n",
-    "display3.display"
+    "display3.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -135,23 +123,23 @@
     "//set the colors used for the min and max\n",
     "//display4.addCellHighlighter(TableDisplayCellHighlighter.getHeatmapHighlighter(\"m6\", TableDisplayCellHighlighter.SINGLE_COLUMN, null, null, Color.YELLOW, Color.BLUE))\n",
     "\n",
-    "display4.display"
+    "display4.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
     "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
     "\n",
-    "val map = List(Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
+    "val map = Seq(Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "               Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "               Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9))\n",
+    "// TODO: remove when TableDisplay interface is fixed\n",
+    "            .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val display5 = new TableDisplay(map)\n",
     "\n",
@@ -161,15 +149,13 @@
     "       }\n",
     "})\n",
     "\n",
-    "display5.display"
+    "display5.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -185,15 +171,13 @@
     "\n",
     "//wipe out all highlighting\n",
     "//display6.removeAllCellHighlighters()\n",
-    "display6.display"
+    "display6.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -201,37 +185,37 @@
     "import com.twosigma.beakerx.chart.Color\n",
     "import com.twosigma.beakerx.table.highlight.ThreeColorHeatmapHighlighter\n",
     "\n",
-    "val table = new TableDisplay(List(List(1,2,3), \n",
-    "                                  List(3,4,5), \n",
-    "                                  List(6,2,8), \n",
-    "                                  List(6,2,8), \n",
-    "                                  List(6,2,8), \n",
-    "                                  List(6,4,8), \n",
-    "                                  List(6,2,8), \n",
-    "                                  List(6,2,8), \n",
-    "                                  List(6,5,8)), \n",
-    "                                  List(\"a\", \"b\", \"b\"), \n",
-    "                                  List(\"double\", \"double\", \"double\"))\n",
+    "val table = new TableDisplay(Seq(Seq(1,2,3), \n",
+    "                                 Seq(3,4,5), \n",
+    "                                 Seq(6,2,8), \n",
+    "                                 Seq(6,2,8), \n",
+    "                                 Seq(6,2,8), \n",
+    "                                 Seq(6,4,8), \n",
+    "                                 Seq(6,2,8), \n",
+    "                                 Seq(6,2,8), \n",
+    "                                 Seq(6,5,8)), \n",
+    "                                 Seq(\"a\", \"b\", \"b\"), \n",
+    "                                 Seq(\"double\", \"double\", \"double\"))\n",
     "\n",
     "table.addCellHighlighter(TableDisplayCellHighlighter.getUniqueEntriesHighlighter(\"b\", HighlightStyle.FULL_ROW))\n",
-    "table.display"
+    "table.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
     "\n",
-    "val mapList4 = List(\n",
+    "val mapList4 = Seq(\n",
     "   Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "   Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9)\n",
     ")\n",
+    "// TODO: remove when TableDisplay interface is fixed\n",
+    " .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val display7 = new TableDisplay(mapList4)\n",
     "\n",
@@ -246,15 +230,13 @@
     "       }\n",
     "})\n",
     "\n",
-    "display7.display"
+    "display7.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -265,6 +247,8 @@
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "   Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9)\n",
     ")\n",
+    "// TODO: remove when TableDisplay interface is fixed\n",
+    " .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val display7 = new TableDisplay(mapList4)\n",
     "\n",
@@ -279,15 +263,13 @@
     "display7.addContextMenuItem(\"run misc_formatting\", \"misc_formatting\");\n",
     "display7.setDoubleClickAction(\"misc_formatting\");\n",
     "\n",
-    "display7.display"
+    "display7.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -299,6 +281,8 @@
     " Map(\"firstCol\" -> 1, \"secondCol\" -> 2, \"thirdCol\" -> 3),\n",
     " Map(\"firstCol\" -> 4, \"secondCol\" -> 5, \"thirdCol\" -> 6),\n",
     " Map(\"firstCol\" -> 9, \"secondCol\" -> 8, \"thirdCol\" -> 7))\n",
+    "// TODO: remove when TableDisplay interface is fixed\n",
+    "    .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val td4 = new TableDisplay(mapList5)\n",
     "\n",
@@ -312,10 +296,10 @@
     "td4.setDataFontSize(15)\n",
     "td4.setHeaderFontSize(30)\n",
     "\n",
-    "val colors = List(\n",
-    "            List(Color.LIGHT_GRAY, Color.GRAY, Color.RED),\n",
-    "            List(Color.YELLOW, Color.ORANGE, Color.RED),\n",
-    "            List(Color.MAGENTA, Color.BLUE, Color.BLACK))\n",
+    "val colors = Seq(\n",
+    "            Seq(Color.LIGHT_GRAY, Color.GRAY, Color.RED),\n",
+    "            Seq(Color.YELLOW, Color.ORANGE, Color.RED),\n",
+    "            Seq(Color.MAGENTA, Color.BLUE, Color.BLACK))\n",
     "\n",
     "td4.setFontColorProvider(new FontColorProvider {\n",
     "    override def apply(row: Integer, col: Integer, display: com.twosigma.beakerx.table.TableDisplay): Color = {\n",
@@ -333,31 +317,29 @@
     "//you can also do this in the right-click menu\n",
     "td4.setHeadersVertical(true)\n",
     "\n",
-    "td4.display"
+    "td4.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val abc = 0 // test variable\n",
-    "val mapList = List(\n",
+    "val mapList = Seq(\n",
     "   Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "   Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 8)\n",
-    ")"
+    ")\n",
+    "// TODO: remove when TableDisplay interface is fixed\n",
+    " .map(_.mapValues(_.asInstanceOf[AnyRef]))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -371,15 +353,13 @@
     "       }\n",
     "})\n",
     "\n",
-    "display1.display"
+    "display1.display()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.table._\n",
@@ -390,7 +370,7 @@
     "display2.addContextMenuItem(\"run print cell\", \"print_cell\");\n",
     "display2.setDoubleClickAction(\"print_cell\");\n",
     "\n",
-    "display2.display"
+    "display2.display()"
    ]
   },
   {

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/Plot.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/Plot.scala
@@ -59,7 +59,7 @@ class Plot extends com.twosigma.beakerx.chart.xychart.Plot {
     super.setTitleStyle(title)
   }
 
-  def add(items: List[Object]): XYChart = {
+  def add(items: Seq[Object]): XYChart = {
     add(items.asJava)
   }
 }

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/SimpleTimePlot.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/SimpleTimePlot.scala
@@ -22,7 +22,7 @@ import scala.collection.JavaConverters._
 
 class SimpleTimePlot(data: util.List[util.Map[String, AnyRef]], columns: util.List[String]) extends com.twosigma.beakerx.chart.xychart.SimpleTimePlot(data, columns) {
 
-  def this(data: util.List[util.Map[String, AnyRef]], columns: List[String], yLabel: String, displayNames: List[String]) {
+  def this(data: util.List[util.Map[String, AnyRef]], columns: Seq[String], yLabel: String, displayNames: Seq[String]) {
     this(data, columns.asJava)
     super.setYLabel(yLabel)
     super.setDisplayNames(displayNames.asJava)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Area.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Area.scala
@@ -22,19 +22,19 @@ import scala.collection.JavaConverters._
 
 class Area extends com.twosigma.beakerx.chart.xychart.plotitem.Area {
 
-  def this(x: List[Int], y: List[Int]) {
+  def this(x: Seq[Int], y: Seq[Int]) {
     this()
     super.setX(x.map(x => x.asInstanceOf[AnyRef]).asJava)
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(x: List[Int], y: List[Int], color: Color, interpolation: Int) {
+  def this(x: Seq[Int], y: Seq[Int], color: Color, interpolation: Int) {
     this(x, y)
     super.setColor(color)
     super.setInterpolation(interpolation)
   }
 
-  def this(y: List[Int], base: List[Int], color: Color, displayName: String) {
+  def this(y: Seq[Int], base: Seq[Int], color: Color, displayName: String) {
     this()
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
     super.setBase(base.map(x => x.asInstanceOf[AnyRef]).asJava)
@@ -42,7 +42,7 @@ class Area extends com.twosigma.beakerx.chart.xychart.plotitem.Area {
     super.setDisplayName(displayName)
   }
 
-  def this(y: List[Int], displayName: String) {
+  def this(y: Seq[Int], displayName: String) {
     this()
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
     super.setDisplayName(displayName)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Bars.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Bars.scala
@@ -21,27 +21,27 @@ import scala.collection.JavaConverters._
 
 class Bars extends com.twosigma.beakerx.chart.xychart.plotitem.Bars {
 
-  def this(x: List[Int], y: List[Int]) {
+  def this(x: Seq[Int], y: Seq[Int]) {
     this()
     super.setX(x.map(x => x.asInstanceOf[AnyRef]).asJava)
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(x: List[Int], y: List[Int], colors: List[Color], outLineColor: Color, width: Number) {
+  def this(x: Seq[Int], y: Seq[Int], colors: Seq[Color], outLineColor: Color, width: Number) {
     this(x, y)
     super.setColor(colors.map(x => x.asInstanceOf[AnyRef]).asJava)
     super.setOutlineColor(outLineColor)
     super.setWidth(width)
   }
 
-  def this(x: List[Int], y: List[Int], color: Color, outLineColor: Color, width: Number) {
+  def this(x: Seq[Int], y: Seq[Int], color: Color, outLineColor: Color, width: Number) {
     this(x, y)
     super.setColor(color)
     super.setOutlineColor(outLineColor)
     super.setWidth(width)
   }
 
-  def this(displayName: String, x: List[Int], y: List[Int], width: Number) {
+  def this(displayName: String, x: Seq[Int], y: Seq[Int], width: Number) {
     this(x, y)
     super.setDisplayName(displayName)
     super.setWidth(width)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/ConstantBand.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/ConstantBand.scala
@@ -21,17 +21,17 @@ import scala.collection.JavaConverters._
 
 class ConstantBand extends com.twosigma.beakerx.chart.xychart.plotitem.ConstantBand {
 
-  def this(x: List[_]) {
+  def this(x: Seq[_]) {
     this()
     super.setX(x.map(x => x.asInstanceOf[AnyRef]).asJava)
   }
 
-  def this(x: List[_], y: List[_]) {
+  def this(x: Seq[_], y: Seq[_]) {
     this(x)
     super.setY(x.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(x: List[_], color: Color) {
+  def this(x: Seq[_], color: Color) {
     this(x)
     super.setColor(color)
   }

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Line.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Line.scala
@@ -19,19 +19,19 @@ package com.twosigma.beakerx.scala.chart.xychart.plotitem
 import scala.collection.JavaConverters._
 
 
-class Line(var xs: List[AnyVal], var ys: List[AnyVal]) extends com.twosigma.beakerx.chart.xychart.plotitem.Line(xs.map(x => x.asInstanceOf[AnyRef]).asJava, ys.map(x => x.asInstanceOf[Number]).asJava) {
+class Line(var xs: Seq[AnyVal], var ys: Seq[AnyVal]) extends com.twosigma.beakerx.chart.xychart.plotitem.Line(xs.map(x => x.asInstanceOf[AnyRef]).asJava, ys.map(x => x.asInstanceOf[Number]).asJava) {
 
-  def this(ys: List[AnyVal]) {
+  def this(ys: Seq[AnyVal]) {
     this(List(), ys)
     super.setY(ys.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(ys: List[AnyVal], displayName: String) {
+  def this(ys: Seq[AnyVal], displayName: String) {
     this(ys)
     super.setDisplayName(displayName)
   }
 
-  def this(displayName: String, xs: List[AnyVal], ys: List[AnyVal], width: Float) {
+  def this(displayName: String, xs: Seq[AnyVal], ys: Seq[AnyVal], width: Float) {
     this(xs, ys)
     super.setDisplayName(displayName)
     super.setWidth(width)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Points.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Points.scala
@@ -22,70 +22,70 @@ import scala.collection.JavaConverters._
 
 class Points extends com.twosigma.beakerx.chart.xychart.plotitem.Points {
 
-  def this(y: List[_]) {
+  def this(y: Seq[_]) {
     this()
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(y: List[_], shape: ShapeType) {
+  def this(y: Seq[_], shape: ShapeType) {
     this(y)
     super.setShape(shape)
   }
 
-  def this(y: List[_], size: Number, color: Color) {
+  def this(y: Seq[_], size: Number, color: Color) {
     this(y)
     super.setSize(size)
     super.setColor(color)
   }
 
-  def this(y: List[_], size: List[_], color: Color) {
+  def this(y: Seq[_], size: Seq[_], color: Color) {
     this(y)
     super.setSize(size.map(x => x.isInstanceOf[Number]).asJava)
     super.setColor(color)
   }
 
-  def this(y: List[_], size: Number, color: List[Color]) {
+  def this(y: Seq[_], size: Number, color: Seq[Color]) {
     this(y)
     super.setColor(color.asJava)
     super.setSize(size)
   }
 
-  def this(y: List[_], size: Number, shape: ShapeType) {
+  def this(y: Seq[_], size: Number, shape: ShapeType) {
     this(y, shape)
     super.setSize(size)
   }
 
-  def this(y: List[_], size: Number, color: Color, outlineColor: Color) {
+  def this(y: Seq[_], size: Number, color: Color, outlineColor: Color) {
     this(y)
     super.setSize(size)
     super.setColor(color)
     super.setOutlineColor(outlineColor)
   }
 
-  def this(y: List[_], size: Number, color: Color, outlineColors: List[Color]) {
+  def this(y: Seq[_], size: Number, color: Color, outlineColors: Seq[Color]) {
     this(y)
     super.setSize(size)
     super.setColor(color)
     super.setOutlineColor(outlineColors.asJava)
   }
 
-  def this(y: List[_], size: Number, color: Color, fill: List[Boolean], outlineColor: Color) {
+  def this(y: Seq[_], size: Number, color: Color, fill: Seq[Boolean], outlineColor: Color) {
     this(y, size, color, outlineColor)
     super.setFill(fill.asJava)
   }
 
-  def this(x: List[_], y: List[_]) {
+  def this(x: Seq[_], y: Seq[_]) {
     this(y)
     super.setX(x.map(x => x.asInstanceOf[AnyRef]).asJava)
   }
 
-  def this(x: List[_], y: List[_], size: Number, tooltip: List[String]) {
+  def this(x: Seq[_], y: Seq[_], size: Number, tooltip: Seq[String]) {
     this(x, y)
     super.setSize(size)
     super.setToolTip(tooltip.asJava)
   }
 
-  def this(x: List[_], y: List[_], size: Number, displayName: String) {
+  def this(x: Seq[_], y: Seq[_], size: Number, displayName: String) {
     this(x, y)
     super.setSize(size)
     super.setDisplayName(displayName)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Rasters.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Rasters.scala
@@ -18,24 +18,24 @@ package com.twosigma.beakerx.scala.chart.xychart.plotitem
 
 import scala.collection.JavaConverters._
 
-class Rasters(y: List[AnyVal], height: List[AnyVal], width: List[AnyVal]) extends com.twosigma.beakerx.chart.xychart.plotitem.Rasters {
+class Rasters(y: Seq[AnyVal], height: Seq[AnyVal], width: Seq[AnyVal]) extends com.twosigma.beakerx.chart.xychart.plotitem.Rasters {
 
   super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
   super.setHeight(height.map(x => x.asInstanceOf[Number]).asJava)
   super.setWidth(width.map(x => x.asInstanceOf[Number]).asJava)
 
-  def this(x: List[AnyVal], y: List[AnyVal], height: List[AnyVal], width: List[AnyVal], opacity: List[AnyVal]) {
+  def this(x: Seq[AnyVal], y: Seq[AnyVal], height: Seq[AnyVal], width: Seq[AnyVal], opacity: Seq[AnyVal]) {
     this(y, height, width)
     super.setX(x.map(x => x.asInstanceOf[AnyRef]).asJava)
     super.setOpacity(opacity.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(x: List[AnyVal], y: List[AnyVal], height: List[AnyVal], width: List[AnyVal], opacity: List[AnyVal], dataString: Array[Byte]) {
+  def this(x: Seq[AnyVal], y: Seq[AnyVal], height: Seq[AnyVal], width: Seq[AnyVal], opacity: Seq[AnyVal], dataString: Array[Byte]) {
     this(x, y, height, width, opacity)
     super.setDataString(dataString)
   }
 
-  def this(x: List[AnyVal], y: List[AnyVal], height: List[AnyVal], width: List[AnyVal], opacity: List[AnyVal], fileUrl: String) {
+  def this(x: Seq[AnyVal], y: Seq[AnyVal], height: Seq[AnyVal], width: Seq[AnyVal], opacity: Seq[AnyVal], fileUrl: String) {
     this(x, y, height, width, opacity)
     super.setFileUrl(fileUrl)
   }

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Stems.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Stems.scala
@@ -23,7 +23,7 @@ import com.twosigma.beakerx.chart.xychart.plotitem.StrokeType
 
 class Stems extends com.twosigma.beakerx.chart.xychart.plotitem.Stems {
 
-  def this(y: List[Double], colors: List[Color], style: StrokeType, width: Float) {
+  def this(y: Seq[Double], colors: Seq[Color], style: StrokeType, width: Float) {
     this()
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
     super.setColor(colors.asJava)
@@ -31,7 +31,7 @@ class Stems extends com.twosigma.beakerx.chart.xychart.plotitem.Stems {
     super.setWidth(width)
   }
 
-  def this(y: List[Double], colors: List[Color], styles: List[StrokeType], width: Float) {
+  def this(y: Seq[Double], colors: Seq[Color], styles: Seq[StrokeType], width: Float) {
     this()
     super.setY(y.map(x => x.asInstanceOf[Number]).asJava)
     super.setColor(colors.asJava)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/easyform/EasyForm.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/easyform/EasyForm.scala
@@ -28,47 +28,47 @@ object EasyForm {
 
 class EasyForm(var caption: String) extends com.twosigma.beakerx.easyform.EasyForm(caption) {
 
-  def addComboBox(label: String, values: List[String]): EasyFormComponent[_ <: DOMWidget] = {
+  def addComboBox(label: String, values: Seq[String]): EasyFormComponent[_ <: DOMWidget] = {
     super.addComboBox(label, values.asJava, false)
   }
 
-  def addComboBox(label: String, values: List[String], editable: Boolean): EasyFormComponent[_ <: DOMWidget] = {
+  def addComboBox(label: String, values: Seq[String], editable: Boolean): EasyFormComponent[_ <: DOMWidget] = {
     super.addComboBox(label, values.asJava, editable)
   }
 
-  def addComboBox(label: String, values: List[String], editable: Boolean, width: Integer): EasyFormComponent[_ <: DOMWidget] = {
+  def addComboBox(label: String, values: Seq[String], editable: Boolean, width: Integer): EasyFormComponent[_ <: DOMWidget] = {
     super.addComboBox(label, values.asJava, editable, width)
   }
 
-  def addList(label: String, values: List[String]): EasyFormComponent[_ <: DOMWidget] = {
+  def addList(label: String, values: Seq[String]): EasyFormComponent[_ <: DOMWidget] = {
     super.addList(label, values.asJava)
   }
 
-  def addList(label: String, values: List[String], multipleSelection: Boolean): EasyFormComponent[_ <: DOMWidget] = {
+  def addList(label: String, values: Seq[String], multipleSelection: Boolean): EasyFormComponent[_ <: DOMWidget] = {
     super.addList(label, values.asJava, multipleSelection)
   }
 
-  def addList(label: String, values: List[String], size: Integer): EasyFormComponent[_ <: DOMWidget] = {
+  def addList(label: String, values: Seq[String], size: Integer): EasyFormComponent[_ <: DOMWidget] = {
     super.addList(label, values.asJava, size)
   }
 
-  def addList(label: String, values: List[String], multipleSelection: Boolean, size: Integer): EasyFormComponent[_ <: DOMWidget] = {
+  def addList(label: String, values: Seq[String], multipleSelection: Boolean, size: Integer): EasyFormComponent[_ <: DOMWidget] = {
     super.addList(label, values.asJava, multipleSelection, size)
   }
 
-  def addRadioButtons(label: String, values: List[String]): EasyFormComponent[_ <: DOMWidget] = {
+  def addRadioButtons(label: String, values: Seq[String]): EasyFormComponent[_ <: DOMWidget] = {
     super.addRadioButtons(label, values.asJava)
   }
 
-  def addRadioButtons(label: String, values: List[String], orientation: Integer): EasyFormComponent[_ <: DOMWidget] = {
+  def addRadioButtons(label: String, values: Seq[String], orientation: Integer): EasyFormComponent[_ <: DOMWidget] = {
     super.addRadioButtons(label, values.asJava, orientation)
   }
 
-  def addCheckBoxes(label: String, values: List[String]): EasyFormComponent[_ <: DOMWidget] = {
+  def addCheckBoxes(label: String, values: Seq[String]): EasyFormComponent[_ <: DOMWidget] = {
     super.addCheckBoxes(label, values.asJava)
   }
 
-  def addCheckBoxes(label: String, values: List[String], orientation: Integer): EasyFormComponent[_ <: DOMWidget] = {
+  def addCheckBoxes(label: String, values: Seq[String], orientation: Integer): EasyFormComponent[_ <: DOMWidget] = {
     super.addCheckBoxes(label, values.asJava, orientation)
   }
 }

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/fileloader/CsvPlotReader.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/fileloader/CsvPlotReader.scala
@@ -22,10 +22,9 @@ import scala.collection.JavaConverters._
 
 class CsvPlotReader extends com.twosigma.beakerx.fileloader.CsvPlotReader {
 
-  def readFile(fileName: String): List[Map[_, _]] = {
+  def readFile(fileName: String): List[Map[String, AnyRef]] = {
     val javaOutput: util.List[util.Map[String, AnyRef]] = super.read(fileName)
-    val refactoredOutput: List[util.Map[_, _]] = javaOutput.asScala.toList
 
-    refactoredOutput.map(ro => ro.asScala.toMap)
+    javaOutput.asScala.map(_.asScala.toMap).toList
   }
 }

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/table/TableDisplay.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/table/TableDisplay.scala
@@ -32,8 +32,8 @@ object TableDisplay {
     new com.twosigma.beakerx.table.TableDisplay(v.asJava)
   }
 
-  private def create(v: List[List[_]], co: List[String], cl: List[String]) = {
-    val javaList: List[java.util.List[_]] = v.map(entry => entry.asJava)
+  private def create(v: Seq[Seq[_]], co: Seq[String], cl: Seq[String]) = {
+    val javaList: Seq[java.util.List[_]] = v.map(entry => entry.asJava)
     val javaListOfList: java.util.List[java.util.List[_]] = javaList.asJava
 
     new com.twosigma.beakerx.table.TableDisplay(javaListOfList, co.asJava, cl.asJava)
@@ -45,15 +45,15 @@ object TableDisplay {
     new com.twosigma.beakerx.table.TableDisplay(javaStandardized)
   }
 
-  private def create(v: List[Map[String, AnyRef]]): com.twosigma.beakerx.table.TableDisplay = {
-    val javaMaps: List[java.util.Map[String, AnyRef]] = v.map(entry => entry.asJava)
+  private def create(v: Seq[Map[String, AnyRef]]): com.twosigma.beakerx.table.TableDisplay = {
+    val javaMaps: Seq[java.util.Map[String, AnyRef]] = v.map(entry => entry.asJava)
     val javaCollection: java.util.Collection[java.util.Map[String, AnyRef]] = javaMaps.asJavaCollection
 
     new com.twosigma.beakerx.table.TableDisplay(javaCollection)
   }
 
-  private def create(v: List[Map[String, AnyRef]], serializer: BeakerObjectConverter): com.twosigma.beakerx.table.TableDisplay = {
-    val javaMaps: List[java.util.Map[String, AnyRef]] = v.map(entry => entry.asJava)
+  private def create(v: Seq[Map[String, AnyRef]], serializer: BeakerObjectConverter): com.twosigma.beakerx.table.TableDisplay = {
+    val javaMaps: Seq[java.util.Map[String, AnyRef]] = v.map(entry => entry.asJava)
     val javaCollection: java.util.Collection[java.util.Map[String, AnyRef]] = javaMaps.asJavaCollection
 
     new com.twosigma.beakerx.table.TableDisplay(javaCollection, serializer)
@@ -66,7 +66,7 @@ class TableDisplay private(tableDisplay: com.twosigma.beakerx.table.TableDisplay
     this(TableDisplay.create(v))
   }
 
-  def this(v: List[List[_]], co: List[String], cl: List[String]) = {
+  def this(v: Seq[Seq[_]], co: Seq[String], cl: Seq[String]) = {
     this(TableDisplay.create(v, co, cl))
   }
 
@@ -74,15 +74,15 @@ class TableDisplay private(tableDisplay: com.twosigma.beakerx.table.TableDisplay
     this(TableDisplay.create(v))
   }
 
-  def this(v: List[Map[String, AnyRef]]) = {
+  def this(v: Seq[Map[String, AnyRef]]) = {
     this(TableDisplay.create(v))
   }
 
-  def this(v: List[Map[String, AnyRef]], serializer: BeakerObjectConverter) = {
+  def this(v: Seq[Map[String, AnyRef]], serializer: BeakerObjectConverter) = {
     this(TableDisplay.create(v, serializer))
   }
 
-  def display = tableDisplay.display()
+  def display() = tableDisplay.display()
 
 
   def setStringFormatForTimes(timeUnit: TimeUnit) = tableDisplay.setStringFormatForTimes(timeUnit)
@@ -105,7 +105,7 @@ class TableDisplay private(tableDisplay: com.twosigma.beakerx.table.TableDisplay
 
   def setColumnVisible(column: String, visible: Boolean) = tableDisplay.setColumnVisible(column, visible)
 
-  def setColumnOrder(columnOrder: List[String]) = tableDisplay.setColumnOrder(columnOrder.asJava)
+  def setColumnOrder(columnOrder: Seq[String]) = tableDisplay.setColumnOrder(columnOrder.asJava)
 
   def addCellHighlighter(cellHighlighter: TableDisplayCellHighlighter) = tableDisplay.addCellHighlighter(cellHighlighter)
 


### PR DESCRIPTION
First part of #5798 changing `List` to `Seq` in Scala interfaces.  Also added an empty argument list to `TableDisplay.display` per Scala convention for side-effecting nullary methods.  Scala notebooks tweaked accordingly.