### PR TITLE
Security - use https for downloading jars

### DIFF
--- a/kernel/base/src/main/resources/PomTemplateMagicCommand.xml
+++ b/kernel/base/src/main/resources/PomTemplateMagicCommand.xml
@@ -11,7 +11,7 @@
     <repositories>
         <repository>
             <id>clojureRepo</id>
-            <url>http://clojars.org/repo</url>
+            <url>https://clojars.org/repo</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Using http for Maven repos is a security risk. See https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/