### PR TITLE
Factor out isNanoPlot condition test and make it work for subclasses

### DIFF
--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/ConstantBandSerializer.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/ConstantBandSerializer.java
@@ -37,7 +37,7 @@ public class ConstantBandSerializer extends JsonSerializer<ConstantBand> {
 
     jgen.writeStartObject();
 
-    boolean isNanoPlot = NanoPlot.class.equals(constantBand.getPlotType());
+    boolean isNanoPlot = NanoPlot.isNanoPlotClass(constantBand.getPlotType());
     jgen.writeObjectField(TYPE, constantBand.getClass().getSimpleName());
     jgen.writeObjectField("x", isNanoPlot ? processLargeNumbers(constantBand.getX()) : constantBand.getX());
     jgen.writeObjectField("y", constantBand.getY());

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/ConstantLineSerializer.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/ConstantLineSerializer.java
@@ -36,7 +36,7 @@ public class ConstantLineSerializer extends JsonSerializer<ConstantLine> {
 
     jgen.writeStartObject();
 
-    boolean isNanoPlot = NanoPlot.class.equals(constantLine.getPlotType());
+    boolean isNanoPlot = NanoPlot.isNanoPlotClass(constantLine.getPlotType());
     jgen.writeObjectField(TYPE, constantLine.getClass().getSimpleName());
     jgen.writeObjectField("x", isNanoPlot ? processLargeNumber(constantLine.getX()) : constantLine.getX());
     jgen.writeObjectField("y", constantLine.getY());

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/TextSerializer.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/TextSerializer.java
@@ -35,7 +35,7 @@ public class TextSerializer extends JsonSerializer<Text> {
   public void serialize(Text text, JsonGenerator jgen, SerializerProvider sp)
     throws IOException, JsonProcessingException {
 
-    boolean isNanoPlot = NanoPlot.class.equals(text.getPlotType());
+    boolean isNanoPlot = NanoPlot.isNanoPlotClass(text.getPlotType());
     jgen.writeStartObject();
     jgen.writeObjectField(TYPE, text.getClass().getSimpleName());
     jgen.writeObjectField("x", isNanoPlot ? processLargeNumber(text.getX()) : text.getX());

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/XYGraphicsSerializer.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/serializer/XYGraphicsSerializer.java
@@ -42,7 +42,7 @@ public class XYGraphicsSerializer<T extends XYGraphics> extends GraphicsSerializ
 
     super.serialize(xyGraphics, jgen, sp);
 
-    boolean isNanoPlot = NanoPlot.class.equals(xyGraphics.getPlotType());
+    boolean isNanoPlot = NanoPlot.isNanoPlotClass(xyGraphics.getPlotType());
     jgen.writeObjectField("x", isNanoPlot ? processLargeNumbers(xyGraphics.getX()) : xyGraphics.getX());
     jgen.writeObjectField("y", xyGraphics.getY());
     jgen.writeObjectField(DISPLAY_NAME, xyGraphics.getDisplayName());

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/NanoPlot.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/NanoPlot.java
@@ -16,6 +16,10 @@
 
 package com.twosigma.beakerx.chart.xychart;
 
-public class NanoPlot extends TimePlot {
+import javax.annotation.Nullable;
 
+public class NanoPlot extends TimePlot {
+  static public boolean isNanoPlotClass(@Nullable Class<?> plotClass) {
+    return plotClass != null && NanoPlot.class.isAssignableFrom(plotClass);
+  }
 }

--- a/kernel/base/src/test/java/com/twosigma/beakerx/chart/xychart/NanoPlotTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/chart/xychart/NanoPlotTest.java
@@ -77,6 +77,15 @@ public class NanoPlotTest  extends XYChartTest<NanoPlot>{
     Assertions.assertThat(nanoPlot.getGraphics().size()).isEqualTo(2);
   }
 
+  @Test
+  public void nanoPlotSubclassIsNanoPlot() {
+    class FemtoPlot extends NanoPlot {
+
+    }
+    NanoPlot plot = new FemtoPlot();
+    Assertions.assertThat(NanoPlot.isNanoPlotClass(plot.getClass())).isTrue();
+  }
+
   @Override
   public NanoPlot createWidget() {
     NanoPlot nanoPlot = new NanoPlot();


### PR DESCRIPTION
The plot-type test for NanoPlot uses class equality, which won't work if we subclass NanoPlot to add language-specific methods and/or do anonymous subclass initialization (e.g. for Scala).