### PR TITLE
#6245 extract common base class for category plotitems that have bases

### DIFF
--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/BasedCategoryGraphics.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/BasedCategoryGraphics.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.beakerx.chart.categoryplot.plotitem;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+public abstract class BasedCategoryGraphics extends CategoryGraphics {
+  private Number baseBase = 0.0d;
+  private List<Object> bases;
+
+  public void setBase(Number base) {
+    this.baseBase = base.floatValue();
+  }
+
+  public void setBase(List<Object> base) {
+    Predicate<Object> number = o -> o instanceof Number;
+    Predicate<Object> listOfNumber = o -> o instanceof List<?> &&
+        ((List<?>)o).stream().allMatch(number);
+    if (base.stream().allMatch(number.or(listOfNumber))) {
+      setBases(base);
+    } else {
+      throw new IllegalArgumentException("List of bases must consist of Numbers or Lists of Numbers");
+    }
+  }
+
+  private void setBases(List<Object> bases) {
+    this.bases = bases;
+  }
+
+  public Number getBase() {
+    return this.baseBase;
+  }
+
+  public List<Object> getBases() {
+    return this.bases;
+  }
+}

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryArea.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryArea.java
@@ -21,12 +21,10 @@ import com.twosigma.beakerx.chart.Color;
 import com.twosigma.beakerx.chart.xychart.plotitem.LabelPositionType;
 import java.util.List;
 
-public class CategoryArea extends CategoryGraphics {
+public class CategoryArea extends BasedCategoryGraphics {
 
   private Number baseWidth;
   private List<Number> widths;
-  private Number baseBase = 0.0d;
-  private List<Number> bases;
   private Color baseOutlineColor;
   private List<Object> outlineColors;
   private Boolean baseFill;
@@ -35,26 +33,6 @@ public class CategoryArea extends CategoryGraphics {
   private List<Boolean> outlines;
 
   private LabelPositionType labelPosition = LabelPositionType.CENTER;
-
-  public void setBase(Number base) {
-    this.baseBase = base.floatValue();
-  }
-
-  public void setBase(List<Number> base) {
-    setBases(base);
-  }
-
-  private void setBases(List<Number> bases) {
-    this.bases = bases;
-  }
-
-  public Number getBase() {
-    return this.baseBase;
-  }
-
-  public List<Number> getBases() {
-    return this.bases;
-  }
 
   public void setWidth(Number width) {
     this.baseWidth = width.floatValue();

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryBars.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryBars.java
@@ -22,12 +22,10 @@ import com.twosigma.beakerx.chart.xychart.plotitem.LabelPositionType;
 
 import java.util.List;
 
-public class CategoryBars extends CategoryGraphics {
+public class CategoryBars extends BasedCategoryGraphics {
 
   private Number       baseWidth;
   private List<Number> widths;
-  private Number baseBase = 0.0d;
-  private List<Number>  bases;
   private Color         baseOutlineColor;
   private List<Object>   outlineColors;
   private Boolean       baseFill;
@@ -36,26 +34,6 @@ public class CategoryBars extends CategoryGraphics {
   private List<Boolean> outlines;
 
   private LabelPositionType labelPosition = LabelPositionType.CENTER;
-
-  public void setBase(Number base) {
-    this.baseBase = base.floatValue();
-  }
-
-  public void setBase(List<Number> base) {
-    setBases(base);
-  }
-
-  private void setBases(List<Number> bases) {
-    this.bases = bases;
-  }
-
-  public Number getBase() {
-    return this.baseBase;
-  }
-
-  public List<Number> getBases() {
-    return this.bases;
-  }
 
   public void setWidth(Number width) {
     this.baseWidth = width.floatValue();

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryGraphics.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryGraphics.java
@@ -39,7 +39,7 @@ public abstract class CategoryGraphics extends Graphics {
   private boolean centerSeries = false;
   private boolean useToolTip = true;
 
-  protected List<Number> getBases() {
+  protected List<Object> getBases() {
     return null;
   }
 

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryStems.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/categoryplot/plotitem/CategoryStems.java
@@ -22,32 +22,10 @@ import com.twosigma.beakerx.chart.xychart.plotitem.StrokeType;
 
 import java.util.List;
 
-public class CategoryStems extends CategoryGraphics {
-  private Number       baseBase;
-  private List<Number> bases;
+public class CategoryStems extends BasedCategoryGraphics {
   private Float      width     = 1.5f;
   private StrokeType baseStyle = StrokeType.SOLID;
   private List<StrokeType> styles;
-
-  public void setBase(Number base) {
-    this.baseBase = base.floatValue();
-  }
-
-  public void setBase(List<Number> base) {
-    setBases(base);
-  }
-
-  private void setBases(List<Number> bases) {
-    this.bases = bases;
-  }
-
-  public Number getBase() {
-    return this.baseBase;
-  }
-
-  public List<Number> getBases() {
-    return this.bases;
-  }
 
   public void setWidth(Float width) {
     this.width = width;

--- a/kernel/base/src/test/java/com/twosigma/beakerx/chart/categoryplot/plotitem/BasedCategoryGraphicsTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/chart/categoryplot/plotitem/BasedCategoryGraphicsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.beakerx.chart.categoryplot.plotitem;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class BasedCategoryGraphicsTest {
+  protected BasedCategoryGraphics graphics;
+  protected List<Object> numberList = Arrays.asList(1, 2, 3);
+  protected List<Object> listOfNumberLists = Arrays.asList(
+      Arrays.asList(1, 2, 3),
+      Arrays.asList(4, 5, 6)
+  );
+  protected List<Object> listOfNumbersAndListsOfNumbers = Arrays.asList(
+      1, 2, Arrays.asList(3, 4, 5)
+  );
+  protected List<Object> numberAndNonNumberList = Arrays.asList(1, "2", 3);
+  protected List<Object> numberAndListWithNonNumbersList = Arrays.asList(1, 2, Arrays.asList(3, "4", 5));
+
+  @Before
+  public void setup() {
+    graphics = new BasedCategoryGraphics() {};
+  }
+
+  @Test
+  public void setBaseNumber() throws Exception {
+    graphics.setBase(3);
+
+    assertEquals(3.0, graphics.getBase().doubleValue(), 0.01);
+  }
+
+  @Test
+  public void setBaseListOfNumbers() throws Exception {
+    graphics.setBase(numberList);
+
+    assertEquals(numberList, graphics.getBases());
+  }
+
+  @Test
+  public void setBaseListOfList() throws Exception {
+    graphics.setBase(listOfNumberLists);
+
+    assertEquals(listOfNumberLists, graphics.getBases());
+  }
+
+  @Test
+  public void setBaseListOfMixed() throws Exception {
+    graphics.setBase(listOfNumbersAndListsOfNumbers);
+
+    assertEquals(listOfNumbersAndListsOfNumbers, graphics.getBases());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setBaseListOfNumbersAndNonNumbers() throws Exception {
+    graphics.setBase(numberAndNonNumberList);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void setBaseListofListsWithNonNumbers() throws Exception {
+    graphics.setBase(numberAndListWithNonNumbersList);
+  }
+}


### PR DESCRIPTION
This pulls out the common behavior, fixes the static type to reflect reality, and adds a runtime check that the values passed are of the expected types.  A test is also provided to verify and document legal and illegal combinations.

The category plot demos all still seem to work as expected.

#6245 