### PR TITLE
#6571 mvn check for updates by default

### DIFF
--- a/kernel/base/src/main/java/com/twosigma/beakerx/kernel/magic/command/MavenJarResolver.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/kernel/magic/command/MavenJarResolver.java
@@ -63,6 +63,7 @@ public class MavenJarResolver {
       InvocationRequest request = createInvocationRequest();
       request.setOffline(commandParams.getOffline());
       request.setPomFile(finalPom);
+      request.setUpdateSnapshots(true);
       Invoker invoker = getInvoker(progress);
       progress.display();
       InvocationResult invocationResult = invoker.execute(request);


### PR DESCRIPTION
Mvn command is now executed with update snapshot flag so if there any outdated snapshots or missing artifacts maven will check for updates in remote repository.