### PR TITLE
5798 scala interfaces part deux

### DIFF
--- a/doc/contents/scala/tableApiScala.ipynb
+++ b/doc/contents/scala/tableApiScala.ipynb
@@ -138,8 +138,6 @@
     "val map = Seq(Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "               Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "               Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9))\n",
-    "// TODO: remove when TableDisplay interface is fixed\n",
-    "            .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val display5 = new TableDisplay(map)\n",
     "\n",
@@ -214,8 +212,6 @@
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "   Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9)\n",
     ")\n",
-    "// TODO: remove when TableDisplay interface is fixed\n",
-    " .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val display7 = new TableDisplay(mapList4)\n",
     "\n",
@@ -247,8 +243,6 @@
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "   Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9)\n",
     ")\n",
-    "// TODO: remove when TableDisplay interface is fixed\n",
-    " .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val display7 = new TableDisplay(mapList4)\n",
     "\n",
@@ -281,8 +275,6 @@
     " Map(\"firstCol\" -> 1, \"secondCol\" -> 2, \"thirdCol\" -> 3),\n",
     " Map(\"firstCol\" -> 4, \"secondCol\" -> 5, \"thirdCol\" -> 6),\n",
     " Map(\"firstCol\" -> 9, \"secondCol\" -> 8, \"thirdCol\" -> 7))\n",
-    "// TODO: remove when TableDisplay interface is fixed\n",
-    "    .map(_.mapValues(_.asInstanceOf[AnyRef]))\n",
     "\n",
     "val td4 = new TableDisplay(mapList5)\n",
     "\n",
@@ -331,9 +323,7 @@
     "   Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "   Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 8)\n",
-    ")\n",
-    "// TODO: remove when TableDisplay interface is fixed\n",
-    " .map(_.mapValues(_.asInstanceOf[AnyRef]))"
+    ")"
    ]
   },
   {

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Line.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/chart/xychart/plotitem/Line.scala
@@ -19,19 +19,19 @@ package com.twosigma.beakerx.scala.chart.xychart.plotitem
 import scala.collection.JavaConverters._
 
 
-class Line(var xs: Seq[AnyVal], var ys: Seq[AnyVal]) extends com.twosigma.beakerx.chart.xychart.plotitem.Line(xs.map(x => x.asInstanceOf[AnyRef]).asJava, ys.map(x => x.asInstanceOf[Number]).asJava) {
+class Line(xs: Seq[Any], ys: Seq[Any]) extends com.twosigma.beakerx.chart.xychart.plotitem.Line(xs.map(x => x.asInstanceOf[AnyRef]).asJava, ys.map(x => x.asInstanceOf[Number]).asJava) {
 
-  def this(ys: Seq[AnyVal]) {
+  def this(ys: Seq[Any]) {
     this(List(), ys)
     super.setY(ys.map(x => x.asInstanceOf[Number]).asJava)
   }
 
-  def this(ys: Seq[AnyVal], displayName: String) {
+  def this(ys: Seq[Any], displayName: String) {
     this(ys)
     super.setDisplayName(displayName)
   }
 
-  def this(displayName: String, xs: Seq[AnyVal], ys: Seq[AnyVal], width: Float) {
+  def this(displayName: String, xs: Seq[Any], ys: Seq[Any], width: Float) {
     this(xs, ys)
     super.setDisplayName(displayName)
     super.setWidth(width)

--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/table/TableDisplay.scala
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/table/TableDisplay.scala
@@ -39,22 +39,22 @@ object TableDisplay {
     new com.twosigma.beakerx.table.TableDisplay(javaListOfList, co.asJava, cl.asJava)
   }
 
-  private def create(v: Array[Map[String, AnyRef]]): com.twosigma.beakerx.table.TableDisplay = {
-    val javaStandardized: Array[java.util.Map[String, AnyRef]] = v.map(v => v.asJava).toArray
+  private def create(v: Array[Map[String, Any]]): com.twosigma.beakerx.table.TableDisplay = {
+    val javaStandardized: Array[java.util.Map[String, Object]] = v.map(v => v.mapValues(_.asInstanceOf[Object]).asJava)
 
     new com.twosigma.beakerx.table.TableDisplay(javaStandardized)
   }
 
-  private def create(v: Seq[Map[String, AnyRef]]): com.twosigma.beakerx.table.TableDisplay = {
-    val javaMaps: Seq[java.util.Map[String, AnyRef]] = v.map(entry => entry.asJava)
-    val javaCollection: java.util.Collection[java.util.Map[String, AnyRef]] = javaMaps.asJavaCollection
+  private def create(v: Seq[Map[String, Any]]): com.twosigma.beakerx.table.TableDisplay = {
+    val javaMaps: Seq[java.util.Map[String, Object]] = v.map(m => m.mapValues(_.asInstanceOf[Object]).asJava)
+    val javaCollection: java.util.Collection[java.util.Map[String, Object]] = javaMaps.asJava
 
     new com.twosigma.beakerx.table.TableDisplay(javaCollection)
   }
 
-  private def create(v: Seq[Map[String, AnyRef]], serializer: BeakerObjectConverter): com.twosigma.beakerx.table.TableDisplay = {
-    val javaMaps: Seq[java.util.Map[String, AnyRef]] = v.map(entry => entry.asJava)
-    val javaCollection: java.util.Collection[java.util.Map[String, AnyRef]] = javaMaps.asJavaCollection
+  private def create(v: Seq[Map[String, Any]], serializer: BeakerObjectConverter): com.twosigma.beakerx.table.TableDisplay = {
+    val javaMaps: Seq[java.util.Map[String, Object]] = v.map(m => m.mapValues(_.asInstanceOf[Object]).asJava)
+    val javaCollection: java.util.Collection[java.util.Map[String, Object]] = javaMaps.asJava
 
     new com.twosigma.beakerx.table.TableDisplay(javaCollection, serializer)
   }
@@ -70,15 +70,15 @@ class TableDisplay private(tableDisplay: com.twosigma.beakerx.table.TableDisplay
     this(TableDisplay.create(v, co, cl))
   }
 
-  def this(v: Array[Map[String, AnyRef]]) = {
+  def this(v: Array[Map[String, Any]]) = {
     this(TableDisplay.create(v))
   }
 
-  def this(v: Seq[Map[String, AnyRef]]) = {
+  def this(v: Seq[Map[String, Any]]) = {
     this(TableDisplay.create(v))
   }
 
-  def this(v: Seq[Map[String, AnyRef]], serializer: BeakerObjectConverter) = {
+  def this(v: Seq[Map[String, Any]], serializer: BeakerObjectConverter) = {
     this(TableDisplay.create(v, serializer))
   }
 


### PR DESCRIPTION
This is the second part of the changes proposed in #5798.  I had thought there might be more, but there were only two places this was an issue, `TableDisplay` and `Line`.  This cleans up `TODO`s in the Scala table doc/demo.