### PR TITLE
#6619 xy properties

### DIFF
--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/AbstractChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/AbstractChart.java
@@ -127,8 +127,16 @@ public abstract class AbstractChart extends Chart {
     return this;
   }
 
-  public Boolean getYAutoRange() {
+  public AbstractChart setYAutoRange(boolean yAutoRange) {
+    return setyAutoRange(yAutoRange);
+  }
+
+  public Boolean getyAutoRange() {
     return this.yAxis.getAutoRange();
+  }
+
+  public Boolean getYAutoRange() {
+    return getyAutoRange();
   }
 
   public AbstractChart setYAutoRangeIncludesZero(boolean yAutoRangeIncludesZero) {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/AbstractChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/AbstractChart.java
@@ -51,6 +51,10 @@ public abstract class AbstractChart extends Chart {
     return this.xLabel;
   }
 
+  public String getxLabel() {
+    return getXLabel();
+  }
+
   public AbstractChart setYLabel(String yLabel) {
     yAxis.setLabel(yLabel);
     sendModelUpdate(ChartToJson.serializeYLabel(this.yAxis.getLabel()));
@@ -107,6 +111,10 @@ public abstract class AbstractChart extends Chart {
     return this.xLowerMargin;
   }
 
+  public double getxLowerMargin() {
+    return getXLowerMargin();
+  }
+
   public AbstractChart setXUpperMargin(double margin) {
     this.xUpperMargin = margin;
     sendModelUpdate(ChartToJson.serializeXUpperMargin(this.xUpperMargin));
@@ -119,6 +127,10 @@ public abstract class AbstractChart extends Chart {
 
   public double getXUpperMargin() {
     return this.xUpperMargin;
+  }
+
+  public double getxUpperMargin() {
+    return getXUpperMargin();
   }
 
   public AbstractChart setyAutoRange(boolean yAutoRange) {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/AbstractChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/AbstractChart.java
@@ -70,6 +70,10 @@ public abstract class AbstractChart extends Chart {
     return yAxis.getLabel();
   }
 
+  public String getyLabel() {
+    return getYLabel();
+  }
+
   public AbstractChart add(YAxis yAxis) {
     this.yAxes.add(yAxis);
     sendModelUpdate(ChartToJson.serializeYAxes(this.yAxes));
@@ -82,6 +86,10 @@ public abstract class AbstractChart extends Chart {
 
   public List<YAxis> getYAxes() {
     return this.yAxes;
+  }
+
+  public List<YAxis> getyAxes() {
+    return getYAxes();
   }
 
   public AbstractChart add(List items) {
@@ -165,6 +173,10 @@ public abstract class AbstractChart extends Chart {
     return this.yAxis.getAutoRangeIncludesZero();
   }
 
+  public Boolean getyAutoRangeIncludesZero() {
+    return getYAutoRangeIncludesZero();
+  }
+
   public AbstractChart setYLowerMargin(double margin) {
     return setyLowerMargin(margin);
   }
@@ -179,6 +191,10 @@ public abstract class AbstractChart extends Chart {
     return this.yAxis.getLowerMargin();
   }
 
+  public double getyLowerMargin() {
+    return getYLowerMargin();
+  }
+
   public AbstractChart setYUpperMargin(double margin) {
     return setyUpperMargin(margin);
   }
@@ -191,6 +207,10 @@ public abstract class AbstractChart extends Chart {
 
   public double getYUpperMargin() {
     return this.yAxis.getUpperMargin();
+  }
+
+  public double getyUpperMargin() {
+    return getYUpperMargin();
   }
 
   public AbstractChart setYBound(double lower, double upper) {
@@ -219,8 +239,16 @@ public abstract class AbstractChart extends Chart {
     return this.yAxis.getLowerBound();
   }
 
+  public Double getyLowerBound() {
+    return getYLowerBound();
+  }
+
   public Double getYUpperBound() {
     return this.yAxis.getUpperBound();
+  }
+
+  public Double getyUpperBound() {
+    return getYUpperBound();
   }
 
   public AbstractChart setLogY(boolean logY) {
@@ -245,6 +273,10 @@ public abstract class AbstractChart extends Chart {
 
   public Double getYLogBase() {
     return this.yAxis.getLogBase();
+  }
+
+  public Double getyLogBase() {
+    return getYLogBase();
   }
 
   protected AbstractChart setTimeZone(TimeZone timeZone) {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/Graphics.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/Graphics.java
@@ -67,6 +67,10 @@ public abstract class Graphics implements Serializable, Cloneable {
     return yAxisName;
   }
 
+  public String getyAxis() {
+    return getYAxis();
+  }
+
   public String getUid() {
     return uid;
   }

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/CombinedPlot.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/CombinedPlot.java
@@ -96,6 +96,10 @@ public class CombinedPlot extends ChartDetails {
     return this.xLabel;
   }
 
+  public String getxLabel() {
+    return getXLabel();
+  }
+
   public CombinedPlot add(XYChart plot, int weight) {
     this.subplots.add(plot);
     this.weights.add(weight);
@@ -146,6 +150,10 @@ public class CombinedPlot extends ChartDetails {
 
   public void setxTickLabelsVisible(boolean xTickLabelsVisible) {
     this.xTickLabelsVisible = xTickLabelsVisible;
+  }
+
+  public void setXTickLabelsVisible(boolean xTickLabelsVisible) {
+    setxTickLabelsVisible(xTickLabelsVisible);
   }
 
   @Override

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/CombinedPlot.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/CombinedPlot.java
@@ -140,6 +140,10 @@ public class CombinedPlot extends ChartDetails {
     return yTickLabelsVisible;
   }
 
+  public boolean isYTickLabelsVisible() {
+    return isyTickLabelsVisible();
+  }
+
   public void setyTickLabelsVisible(boolean yTickLabelsVisible) {
     this.yTickLabelsVisible = yTickLabelsVisible;
   }
@@ -150,6 +154,10 @@ public class CombinedPlot extends ChartDetails {
 
   public boolean isxTickLabelsVisible() {
     return xTickLabelsVisible;
+  }
+
+  public boolean isXTickLabelsVisible() {
+    return isxTickLabelsVisible();
   }
 
   public void setxTickLabelsVisible(boolean xTickLabelsVisible) {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/CombinedPlot.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/CombinedPlot.java
@@ -144,6 +144,10 @@ public class CombinedPlot extends ChartDetails {
     this.yTickLabelsVisible = yTickLabelsVisible;
   }
 
+  public void setYTickLabelsVisible(boolean yTickLabelsVisible) {
+    setyTickLabelsVisible(yTickLabelsVisible);
+  }
+
   public boolean isxTickLabelsVisible() {
     return xTickLabelsVisible;
   }

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/TimePlot.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/TimePlot.java
@@ -44,6 +44,10 @@ public class TimePlot extends XYChart {
     return this;
   }
 
+  public XYChart setxBound(Date lower, Date upper) {
+    return setXBound(lower, upper);
+  }
+
   @Override
   public XYChart setXBound(List bound) {
     if (bound.size() != 2) {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
@@ -180,15 +180,6 @@ abstract public class XYChart extends AbstractChart {
     return this.xUpperBound;
   }
 
-  public XYChart setYAutoRange(boolean yAutoRange) {
-    setXAutoRange(yAutoRange);
-    return this;
-  }
-
-  public XYChart setyAutoRange(boolean yAutoRange) {
-    return this.setYAutoRange(yAutoRange);
-  }
-
   public XYChart setLogX(boolean logX) {
     this.logX = logX;
     sendModelUpdate(ChartToJson.serializeLogX(this.logX));

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
@@ -149,12 +149,20 @@ abstract public class XYChart extends AbstractChart {
     return this.xAutoRange;
   }
 
+  public Boolean getxAutoRange() {
+    return getXAutoRange();
+  }
+
   public XYChart setXBound(double lower, double upper) {
     this.xAutoRange = false;
     this.xLowerBound = lower;
     this.xUpperBound = upper;
     sendModelUpdate(ChartToJson.serializeXBound(this));
     return this;
+  }
+
+  public XYChart setxBound(double lower, double upper) {
+    return setXBound(lower, upper);
   }
 
   public XYChart setXBound(List<Number> bound) {
@@ -176,8 +184,16 @@ abstract public class XYChart extends AbstractChart {
     return this.xLowerBound;
   }
 
+  public Double getxLowerBound() {
+    return getXLowerBound();
+  }
+
   public Double getXUpperBound() {
     return this.xUpperBound;
+  }
+
+  public Double getxUpperBound() {
+    return getXUpperBound();
   }
 
   public XYChart setLogX(boolean logX) {
@@ -192,6 +208,10 @@ abstract public class XYChart extends AbstractChart {
 
   public Double getXLogBase() {
     return xLogBase;
+  }
+
+  public Double getxLogBase() {
+    return getXLogBase();
   }
 
   public XYChart setXLogBase(double xLogBase) {
@@ -220,6 +240,10 @@ abstract public class XYChart extends AbstractChart {
   public void setxTickLabelsVisible(boolean xTickLabelsVisible) {
     this.xTickLabelsVisible = xTickLabelsVisible;
     sendModelUpdate(ChartToJson.serializeXTickLabelsVisible(this.xTickLabelsVisible));
+  }
+
+  public void setXTickLabelsVisible(boolean xTickLabelsVisible) {
+    setxTickLabelsVisible(xTickLabelsVisible);
   }
 
   public boolean isyTickLabelsVisible() {

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
@@ -254,4 +254,8 @@ abstract public class XYChart extends AbstractChart {
     this.yTickLabelsVisible = yTickLabelsVisible;
     sendModelUpdate(ChartToJson.serializeYTickLabelsVisible(this.yTickLabelsVisible));
   }
+
+  public void setYTickLabelsVisible(boolean yTickLabelsVisible) {
+    setyTickLabelsVisible(yTickLabelsVisible);
+  }
 }

--- a/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/chart/xychart/XYChart.java
@@ -237,6 +237,10 @@ abstract public class XYChart extends AbstractChart {
     return xTickLabelsVisible;
   }
 
+  public boolean isXTickLabelsVisible() {
+    return isxTickLabelsVisible();
+  }
+
   public void setxTickLabelsVisible(boolean xTickLabelsVisible) {
     this.xTickLabelsVisible = xTickLabelsVisible;
     sendModelUpdate(ChartToJson.serializeXTickLabelsVisible(this.xTickLabelsVisible));
@@ -248,6 +252,10 @@ abstract public class XYChart extends AbstractChart {
 
   public boolean isyTickLabelsVisible() {
     return yTickLabelsVisible;
+  }
+
+  public boolean isYTickLabelsVisible() {
+    return isyTickLabelsVisible();
   }
 
   public void setyTickLabelsVisible(boolean yTickLabelsVisible) {

--- a/kernel/base/src/test/java/com/twosigma/beakerx/chart/AbstractChartTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/chart/AbstractChartTest.java
@@ -291,6 +291,19 @@ public abstract class AbstractChartTest <T extends AbstractChart> extends ChartT
   }
 
   @Test
+  public void setyAutoRangeByFalse_YAutoRangeIsFalse() {
+    //given
+    AbstractChart chart =createWidget();
+    //when
+    chart.setyAutoRange(false);
+    //then
+    assertThat(chart.getYAutoRange()).isFalse();
+    LinkedHashMap model = getModelUpdate();
+    assertThat(model.size()).isEqualTo(1);
+    assertThat(model.get(Y_AUTO_RANGE)).isEqualTo(false);
+  }
+
+  @Test
   public void setyLogBaseWithDoubleParam_hasYLogBase() {
     //given
     AbstractChart chart =createWidget();

--- a/kernel/base/src/test/java/com/twosigma/beakerx/chart/xychart/XYChartTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/chart/xychart/XYChartTest.java
@@ -219,17 +219,4 @@ public abstract class XYChartTest<T extends XYChart> extends AbstractChartTest<X
 
   @Override
   public abstract T createWidget();
-
-  @Test
-  public void setyAutoRangeByTrue_YAutoRangeIsTrue() {
-    //given
-    AbstractChart chart =createWidget();
-    //when
-    chart.setyAutoRange(true);
-    //then
-    assertThat(chart.getYAutoRange()).isTrue();
-    LinkedHashMap model = getModelUpdate();
-    assertThat(model.size()).isEqualTo(1);
-    assertThat(model.get(X_AUTO_RANGE)).isEqualTo(true);
-  }
 }


### PR DESCRIPTION
This fixes the setyAutoRange bug and supplies (I think) all the missing upper/lower case versions of properties that start with X or Y.