### PR TITLE
5895 Use jvm-repr for auto-display of Scala DisplayTables and Maps

### DIFF
--- a/doc/contents/scala/EasyFormScalaDemos.ipynb
+++ b/doc/contents/scala/EasyFormScalaDemos.ipynb
@@ -10,10 +10,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "val form : EasyForm = new com.twosigma.beakerx.scala.easyform.EasyForm(\"Form and Run\")\n",
+    "val form : EasyForm = new EasyForm(\"Form and Run\")\n",
     "form.addTextField(\"First\", 250)\n",
     "form.addTextField(\"Last\", 250)\n",
     "form.addButton(\"Go!\", \"run\")\n",
@@ -25,6 +27,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": true,
     "tags": [
      "run"
     ]
@@ -37,7 +40,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "val h = new EasyForm(\"Form and Run\")\n",
@@ -49,10 +54,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "val g2 = new com.twosigma.beakerx.scala.easyform.EasyForm(\"Field Types\")\n",
+    "val g2 = new EasyForm(\"Field Types\")\n",
     "val options = Seq(\"a\", \"b\", \"c\", \"d\")\n",
     "g2.addList(\"List Single\", options, false)\n",
     "g2"
@@ -61,7 +68,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "//You can use onInit and onChange to handle component events. For button events use actionPerfromed or addAction.\n",
@@ -89,7 +98,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "//All Kinds of Fields\n",
@@ -122,7 +133,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "val gdp = new EasyForm(\"Field Types\")\n",
@@ -133,7 +146,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "date.getValue()"
@@ -142,7 +157,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "form.put(\"First\", \"Micheal\")\n",
@@ -157,7 +174,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "EasyForm.HORIZONTAL"

--- a/doc/contents/scala/plotScalaDemo.ipynb
+++ b/doc/contents/scala/plotScalaDemo.ipynb
@@ -11,19 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "10f5dbf2-4ff1-40f4-b30b-368bc94a6518"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot();\n",
     "val y1 = Seq(1.5, 1, 6, 5, 2, 8)\n",
@@ -34,19 +24,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f2a609f3-068b-48a2-b0e4-83d4e6151f41"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot(\"Elo\")\n",
     "var cs = new Color(255, 0, 0, 128)// transparent bars\n",
@@ -56,19 +36,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "229c19cf-9d65-4402-b124-ad5008866331"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot(\"Changing Point Size, Color, Shape\")\n",
     "val y1 = Seq(6, 7, 12, 11, 8, 14)\n",
@@ -83,19 +53,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78bc96c8-0412-4f23-83df-d01f4ba8e301"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot(\"Changing point properties with list\")\n",
     "val cs = Seq(Color.black, Color.red, Color.orange, Color.green, Color.blue, Color.pink)\n",
@@ -112,19 +72,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5e23ab37-45ae-4926-9d59-30c7f97208ca"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot()\n",
     "val y = Seq(3, 5, 2, 3)\n",
@@ -136,19 +86,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b5a2d8ac-9746-4976-8cad-110d02185d26"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val p = new Plot()\n",
     "p.add(new Line(Seq(3, 6, 12, 24), \"Median\"))\n",
@@ -157,19 +97,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0fad36fb-b0d3-4ce1-81d4-16172a4319da"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val y1 = Seq(1,5,3,2,3)\n",
     "val y2 = Seq(7,2,4,1,3)\n",
@@ -180,19 +110,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "04d7ba26-d03d-4004-8f29-e3bad2cb6f9d"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val p = new Plot ()\n",
     "p.add(new Line(Seq(-1, 1)))\n",
@@ -203,19 +123,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9035e0ba-f910-41bb-a081-545b3a8abaae"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val constBand = new ConstantBand(Seq(1, 2), Seq(1, 3))\n",
     "val lineVal = new Line(Seq(-3, 1, 3, 4, 5))\n",
@@ -226,19 +136,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fd1b8496-92e5-40d7-9fe8-8f12cf3b646a"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val p = new Plot() \n",
     "p.add(new Line(Seq(-3, 1, 2, 4, 5), Seq(4, 2, 6, 1, 5)))\n",
@@ -249,19 +149,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f4d0e3ab-6027-44b5-8d9a-fb4259cd4d7f"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot()\n",
     "val xs = Seq(1,2,3,4,5,6,7,8,9,10)\n",
@@ -288,19 +178,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b0ce34ce-dab9-4def-9c5a-227d81f3dd1b"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val ch = new Crosshair(new Color(255, 128, 5), 2, StrokeType.DOT)\n",
     "val pp = new Plot(ch, true, LegendLayout.HORIZONTAL, LegendPosition.TOP)\n",
@@ -313,19 +193,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "99124a78-610b-4906-b2c6-1cf4ecd25ede"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
     "\n",
@@ -336,19 +206,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "44b49da6-b351-4340-aaba-eec62f02bc94"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val points = 100\n",
     "val logBase = 10\n",
@@ -373,19 +233,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f3187af2-ef55-4f93-8cb3-632d0ac3cc2a"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val points = 100\n",
     "val logBase = 10\n",
@@ -401,19 +251,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fccdca7d-5fae-464a-bb72-7df636424807"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import java.util.{Calendar, Date}\n",
     "import java.util.SimpleTimeZone\n",
@@ -443,19 +283,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bb736680-b8b7-47e6-a24a-453acc812835"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import java.util.Date\n",
     "\n",
@@ -470,19 +300,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "11723781-ca99-4016-9f00-0c10620e1ebb"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import scala.util.Random\n",
     "\n",
@@ -498,19 +318,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c860b0b1-1e64-42c9-a865-2afe405a2c84"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import java.nio.file.Files\n",
     "import java.io.File\n",
@@ -535,19 +345,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "69fb5199-efc9-4393-8f1a-5ab7e545cb9e"
-      }
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "val plot = new Plot(\"Setting 2nd Axis bounds\")\n",
     "val ys = List(0, 2, 4, 6, 15, 10)\n",

