### PR TITLE
do not install our magic to avoid #6810

### DIFF
--- a/beakerx/beakerx/install.py
+++ b/beakerx/beakerx/install.py
@@ -196,7 +196,7 @@ def _install_beakerx(args):
     _install_css()
     _copy_icons()
     _install_kernelspec_manager(args.prefix)
-    _install_magics()
+    #_install_magics()
     _set_conf_privileges()
 
 


### PR DESCRIPTION
todo: add `%load_ext beakerx.groovy_magic` to doc/python/GroovyMagic.ipynb