### PR TITLE
improve STIL example (#6722)

### DIFF
--- a/doc/groovy/STIL.ipynb
+++ b/doc/groovy/STIL.ipynb
@@ -23,7 +23,7 @@
     "stilFile = System.getProperty(\"java.io.tmpdir\") + \"/stilFiles/stil.jar\"\n",
     "FileUtils.copyURLToFile(new URL(stilUrl), new File(stilFile));\n",
     "\n",
-    "%classpath add dynamic stilFile"
+    "%classpath add dynamic stilFile\n"
    ]
   },
   {
@@ -32,23 +32,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import uk.ac.starlink.table.formats.StreamStarTable\n",
+    "import uk.ac.starlink.table.StarTable\n",
+    "import uk.ac.starlink.table.Tables\n",
     "import jupyter.Displayer\n",
     "import jupyter.Displayers\n",
     "\n",
-    "Displayers.register(StreamStarTable.class, new Displayer<StreamStarTable>() {\n",
-    "    \n",
-    "    def getArray(t){\n",
-    "        nCol = t.getColumnCount()\n",
-    "        rseq = t.getRowSequence()\n",
-    "        tableAsArray = []\n",
-    "        while ( rseq.next() ) {\n",
-    "            row = rseq.getRow();\n",
-    "            tableAsArray.add(row)\n",
-    "        }\n",
-    "        rseq.close();\n",
-    "        tableAsArray.toArray()\n",
-    "    };  \n",
+    "Displayers.register(StarTable.class, new Displayer<StarTable>() {\n",
     "        \n",
     "    def getColumnNames(t){\n",
     "        names = []\n",
@@ -60,10 +49,11 @@
     "    }\n",
     "    \n",
     "    @Override\n",
-    "    public Map<String, String> display(StreamStarTable table) {\n",
+    "    public Map<String, String> display(StarTable table) {\n",
     "        \n",
-    "        array =  getArray(table)  \n",
     "        columnNames = getColumnNames(table)\n",
+    "        columnInfos = Tables.getColumnInfos(table)\n",
+    "        MAXCHAR = 64\n",
     "        \n",
     "        new TableDisplay(\n",
     "                (int)table.getRowCount(),\n",
@@ -72,7 +62,8 @@
     "                new TableDisplay.Element() {\n",
     "                  @Override\n",
     "                  public String get(int columnIndex, int rowIndex) {\n",
-    "                    return array[rowIndex][columnIndex];\n",
+    "                    Object cell = table.getCell(rowIndex, columnIndex);\n",
+    "                    return columnInfos[columnIndex].formatValue(cell, MAXCHAR)\n",
     "                  }\n",
     "                }\n",
     "        ).display();\n",
@@ -101,9 +92,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import uk.ac.starlink.table.StarTable\n",
     "import uk.ac.starlink.table.StarTableFactory\n",
+    "import uk.ac.starlink.table.Tables\n",
     "\n",
-    "starTable= new StarTableFactory().makeStarTable( messierFile, \"csv\" );"
+    "starTable = new StarTableFactory().makeStarTable( messierFile, \"csv\" );\n",
+    "starTable = Tables.randomTable(starTable)"
    ]
   }
  ],


### PR DESCRIPTION
Fix the STIL example so that it accesses the StarTable object
cell values directly rather than just reading all the cells
into an internal array and accessing that.

The StarTable object requires random access for this to work;
tables read from CSV files are not random-access by default,
so the Tables.randomTable method has to get called on it.

In fact this is just moving the copy-to-internal-array step
out of the groovy and into the STIL library, so in this case
it doesn't make a huge amount of difference.  However, if the
input file was e.g. a FITS file, it would mean that data access
was strictly on-demand to the mapped disk file, and so potentially
much more efficient, especially for large files.