### PR TITLE
#6597 comm_info handler should filter requested comms by `target_name`

### DIFF
--- a/js/lab/src/interface/messageData.ts
+++ b/js/lab/src/interface/messageData.ts
@@ -1,4 +1,9 @@
 export interface messageData {
+  state?: messageState
+}
+
+export interface messageState {
   name?: string,
-  value?: any
+  value?: any,
+  runByTag?: string
 }

--- a/js/lab/src/plugin/comm.ts
+++ b/js/lab/src/plugin/comm.ts
@@ -18,7 +18,7 @@ import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { INotebookModel, Notebook, NotebookPanel } from '@jupyterlab/notebook';
 import { showDialog, Dialog, IClientSession } from '@jupyterlab/apputils';
 import { sendJupyterCodeCells, getCodeCellsByTag } from './codeCells';
-import { messageData } from '../interface/messageData';
+import {messageData, messageState} from '../interface/messageData';
 import { Kernel } from "@jupyterlab/services";
 import { CodeCell } from '@jupyterlab/cells';
 
@@ -32,27 +32,27 @@ const getMsgHandlers = (
   notebook: Notebook
 ) => ({
   [BEAKER_GETCODECELLS]: (msg) => {
-    const data: messageData = <object>msg.content.data;
+    const state: messageState = msg.content.data.state;
 
-    if (!data.name) {
+    if (!state.name) {
       return;
     }
 
-    if(data.name == "CodeCells") {
-      sendJupyterCodeCells(kernelInstance, notebook, JSON.parse(data.value));
+    if(state.name == "CodeCells") {
+      sendJupyterCodeCells(kernelInstance, notebook, JSON.parse(state.value));
     }
 
-    window.beakerx[data.name] = JSON.parse(data.value);
+    window.beakerx[state.name] = JSON.parse(state.value);
   },
 
   [BEAKER_AUTOTRANSLATION]: (msg) => {
-    const data: messageData = <object>msg.content.data;
+    const state: messageState = msg.content.data.state;
 
-    window.beakerx[data.name] = JSON.parse(data.value);
+    window.beakerx[state.name] = JSON.parse(state.value);
   },
 
   [BEAKER_TAG_RUN]: (msg) => {
-    const data: { state?: any } = <object>msg.content.data;
+    const data: messageData = msg.content.data;
 
     if(!data.state || !data.state.runByTag) {
       return;

--- a/js/notebook/src/extension/comm.ts
+++ b/js/notebook/src/extension/comm.ts
@@ -84,7 +84,7 @@ export const registerCommTargets = (kernel: any): void => {
   });
 
   kernel.comm_info(
-    'beaker.getcodecells', (msg) => { assignMsgHandlersToExistingComms(msg.content.comms, kernel); }
+    null, (msg) => { assignMsgHandlersToExistingComms(msg.content.comms, kernel); }
   );
 };
 
@@ -108,15 +108,10 @@ const sendJupyterCodeCells = (filter: string) => {
 
 const assignMsgHandlersToExistingComms = (comms, kernel) => {
   for (let commId in comms) {
-    if (kernel.comm_manager.comms[commId]) {
-      continue;
-    }
-
     let comm = new Comm(comms[commId].target_name, commId);
+    kernel.comm_manager.register_comm(comm);
 
     assignMsgHandlerToComm(comm);
-
-    kernel.comm_manager.register_comm(comm);
   }
 };
 

--- a/js/notebook/src/extension/comm.ts
+++ b/js/notebook/src/extension/comm.ts
@@ -30,7 +30,7 @@ const { Comm } = require('services/kernels/comm');
 
 const msgHandlers = {
   [BEAKER_GETCODECELLS]: (msg) => {
-    if(msg.content.data.name == "CodeCells"){
+    if(msg.content.data.state.name == "CodeCells"){
       sendJupyterCodeCells(JSON.parse(msg.content.data.state.value));
     }
 
@@ -74,21 +74,17 @@ export const registerCommTargets = (kernel: any): void => {
   kernel.comm_manager.register_target(BEAKER_GETCODECELLS, function(comm) {
     comm.on_msg(msgHandlers[BEAKER_GETCODECELLS]);
   });
+
   kernel.comm_manager.register_target(BEAKER_AUTOTRANSLATION, function(comm) {
     comm.on_msg(msgHandlers[BEAKER_AUTOTRANSLATION]);
   });
+
   kernel.comm_manager.register_target(BEAKER_TAG_RUN, function(comm) {
     comm.on_msg(msgHandlers[BEAKER_TAG_RUN]);
   });
 
-  kernel.send_shell_message(
-    "comm_info_request",
-    {},
-    {
-      shell: {
-        reply: (msg) => { assignMsgHandlersToExistingComms(msg.content.comms, kernel); }
-      }
-    }
+  kernel.comm_info(
+    'beaker.getcodecells', (msg) => { assignMsgHandlersToExistingComms(msg.content.comms, kernel); }
   );
 };
 
@@ -112,11 +108,15 @@ const sendJupyterCodeCells = (filter: string) => {
 
 const assignMsgHandlersToExistingComms = (comms, kernel) => {
   for (let commId in comms) {
+    if (kernel.comm_manager.comms[commId]) {
+      continue;
+    }
+
     let comm = new Comm(comms[commId].target_name, commId);
 
-    kernel.comm_manager.register_comm(comm);
-
     assignMsgHandlerToComm(comm);
+
+    kernel.comm_manager.register_comm(comm);
   }
 };
 


### PR DESCRIPTION
The widgets manager sends the `comm_info_request` msg to kernel with `{ target_name: "jupyter.widgets" }` content and expects only comms with this target to be returned.
Instead our handler returns all comms ( e.g. 'beaker.getcodecells' ) and then WidgetManager registers our comm (`beaker.getcodecells`) as the `jupyter.widgets` comm. That is why frontend do not responds to backend msg after calling for the codeCells. It does not have the proper comm registered to handle this response.  