--- a/doc/contents/scala/tableApiScala.ipynb
+++ b/doc/contents/scala/tableApiScala.ipynb
@@ -6,18 +6,9 @@
    "source": [
     "# Scala API to the Table Widget\n",
     "\n",
-    "This API is being [improved](https://github.com/twosigma/beakerx/issues/5798)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "val table = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
+    "This API is being [improved](https://github.com/twosigma/beakerx/issues/5798).\n",
     "\n",
-    "table.display()"
+    "Note: The Scala kernel automatically imports Plot, Forms, and TableDisplay support."
    ]
   },
   {
@@ -26,9 +17,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.table.format.TableDisplayStringFormat\n",
+    "val table = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import java.util.concurrent.TimeUnit\n",
     "\n",
     "val display = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
@@ -42,7 +39,7 @@
     "display.setAlignmentProviderForType(ColumnType.Double, TableDisplayAlignmentProvider.RIGHT_ALIGNMENT)\n",
     "display.setAlignmentProviderForColumn(\"m3\", TableDisplayAlignmentProvider.CENTER_ALIGNMENT)\n",
     "\n",
-    "display.display()"
+    "display"
    ]
   },
   {
@@ -52,8 +49,7 @@
    "outputs": [],
    "source": [
     "display.setStringFormatForTimes(TimeUnit.HOURS)\n",
-    "\n",
-    "display.display()"
+    "display"
    ]
   },
   {
@@ -62,10 +58,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.table.format.TableDisplayStringFormat\n",
-    "import com.twosigma.beakerx.table.renderer.TableDisplayCellRenderer\n",
     "import java.util.concurrent.TimeUnit\n",
     "\n",
     "val display2 = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
@@ -74,7 +66,7 @@
     "//use the false parameter to hide the String value\n",
     "display2.setRendererForColumn(\"y10\", TableDisplayCellRenderer.getDataBarsRenderer(false))\n",
     "\n",
-    "display2.display()"
+    "display2"
    ]
   },
   {
@@ -83,11 +75,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.table.format.TableDisplayStringFormat\n",
-    "import com.twosigma.beakerx.table.renderer.TableDisplayCellRenderer\n",
-    "\n",
     "val display3 = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
     "display3.setStringFormatForType(ColumnType.Double, TableDisplayStringFormat.getDecimalFormat(9,9))\n",
     "//freeze a column\n",
@@ -99,7 +86,7 @@
     "\n",
     "//explicitly set column order/visiblity\n",
     "display3.setColumnOrder(List(\"m3\", \"y1\", \"y5\", \"time\", \"y2\")) //Columns in the list will be shown in the provided order. Columns not in the list will be hidden.\n",
-    "display3.display()"
+    "display3"
    ]
   },
   {
@@ -108,12 +95,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.table.format.TableDisplayStringFormat\n",
-    "import com.twosigma.beakerx.table.renderer.TableDisplayCellRenderer\n",
-    "import com.twosigma.beakerx.table.highlight.TableDisplayCellHighlighter\n",
-    "\n",
     "def display4 = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
     "display4.addCellHighlighter(TableDisplayCellHighlighter.getHeatmapHighlighter(\"m3\", TableDisplayCellHighlighter.FULL_ROW))\n",
     "\n",
@@ -123,7 +104,7 @@
     "//set the colors used for the min and max\n",
     "//display4.addCellHighlighter(TableDisplayCellHighlighter.getHeatmapHighlighter(\"m6\", TableDisplayCellHighlighter.SINGLE_COLUMN, null, null, Color.YELLOW, Color.BLUE))\n",
     "\n",
-    "display4.display()"
+    "display4"
    ]
   },
   {
@@ -132,9 +113,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "\n",
     "val map = Seq(Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "               Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
     "               Map(\"a\" -> 7, \"b\" -> 8, \"c\" -> 9))\n",
@@ -147,20 +125,17 @@
     "       }\n",
     "})\n",
     "\n",
-    "display5.display()"
+    "display5"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.chart.Color\n",
-    "import com.twosigma.beakerx.table.highlight.ThreeColorHeatmapHighlighter\n",
-    "\n",
     "val display6 = new TableDisplay(new CsvPlotReader().readFile(\"../demoResources/interest-rates.csv\"))\n",
     "display6.addCellHighlighter(TableDisplayCellHighlighter.getHeatmapHighlighter(\"m3\", 0, 8, Color.ORANGE, Color.PINK))\n",
     "display6.addCellHighlighter(TableDisplayCellHighlighter.getHeatmapHighlighter(\"m6\", HighlightStyle.SINGLE_COLUMN, 6, 8, Color.BLACK, Color.PINK))\n",
@@ -169,7 +144,7 @@
     "\n",
     "//wipe out all highlighting\n",
     "//display6.removeAllCellHighlighters()\n",
-    "display6.display()"
+    "display6"
    ]
   },
   {
@@ -178,11 +153,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.chart.Color\n",
-    "import com.twosigma.beakerx.table.highlight.ThreeColorHeatmapHighlighter\n",
-    "\n",
     "val table = new TableDisplay(Seq(Seq(1,2,3), \n",
     "                                 Seq(3,4,5), \n",
     "                                 Seq(6,2,8), \n",
@@ -196,7 +166,7 @@
     "                                 Seq(\"double\", \"double\", \"double\"))\n",
     "\n",
     "table.addCellHighlighter(TableDisplayCellHighlighter.getUniqueEntriesHighlighter(\"b\", HighlightStyle.FULL_ROW))\n",
-    "table.display()"
+    "table"
    ]
   },
   {
@@ -205,8 +175,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "\n",
     "val mapList4 = Seq(\n",
     "   Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
@@ -226,7 +194,7 @@
     "       }\n",
     "})\n",
     "\n",
-    "display7.display()"
+    "display7"
    ]
   },
   {
@@ -235,9 +203,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "\n",
     "val mapList4 = List(\n",
     "   Map(\"a\" -> 1, \"b\" -> 2, \"c\" -> 3),\n",
     "   Map(\"a\" -> 4, \"b\" -> 5, \"c\" -> 6),\n",
@@ -257,7 +222,7 @@
     "display7.addContextMenuItem(\"run misc_formatting\", \"misc_formatting\");\n",
     "display7.setDoubleClickAction(\"misc_formatting\");\n",
     "\n",
-    "display7.display()"
+    "display7"
    ]
   },
   {
@@ -266,10 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "import com.twosigma.beakerx.scala.fileloader.CsvPlotReader\n",
-    "import com.twosigma.beakerx.chart.Color\n",
-    "import java.{lang, util}\n",
+    "import java.util\n",
     "\n",
     "val mapList5 = List(\n",
     " Map(\"firstCol\" -> 1, \"secondCol\" -> 2, \"thirdCol\" -> 3),\n",
@@ -300,7 +262,7 @@
     "})\n",
     "\n",
     "td4.setRowFilter(new RowFilter {\n",
-    "override def apply(row: Integer, values: util.List[util.List[_]]): lang.Boolean = {\n",
+    "override def apply(row: Integer, values: util.List[util.List[_]]): java.lang.Boolean = {\n",
     "        if (values.get(row).get(0).asInstanceOf[Int] > 0) true else false\n",
     "    }\n",
     "})\n",
@@ -309,7 +271,7 @@
     "//you can also do this in the right-click menu\n",
     "td4.setHeadersVertical(true)\n",
     "\n",
-    "td4.display()"
+    "td4"
    ]
   },
   {
@@ -332,8 +294,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "    \n",
     "val display1 = new TableDisplay(mapList)\n",
     "\n",
     "//add a context menu item\n",
@@ -343,7 +303,7 @@
     "       }\n",
     "})\n",
     "\n",
-    "display1.display()"
+    "display1"
    ]
   },
   {
@@ -352,15 +312,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import com.twosigma.beakerx.scala.table._\n",
-    "    \n",
     "val display2 = new TableDisplay(mapList)\n",
     "\n",
     "//run tagged cell on action\n",
     "display2.addContextMenuItem(\"run print cell\", \"print_cell\");\n",
     "display2.setDoubleClickAction(\"print_cell\");\n",
     "\n",
-    "display2.display()"
+    "display2"
    ]
   },
   {


### PR DESCRIPTION
Here's some code to do the Scala auto-display of DisplayTables and (immutable) Maps (#5895).

As noted in the comments, there is a limitation in the current jvm-repr that makes it work only with classes and not interfaces (or Scala traits, which map to JVM interfaces modulo concrete methods).  It's just lucky that there is an abstract class for Map.  I opened an issue in jvm-repr for this, but I doubt anything will change in the near future.

Minor accompanying changes to the doc notebooks, mostly removing redundant `.display()` calls and unnecessary imports.