### PR TITLE
#6674 add EventManager and CellFocusManager tests

### DIFF
--- a/js/notebook/.gitignore
+++ b/js/notebook/.gitignore
@@ -4,3 +4,4 @@
 /dist
 node_modules/
 /build/
+/.nyc_output

--- a/js/notebook/package.json
+++ b/js/notebook/package.json
@@ -15,6 +15,13 @@
     "ipython",
     "ipywidgets"
   ],
+  "nyc": {
+    "extension": [
+      ".ts",
+      ".js"
+    ],
+    "include": ["**/src/tableDisplay/**/*.ts"]
+  },
   "scripts": {
     "build": "yarn run build:dev",
     "build:prod": "webpack --config webpack.prod.js --progress && yarn run build-lab-extension",
@@ -22,6 +29,7 @@
     "build-lab-extension": "cd ../lab && npm install",
     "prepublish": "yarn run build:prod",
     "test": "TS_NODE_PROJECT=test mocha",
+    "coverage": "TS_NODE_PROJECT=test nyc mocha",
     "stats": "webpack --env production --profile --json > stats.json"
   },
   "devDependencies": {
@@ -38,6 +46,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^5.0.0",
     "node-sass": "^4.5.2",
+    "nyc": "^11.4.1",
     "sass-loader": "^6.0.5",
     "sinon": "^4.2.0",
     "source-map-loader": "^0.2.1",

--- a/js/notebook/package.json
+++ b/js/notebook/package.json
@@ -16,11 +16,8 @@
     "ipywidgets"
   ],
   "nyc": {
-    "extension": [
-      ".ts",
-      ".js"
-    ],
-    "include": ["**/src/tableDisplay/**/*.ts"]
+    "extension": [ ".ts" ],
+    "include": [ "**/src/**/*.ts" ]
   },
   "scripts": {
     "build": "yarn run build:dev",

--- a/js/notebook/src/tableDisplay/dataGrid/DataGridScope.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/DataGridScope.ts
@@ -18,7 +18,6 @@ import { Widget } from '@phosphor/widgets';
 import { BeakerxDataGrid } from './BeakerxDataGrid';
 import { silverStripeStyle } from './style/dataGridStyle';
 import IDataGridScopeOptions from "./interface/IDataGridScopeOptions";
-import consts from "../consts";
 
 export class DataGridScope {
   readonly dataGrid: BeakerxDataGrid;
@@ -36,6 +35,8 @@ export class DataGridScope {
       },
       options.data
     );
+
+    this.connectToCommSignal();
   }
 
   render(): void {
@@ -48,7 +49,6 @@ export class DataGridScope {
 
   updateModelData(newData) {
     this.dataGrid.updateModelData(newData);
-    this.dataGrid.model.reset();
   }
 
   doResetAll() {
@@ -59,5 +59,11 @@ export class DataGridScope {
     this.dataGrid.columnManager.showAllColumns();
     this.dataGrid.columnManager.resetColumnsAlignment();
     this.dataGrid.columnManager.resetColumnsOrder();
+  }
+
+  connectToCommSignal() {
+    this.dataGrid.commSignal.connect((handler, args) => {
+      this.tableDisplayModel.send(args, this.tableDisplayView.callbacks());
+    }, this);
   }
 }

--- a/js/notebook/src/tableDisplay/dataGrid/EventManager.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/EventManager.ts
@@ -15,7 +15,7 @@
  */
 
 import {BeakerxDataGrid} from "./BeakerxDataGrid";
-import DataGridColumn from "./column/DataGridColumn";
+import DataGridColumn, {COLUMN_TYPES} from "./column/DataGridColumn";
 import {HIGHLIGHTER_TYPE} from "./interface/IHighlighterState";
 import {DataGridHelpers} from "./dataGridHelpers";
 import disableKeyboardManager = DataGridHelpers.disableKeyboardManager;
@@ -29,9 +29,12 @@ export default class EventManager {
     this.handleKeyDown = this.handleKeyDown.bind(this);
     this.handleMouseOut = this.handleMouseOut.bind(this);
     this.handleMouseOut = this.handleMouseOut.bind(this);
+    this.handleDoubleClick = this.handleDoubleClick.bind(this);
 
     this.dataGrid.node.removeEventListener('mouseout', this.handleMouseOut);
     this.dataGrid.node.addEventListener('mouseout', this.handleMouseOut);
+    this.dataGrid.node.removeEventListener('dblclick', this.handleDoubleClick);
+    this.dataGrid.node.addEventListener('dblclick', this.handleDoubleClick);
     document.removeEventListener('keydown', this.handleKeyDown);
     document.addEventListener('keydown', this.handleKeyDown);
   }
@@ -158,6 +161,40 @@ export default class EventManager {
       column.setDataTypePrecission(parseInt(charCode));
     } else {
       this.dataGrid.columnManager.setColumnsDataTypePrecission(parseInt(charCode));
+    }
+  }
+
+  private handleDoubleClick(event: MouseEvent) {
+    event.stopPropagation();
+    event.preventDefault();
+
+    if (this.dataGrid.isOverHeader(event)) {
+      return;
+    }
+
+    const data = this.dataGrid.getCellData(event.clientX, event.clientY);
+
+    if (!data || data.type === COLUMN_TYPES.index) {
+      return;
+    }
+
+    if (this.dataGrid.model.state.hasDoubleClickAction) {
+      this.dataGrid.commSignal.emit({
+        event: 'DOUBLE_CLICK',
+        row : data.row,
+        column: data.column
+      });
+    }
+
+    if (this.dataGrid.model.state.doubleClickTag) {
+      this.dataGrid.commSignal.emit({
+        event: 'actiondetails',
+        params: {
+          actionType: 'DOUBLE_CLICK',
+          row: data.row,
+          col: data.column
+        }
+      });
     }
   }
 }

--- a/js/notebook/src/tableDisplay/dataGrid/cell/CellFocusManager.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/cell/CellFocusManager.ts
@@ -26,6 +26,7 @@ export default class CellFocusManager {
 
   constructor(dataGrid: BeakerxDataGrid) {
     this.dataGrid = dataGrid;
+    this.focusedCellData = null;
   }
 
   setFocusedCell(cellData: ICellData|null) {

--- a/js/notebook/src/tableDisplay/dataGrid/column/DataGridColumn.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/column/DataGridColumn.ts
@@ -122,6 +122,7 @@ export default class DataGridColumn {
     this.setState({ displayType });
     this.assignFormatFn();
     this.dataGrid.repaint();
+    this.dataGrid.resizeSections();
   }
 
   setTimeDisplayType(timeUnit) {
@@ -306,6 +307,27 @@ export default class DataGridColumn {
     }
   }
 
+  addMinMaxValues() {
+    let valueResolver = this.getValueResolver();
+    let minMax = minmax(this.valuesIterator.clone(), (a:any, b:any) => {
+      let value1 = valueResolver(a);
+      let value2 = valueResolver(b);
+
+      if (value1 === value2) {
+        return 0;
+      }
+
+      return value1 < value2 ? -1 : 1;
+    });
+
+    this.minValue = minMax ? minMax[0] : null;
+    this.maxValue = minMax ? minMax[1] : null;
+  }
+
+  updateValuesIterator() {
+    this.valuesIterator = this.dataGrid.model.getColumnValuesIterator(this);
+  }
+
   private dateValueResolver(value) {
     return value.timestamp;
   }
@@ -338,23 +360,6 @@ export default class DataGridColumn {
 
   private getDataType(): ALL_TYPES {
     return getTypeByName(this.getDataTypeName());
-  }
-
-  private addMinMaxValues() {
-    let valueResolver = this.getValueResolver();
-    let minMax = minmax(this.valuesIterator.clone(), (a:any, b:any) => {
-      let value1 = valueResolver(a);
-      let value2 = valueResolver(b);
-
-      if (value1 === value2) {
-        return 0;
-      }
-
-      return value1 < value2 ? -1 : 1;
-    });
-
-    this.minValue = minMax ? minMax[0] : null;
-    this.maxValue = minMax ? minMax[1] : null;
   }
 
   private addDataTypeTooltip(menuOptions: ITriggerOptions) {

--- a/js/notebook/src/tableDisplay/dataGrid/interface/IDataGridModelState.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/interface/IDataGridModelState.ts
@@ -24,16 +24,16 @@ export default interface IDataModelState {
   alignmentForType?: {},
   cellHighlighters: IHihglighterState[],
   columnNames: string[],
-  columnOrder?: number[], //@todo
+  columnOrder: string[],
   columnsFrozen?: {}, //@todo
   columnsFrozenRight?: {}, //feature is dropped
   columnsVisible: {},
   contextMenuItems?: object[], //@todo
   contextMenuTags?: {}, //@todo
   dataFontSize?: number|null,
-  doubleClickTag?: string|null, //@todo
+  doubleClickTag?: string|null,
   fontColor?: string[],
-  hasDoubleClickAction?: boolean, //@todo
+  hasDoubleClickAction?: boolean,
   hasIndex: boolean,
   headerFontSize?: number|null,
   headersVertical?: boolean, //@todo Needs custom cell renderer

--- a/js/notebook/src/tableDisplay/dataGrid/model/BeakerxDataGridModel.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/model/BeakerxDataGridModel.ts
@@ -36,8 +36,6 @@ export class BeakerxDataGridModel extends DataModel {
 
   private _data: Array<any>;
   private _state: IDataModelState;
-  private _columnCount: number;
-  private _rowCount: number;
 
   constructor(state: IDataModelState, columnManager: ColumnManager, rowManager: RowManager) {
     super();
@@ -65,14 +63,17 @@ export class BeakerxDataGridModel extends DataModel {
 
     this._state = state;
     this._data = state.values;
-    this._columnCount = this.state.hasIndex
-      ? this.state.columnNames.length -1
-      : this.state.columnNames.length || 0;
-    this._rowCount = this._data.length;
 
     this.setState({
       columnsVisible: this.state.columnsVisible || {}
     });
+  }
+
+  updateData(state: IDataModelState) {
+    this.setState({ ...state });
+    this._data = state.values;
+    this.rowManager.createRows(this._data, this.state.hasIndex);
+    this.reset();
   }
 
   rowCount(region: DataModel.RowRegion): number {

--- a/js/notebook/test/src/tableDisplay/dataGrid/EventManager.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/EventManager.spec.ts
@@ -53,6 +53,7 @@ describe('EventManager', () => {
     expect(eventManager).to.have.property('handleMouseOut');
     expect(eventManager).to.have.property('handleMouseWheel');
     expect(eventManager).to.have.property('handleKeyDown');
+    expect(eventManager).to.have.property('handleDoubleClick');
   });
 
   it('should implement DataGrid event handlers', () => {

--- a/js/notebook/test/src/tableDisplay/dataGrid/EventManager.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/EventManager.spec.ts
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { BeakerxDataGrid } from "@beakerx/tableDisplay/dataGrid/BeakerxDataGrid";
+import modelStateMock from "./mock/modelStateMock";
+import EventManager from "@beakerx/tableDisplay/dataGrid/EventManager";
+import cellDataMock from "./mock/cellDataMock";
+
+describe('EventManager', () => {
+  let dataGrid;
+  let eventManager;
+
+  before(() => {
+    dataGrid = new BeakerxDataGrid({}, modelStateMock);
+    eventManager = dataGrid.eventManager;
+  });
+
+  after(() => {
+    dataGrid.destroy();
+  });
+
+  it('should be an instance of EventManager', () => {
+    expect(eventManager).to.be.an.instanceof(EventManager);
+  });
+
+  it('should implement handleEvent method', () => {
+    expect(eventManager).to.have.property('handleEvent');
+    expect(eventManager.handleEvent).to.be.a('Function');
+  });
+
+  it('should implement destroy method', () => {
+    expect(eventManager).to.have.property('destroy');
+    expect(eventManager.destroy).to.be.a('Function');
+  });
+
+  it('should implement DOM event handlers', () => {
+    expect(eventManager).to.have.property('handleMouseDown');
+    expect(eventManager).to.have.property('handleMouseOut');
+    expect(eventManager).to.have.property('handleMouseWheel');
+    expect(eventManager).to.have.property('handleKeyDown');
+  });
+
+  it('should implement DataGrid event handlers', () => {
+    expect(eventManager).to.have.property('handleHeaderClick');
+    expect(eventManager).to.have.property('handleHeaderCellHover');
+  });
+
+  it('should implement handleMouseDown event handler', () => {
+    expect(eventManager).to.have.property('handleMouseDown');
+    expect(eventManager.handleMouseDown).to.be.a('Function');
+    eventManager.handleMouseDown(new MouseEvent('mousedown'));
+    expect(dataGrid.focused).to.be.true;
+    expect(dataGrid.node.classList.contains('bko-focused')).to.be.true;
+  });
+
+  it('should implement handleMouseOut event handler', () => {
+    expect(eventManager).to.have.property('handleMouseDown');
+    expect(eventManager.handleMouseOut).to.be.a('Function');
+    eventManager.handleMouseOut(new MouseEvent('mouseout'));
+    expect(dataGrid.focused).to.be.false;
+    expect(dataGrid.node.classList.contains('bko-focused')).to.be.false;
+  });
+
+  it('should implement handleMouseWheel event handler', () => {
+    const mouseWheelHandler = sinon.spy();
+
+    expect(eventManager).to.have.property('handleMouseWheel');
+    expect(eventManager.handleMouseWheel).to.be.a('Function');
+    expect(dataGrid.focused).to.be.false;
+
+    eventManager.handleMouseWheel(new MouseEvent('mousewheel'), mouseWheelHandler);
+    expect(mouseWheelHandler.called).to.be.false;
+
+    dataGrid.focused = true;
+    eventManager.handleMouseWheel(new MouseEvent('mousewheel'), mouseWheelHandler);
+    expect(mouseWheelHandler.called).to.be.true;
+  });
+
+  it('should implement handleKeyDown event handler', () => {
+    const highlighterStub = sinon.stub(eventManager, 'handleHighlighterKeyDown');
+    const numStub = sinon.stub(eventManager, 'handleNumKeyDown');
+    const arrowStub = sinon.stub(eventManager, 'handleArrowKeyDown');
+    const columnStub = sinon.stub(dataGrid.columnManager, 'takeColumnByCell');
+
+    expect(eventManager).to.have.property('handleKeyDown');
+    expect(eventManager.handleKeyDown).to.be.a('Function');
+
+    const event = new KeyboardEvent('keydown', { key: 'ArrowUp', code: 'ArrowUp' });
+
+    eventManager.handleKeyDown(event);
+
+    expect(highlighterStub.calledOnce).to.be.true;
+    expect(numStub.calledOnce).to.be.true;
+    expect(arrowStub.calledOnce).to.be.true;
+    expect(columnStub.calledOnce).to.be.false
+
+    dataGrid.cellFocusManager.setFocusedCell(cellDataMock);
+    eventManager.handleKeyDown(event);
+
+    expect(highlighterStub.calledTwice).to.be.true;
+    expect(numStub.calledTwice).to.be.true;
+    expect(arrowStub.calledTwice).to.be.true;
+    expect(columnStub.calledOnce).to.be.true;
+
+    highlighterStub.restore();
+    numStub.restore();
+    arrowStub.restore();
+    columnStub.restore();
+  });
+
+});

--- a/js/notebook/test/src/tableDisplay/dataGrid/cell/CellFocusManager.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/cell/CellFocusManager.spec.ts
@@ -1,0 +1,95 @@
+/*
+ *  Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { BeakerxDataGrid } from "@beakerx/tableDisplay/dataGrid/BeakerxDataGrid";
+import modelStateMock from "../mock/modelStateMock";
+import CellFocusManager from "@beakerx/tableDisplay/dataGrid/cell/CellFocusManager";
+import cellDataMock from "../mock/cellDataMock";
+import cellConfigMock from "../mock/cellConfigMock";
+import {
+  DEFAULT_CELL_BACKGROUND,
+  FOCUSED_CELL_BACKGROUND
+} from "@beakerx/tableDisplay/dataGrid/style/dataGridStyle";
+import {COLUMN_TYPES} from "@beakerx/tableDisplay/dataGrid/column/DataGridColumn";
+
+describe('CellFocusManager', () => {
+  let dataGrid;
+  let cellFocusManager;
+  let focusedCell = { ...cellDataMock };
+
+  before(() => {
+    dataGrid = new BeakerxDataGrid({}, modelStateMock);
+    cellFocusManager = dataGrid.cellFocusManager;
+  });
+
+  after(() => {
+    dataGrid.destroy();
+  });
+
+  it('should be an instance of CellFocusManager', () => {
+    expect(cellFocusManager).to.be.an.instanceof(CellFocusManager);
+  });
+
+  it('should have the focusedCellData property', () => {
+    expect(cellFocusManager).to.have.property('focusedCellData');
+  });
+
+  it('should implement setFocusedCell method', () => {
+    expect(cellFocusManager).to.have.property('setFocusedCell');
+    expect(cellFocusManager.setFocusedCell).to.be.a('Function');
+
+    cellFocusManager.setFocusedCell(focusedCell);
+    expect(cellFocusManager.focusedCellData).to.equal(focusedCell);
+  });
+
+  it('should implement getFocussedCellBackground method', () => {
+    expect(cellFocusManager).to.have.property('getFocussedCellBackground');
+    expect(cellFocusManager.getFocussedCellBackground).to.be.a('Function');
+    expect(cellFocusManager.getFocussedCellBackground(cellConfigMock)).to.equal(FOCUSED_CELL_BACKGROUND);
+    expect(cellFocusManager.getFocussedCellBackground({ ...cellConfigMock, column: 1 })).to.equal(DEFAULT_CELL_BACKGROUND);
+  });
+
+  it('should implement setFocusedCellByArrowKey method', () => {
+    expect(cellFocusManager).to.have.property('setFocusedCellByArrowKey');
+    expect(cellFocusManager.setFocusedCellByArrowKey).to.be.a('Function');
+
+    cellFocusManager.setFocusedCellByArrowKey(39); // right arrow
+    expect(cellFocusManager.focusedCellData.column).to.equal(1);
+    expect(cellFocusManager.focusedCellData.row).to.equal(0);
+    expect(cellFocusManager.focusedCellData.type).to.equal(COLUMN_TYPES.body);
+
+    cellFocusManager.setFocusedCellByArrowKey(40); // down arrow
+    expect(cellFocusManager.focusedCellData.column).to.equal(1);
+    expect(cellFocusManager.focusedCellData.row).to.equal(1);
+    expect(cellFocusManager.focusedCellData.type).to.equal(COLUMN_TYPES.body);
+
+    cellFocusManager.setFocusedCellByArrowKey(37); // left arrow
+    expect(cellFocusManager.focusedCellData.column).to.equal(0);
+    expect(cellFocusManager.focusedCellData.row).to.equal(1);
+    expect(cellFocusManager.focusedCellData.type).to.equal(COLUMN_TYPES.body);
+
+    cellFocusManager.setFocusedCellByArrowKey(38); // up arrow
+    expect(cellFocusManager.focusedCellData.column).to.equal(0);
+    expect(cellFocusManager.focusedCellData.row).to.equal(0);
+    expect(cellFocusManager.focusedCellData.type).to.equal(COLUMN_TYPES.body);
+
+    cellFocusManager.setFocusedCellByArrowKey(37); // left arrow
+    expect(cellFocusManager.focusedCellData.column).to.equal(0);
+    expect(cellFocusManager.focusedCellData.row).to.equal(0);
+    expect(cellFocusManager.focusedCellData.type).to.equal(COLUMN_TYPES.index);
+  });
+});

--- a/js/notebook/test/src/tableDisplay/dataGrid/cell/CellManager.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/cell/CellManager.spec.ts
@@ -18,14 +18,19 @@ import { expect } from 'chai';
 import { BeakerxDataGrid } from "@beakerx/tableDisplay/dataGrid/BeakerxDataGrid";
 import modelStateMock from "../mock/modelStateMock";
 import CellManager from "@beakerx/tableDisplay/dataGrid/cell/CellManager";
+import cellDataMock from "../mock/cellDataMock";
 
 describe('CellManager', () => {
   let dataGrid;
   let cellManager;
+  let cellSelectionManager;
 
   before(() => {
     dataGrid = new BeakerxDataGrid({}, modelStateMock);
     cellManager = dataGrid.cellManager;
+    cellSelectionManager = dataGrid.cellSelectionManager;
+    cellSelectionManager.setStartCell(cellDataMock);
+    cellSelectionManager.setEndCell({ ...cellDataMock, column: 1 });
   });
 
   after(() => {
@@ -39,6 +44,7 @@ describe('CellManager', () => {
   it('should implement getSelectedCells method', () => {
     expect(cellManager).to.have.property('getSelectedCells');
     expect(cellManager.getSelectedCells).to.be.a('Function');
+    expect(cellManager.getSelectedCells()).to.have.length(2);
   });
 
   it('should implement getAllCells method', () => {
@@ -54,6 +60,10 @@ describe('CellManager', () => {
   it('should implement getCells method', () => {
     expect(cellManager).to.have.property('getCells');
     expect(cellManager.getCells).to.be.a('Function');
+    const rowsRange = cellSelectionManager.getRowsRangeCells();
+    const columnsRange = cellSelectionManager.getColumnsRangeCells();
+
+    expect(cellManager.getCells(rowsRange, columnsRange)).to.have.length(2);
   });
 
   it('should implement copyToClipboard method', () => {
@@ -64,5 +74,46 @@ describe('CellManager', () => {
   it('should implement CSVDownload method', () => {
     expect(cellManager).to.have.property('CSVDownload');
     expect(cellManager.CSVDownload).to.be.a('Function');
+  });
+
+  it('should implement createCellConfig method', () => {
+    expect(cellManager).to.have.property('createCellConfig');
+    expect(cellManager.createCellConfig).to.be.a('Function');
+
+    const cellConfig = cellManager.createCellConfig({
+      row: 1,
+      column: 1,
+      value: 2,
+      region: 'body'
+    });
+
+    expect(cellConfig.row).to.equal(1);
+    expect(cellConfig.column).to.equal(1);
+    expect(cellConfig.value).to.equal(2);
+    expect(cellConfig.region).to.equal('body');
+
+    expect(cellConfig).to.have.property('x');
+    expect(cellConfig).to.have.property('y');
+    expect(cellConfig).to.have.property('width');
+    expect(cellConfig).to.have.property('height');
+  });
+
+  it('should implement exportCellsTo method', () => {
+    expect(cellManager).to.have.property('exportCellsTo');
+    expect(cellManager.exportCellsTo).to.be.a('Function');
+    const cells = cellManager.getSelectedCells();
+    const resultCsv = `"test","column"\n"1","2"\n`;
+    const resultTabs = `test\tcolumn\n1\t2\n`;
+
+    expect(cellManager.exportCellsTo(cells, 'csv')).to.equal(resultCsv);
+    expect(cellManager.exportCellsTo(cells, 'tabs')).to.equal(resultTabs);
+  });
+
+  it('should implement getCSVFromCells method', () => {
+    expect(cellManager).to.have.property('getCSVFromCells');
+    expect(cellManager.getCSVFromCells).to.be.a('Function');
+    const result = `"test","column"\n"1","2"\n`;
+
+    expect(cellManager.getCSVFromCells(true)).to.equal(result);
   });
 });

--- a/js/notebook/test/src/tableDisplay/dataGrid/cell/CellSelectionManager.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/cell/CellSelectionManager.spec.ts
@@ -25,8 +25,8 @@ import cellConfigMock from "../mock/cellConfigMock";
 describe('CellSelectionManager', () => {
   let dataGrid;
   let cellSelectionManager;
-  let startCell: ICellData = { row: 0, column: 0, type: COLUMN_TYPES.index };
-  let endCell: ICellData = { row: 2, column: 3, type: COLUMN_TYPES.body };
+  let startCell: ICellData = { row: 0, column: 0, type: COLUMN_TYPES.index, offset: 0, delta: 0 };
+  let endCell: ICellData = { row: 2, column: 3, type: COLUMN_TYPES.body, offset: 0, delta: 0 };
 
   before(() => {
     dataGrid = new BeakerxDataGrid({}, modelStateMock);

--- a/js/notebook/test/src/tableDisplay/dataGrid/column/ColumnManager.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/column/ColumnManager.spec.ts
@@ -26,8 +26,17 @@ import ColumnManager, {
 import cellConfigMock from "../mock/cellConfigMock";
 
 describe('ColumnManager', () => {
-  const dataGrid = new BeakerxDataGrid({}, modelStateMock);
-  const columnManager = dataGrid.columnManager;
+  let dataGrid;
+  let columnManager;
+
+  before(() => {
+    dataGrid = new BeakerxDataGrid({}, modelStateMock);
+    columnManager = dataGrid.columnManager;
+  });
+
+  after(() => {
+    dataGrid.destroy();
+  });
 
   it('should create IndexResolver', () => {
     expect(columnManager).to.have.property('indexResolver');
@@ -53,14 +62,6 @@ describe('ColumnManager', () => {
     expect(columnManager.getColumnByName('test')).to.equal(columnManager.columns[COLUMN_TYPES.body][0]);
   });
 
-  it('should implement destroy method', () => {
-    const destroyStub = sinon.stub(columnManager, 'destroyAllColumns');
-
-    columnManager.destroy();
-    expect(destroyStub.calledOnce).to.be.true;
-    destroyStub.restore();
-  });
-
   it('should implement moveColumn method', () => {
     const column = columnManager.columns[COLUMN_TYPES.body][0];
 
@@ -79,19 +80,28 @@ describe('ColumnManager', () => {
 
     column.hide();
     expect(column.getResolvedIndex()).to.equal(1);
-    expect(columnManager.columns[COLUMN_TYPES.body][1].getResolvedIndex()).to.equal(0);
+    expect(columnManager.bodyColumns[1].getResolvedIndex()).to.equal(0);
 
     column.show();
     column.move(0);
+    console.log(column.index, column.getResolvedIndex());
     expect(column.getResolvedIndex()).to.equal(0);
   });
 
   it('should call setColumnVisible', () => {
     const stub = sinon.stub(columnManager, 'setColumnVisible');
+    columnManager.bodyColumns[0].hide();
+    columnManager.bodyColumns[0].show();
 
-    columnManager.columns[COLUMN_TYPES.body][0].hide();
-    columnManager.columns[COLUMN_TYPES.body][0].show();
     expect(stub.calledTwice).to.be.true;
     stub.restore();
+  });
+
+  it('should implement destroy method', () => {
+    const destroyStub = sinon.stub(columnManager, 'destroyAllColumns');
+
+    columnManager.destroy();
+    expect(destroyStub.calledOnce).to.be.true;
+    destroyStub.restore();
   });
 });

--- a/js/notebook/test/src/tableDisplay/dataGrid/headerMenu/BkoMenu.spec.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/headerMenu/BkoMenu.spec.ts
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { Menu } from '@phosphor/widgets';
+import BkoMenu from '@beakerx/tableDisplay/dataGrid/headerMenu/BkoMenu';
+import {CommandRegistry} from '@phosphor/commands';
+
+describe('BkoMenu', () => {
+  let bkoMenu;
+
+  before(() => {
+    bkoMenu = new BkoMenu({ commands: new CommandRegistry() });
+  });
+
+  after(() => {
+    bkoMenu.dispose();
+  });
+
+  it('should be an instance of Menu', () => {
+    expect(bkoMenu).to.be.an.instanceof(Menu);
+  });
+
+  it('should implement the triggerActiveItem method', () => {
+    expect(bkoMenu).to.have.property('triggerActiveItem');
+    expect(bkoMenu.triggerActiveItem).to.be.a('Function');
+  });
+
+  it('should implement the close method', () => {
+    expect(bkoMenu).to.have.property('close');
+    expect(bkoMenu.close).to.be.a('Function');
+  });
+
+  it('should implement the onBeforeAttach method', () => {
+    expect(bkoMenu).to.have.property('onBeforeAttach');
+    expect(bkoMenu.onBeforeAttach).to.be.a('Function');
+  });
+
+  it('should implement the onActivateRequest method', () => {
+    expect(bkoMenu).to.have.property('onActivateRequest');
+    expect(bkoMenu.onActivateRequest).to.be.a('Function');
+  });
+
+});

--- a/js/notebook/test/src/tableDisplay/dataGrid/mock/cellDataMock.ts
+++ b/js/notebook/test/src/tableDisplay/dataGrid/mock/cellDataMock.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2017 TWO SIGMA OPEN SOURCE, LLC
+ *  Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -14,20 +14,15 @@
  *  limitations under the License.
  */
 
-var jsdom = require('jsdom');
+import {ICellData} from "@beakerx/tableDisplay/dataGrid/interface/ICell";
+import {COLUMN_TYPES} from "@beakerx/tableDisplay/dataGrid/column/DataGridColumn";
 
-global.window = new jsdom.JSDOM().window;
-global.document = window.document;
-global.Element = window.Element;
-global.HTMLElement = window.HTMLElement;
-global.HTMLSpanElement = window.HTMLSpanElement;
-global.HTMLInputElement = window.HTMLInputElement;
-global.MouseEvent = window.MouseEvent;
-global.KeyboardEvent = window.KeyboardEvent;
-
-window.HTMLCanvasElement.prototype.getContext = function() {
-  return {};
+const cellDataMock: ICellData = {
+  row: 0,
+  column: 0,
+  type: COLUMN_TYPES.body,
+  offset: 0,
+  delta: 0
 };
 
-global.navigator = window.navigator;
-global.define = function() {};
+export default cellDataMock;

--- a/js/notebook/yarn.lock
+++ b/js/notebook/yarn.lock
@@ -213,9 +213,19 @@ anymatch@^1.3.0:
     micromatch "^2.1.5"
     normalize-path "^2.0.0"
 
+append-transform@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
+  dependencies:
+    default-require-extensions "^1.0.0"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -252,7 +262,7 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-arrify@^1.0.0:
+arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -298,6 +308,10 @@ async-foreach@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/async-foreach/-/async-foreach-0.1.3.tgz#36121f845c0578172de419a97dbeb1d16ec34542"
 
+async@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
+
 async@^2.1.2, async@^2.1.5, async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
@@ -331,13 +345,76 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.11.0, babel-code-frame@^6.22.0:
+babel-code-frame@^6.11.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
+
+babel-generator@^6.18.0:
+  version "6.26.1"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.7"
+    trim-right "^1.0.1"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-runtime@^6.22.0, babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babel-template@^6.16.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.18.0, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@^6.18.0, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 balanced-match@^0.4.2:
   version "0.4.2"
@@ -529,6 +606,14 @@ cacache@^10.0.0:
     unique-filename "^1.1.0"
     y18n "^3.2.1"
 
+caching-transform@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-1.0.1.tgz#6dbdb2f20f8d8fbce79f3e94e9d1742dcdf5c0a1"
+  dependencies:
+    md5-hex "^1.2.0"
+    mkdirp "^0.5.1"
+    write-file-atomic "^1.1.4"
+
 camel-case@3.0.x:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -674,6 +759,14 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
+cliui@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
+    wrap-ansi "^2.0.0"
+
 clone-deep@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.3.0.tgz#348c61ae9cdbe0edfe053d91ff4cc521d790ede8"
@@ -785,6 +878,10 @@ content-type-parser@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
+convert-source-map@^1.3.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -795,6 +892,10 @@ copy-concurrently@^1.0.0:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.0"
+
+core-js@^2.4.0:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -830,6 +931,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
     which "^1.2.9"
@@ -1267,13 +1375,17 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@3.1.0:
+debug-log@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+
+debug@3.1.0, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^2.2.0:
+debug@^2.2.0, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1301,6 +1413,12 @@ deepmerge@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.0.1.tgz#25c1c24f110fb914f80001b925264dd77f3f4312"
 
+default-require-extensions@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
+  dependencies:
+    strip-bom "^2.0.0"
+
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
@@ -1319,6 +1437,12 @@ des.js@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
+
+detect-indent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
+  dependencies:
+    repeating "^2.0.0"
 
 detect-indent@^5.0.0:
   version "5.0.0"
@@ -1616,6 +1740,14 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
+
 find-cache-dir@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-1.0.0.tgz#9288e3e9e3cc3748717d39eade17cf71fc30ee6f"
@@ -1671,6 +1803,13 @@ for-own@^1.0.0:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
   dependencies:
     for-in "^1.0.1"
+
+foreground-child@^1.5.3, foreground-child@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
+  dependencies:
+    cross-spawn "^4"
+    signal-exit "^3.0.0"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1823,7 +1962,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2, glob@~7.1.1:
+glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2, glob@~7.1.1:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1844,6 +1983,10 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
 globule@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.0.tgz#1dc49c6822dd9e8a2fa00ba2a295006e8664bd09"
@@ -1859,6 +2002,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2:
 growl@1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.3.tgz#1926ba90cf3edfe2adb4927f5880bc22c66c790f"
+
+handlebars@^4.0.3:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.0.11.tgz#630a35dfe0294bc281edae6ffc5d329fc7982dcc"
+  dependencies:
+    async "^1.4.0"
+    optimist "^0.6.1"
+    source-map "^0.4.4"
+  optionalDependencies:
+    uglify-js "^2.6"
 
 har-schema@^1.0.5:
   version "1.0.5"
@@ -2122,6 +2275,12 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
+invariant@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.3.tgz#1a827dfde7dcbd7c323f0ca826be8fa7c5e9d688"
+  dependencies:
+    loose-envify "^1.0.0"
+
 invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
@@ -2277,6 +2436,53 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+istanbul-lib-coverage@^1.1.1, istanbul-lib-coverage@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.2.tgz#4113c8ff6b7a40a1ef7350b01016331f63afde14"
+
+istanbul-lib-hook@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
+  dependencies:
+    append-transform "^0.4.0"
+
+istanbul-lib-instrument@^1.9.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.2.tgz#84905bf47f7e0b401d6b840da7bad67086b4aab6"
+  dependencies:
+    babel-generator "^6.18.0"
+    babel-template "^6.16.0"
+    babel-traverse "^6.18.0"
+    babel-types "^6.18.0"
+    babylon "^6.18.0"
+    istanbul-lib-coverage "^1.1.2"
+    semver "^5.3.0"
+
+istanbul-lib-report@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz#2df12188c0fa77990c0d2176d2d0ba3394188259"
+  dependencies:
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    path-parse "^1.0.5"
+    supports-color "^3.1.2"
+
+istanbul-lib-source-maps@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz#20fb54b14e14b3fb6edb6aca3571fd2143db44e6"
+  dependencies:
+    debug "^3.1.0"
+    istanbul-lib-coverage "^1.1.2"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.1"
+    source-map "^0.5.3"
+
+istanbul-reports@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.4.tgz#5ccba5e22b7b5a5d91d5e0a830f89be334bf97bd"
+  dependencies:
+    handlebars "^4.0.3"
+
 jquery-ui@^1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
@@ -2289,7 +2495,7 @@ js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.0.tgz#9e566fee624751a1d720c966cd6226d29d4025aa"
 
-js-tokens@^3.0.2:
+js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
@@ -2332,6 +2538,10 @@ jsdom@^11.5.1:
     whatwg-encoding "^1.0.1"
     whatwg-url "^6.3.0"
     xml-name-validator "^2.0.1"
+
+jsesc@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -2542,6 +2752,12 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
 loud-rejection@^1.0.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
@@ -2582,6 +2798,16 @@ math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
 
+md5-hex@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/md5-hex/-/md5-hex-1.3.0.tgz#d2c4afe983c4370662179b8cad145219135046c4"
+  dependencies:
+    md5-o-matic "^0.1.1"
+
+md5-o-matic@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/md5-o-matic/-/md5-o-matic-0.1.1.tgz#822bccd65e117c514fab176b25945d54100a03c3"
+
 md5.js@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.4.tgz#e9bdbde94a20a5ac18b04340fc5764d5b09d901d"
@@ -2617,7 +2843,13 @@ meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
-micromatch@^2.1.5:
+merge-source-map@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  dependencies:
+    source-map "^0.6.1"
+
+micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -2681,6 +2913,10 @@ minimist@0.0.8:
 minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
 mississippi@^1.3.0:
   version "1.3.0"
@@ -2934,6 +3170,38 @@ nwmatcher@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
 
+nyc@^11.4.1:
+  version "11.4.1"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-11.4.1.tgz#13fdf7e7ef22d027c61d174758f6978a68f4f5e5"
+  dependencies:
+    archy "^1.0.0"
+    arrify "^1.0.1"
+    caching-transform "^1.0.0"
+    convert-source-map "^1.3.0"
+    debug-log "^1.0.1"
+    default-require-extensions "^1.0.0"
+    find-cache-dir "^0.1.1"
+    find-up "^2.1.0"
+    foreground-child "^1.5.3"
+    glob "^7.0.6"
+    istanbul-lib-coverage "^1.1.1"
+    istanbul-lib-hook "^1.1.0"
+    istanbul-lib-instrument "^1.9.1"
+    istanbul-lib-report "^1.1.2"
+    istanbul-lib-source-maps "^1.2.2"
+    istanbul-reports "^1.1.3"
+    md5-hex "^1.2.0"
+    merge-source-map "^1.0.2"
+    micromatch "^2.3.11"
+    mkdirp "^0.5.0"
+    resolve-from "^2.0.0"
+    rimraf "^2.5.4"
+    signal-exit "^3.0.1"
+    spawn-wrap "^1.4.2"
+    test-exclude "^4.1.1"
+    yargs "^10.0.3"
+    yargs-parser "^8.0.0"
+
 oauth-sign@~0.8.1, oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
@@ -2955,6 +3223,13 @@ once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
+
 optionator@^0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -2970,7 +3245,7 @@ os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
 
-os-homedir@^1.0.0:
+os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
@@ -3088,6 +3363,10 @@ path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-to-regexp@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
@@ -3147,6 +3426,12 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -3622,6 +3907,10 @@ regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
+
 regex-cache@^0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
@@ -3769,6 +4058,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+resolve-from@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -3888,7 +4181,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.1, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -3903,6 +4196,10 @@ sinon@^4.2.0:
     nise "^1.2.0"
     supports-color "^5.1.0"
     type-detect "^4.0.5"
+
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -3950,11 +4247,11 @@ source-map-support@^0.5.0:
   dependencies:
     source-map "^0.6.0"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
-source-map@^0.4.2, source-map@~0.4.1:
+source-map@^0.4.2, source-map@^0.4.4, source-map@~0.4.1:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -3963,6 +4260,17 @@ source-map@^0.4.2, source-map@~0.4.1:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
+spawn-wrap@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.2.tgz#cff58e73a8224617b6561abdc32586ea0c82248c"
+  dependencies:
+    foreground-child "^1.5.6"
+    mkdirp "^0.5.0"
+    os-homedir "^1.0.1"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    which "^1.3.0"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -4052,7 +4360,7 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0:
+string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -4122,7 +4430,7 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
-supports-color@^3.2.3:
+supports-color@^3.1.2, supports-color@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
@@ -4181,6 +4489,16 @@ tar@^2.0.0, tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+test-exclude@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.0.tgz#07e3613609a362c74516a717515e13322ab45b3c"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^2.3.11"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
 text-encoding@^0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.6.4.tgz#e399a982257a276dae428bb92845cb71bdc26d19"
@@ -4206,6 +4524,10 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
 
+to-fast-properties@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
@@ -4221,6 +4543,10 @@ tr46@^1.0.0:
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
+
+trim-right@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 "true-case-path@^1.0.2":
   version "1.0.2"
@@ -4326,7 +4652,7 @@ uglify-js@3.2.x:
     commander "~2.12.1"
     source-map "~0.6.1"
 
-uglify-js@^2.8.29:
+uglify-js@^2.6, uglify-js@^2.8.29:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
@@ -4541,7 +4867,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.2.9:
+which@1, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -4560,6 +4886,10 @@ window-size@0.1.0:
 wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
+
+wordwrap@~0.0.2:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
 
 wordwrap@~1.0.0:
   version "1.0.0"
@@ -4582,6 +4912,14 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 write-file-atomic@^2.0.0:
   version "2.3.0"
@@ -4637,6 +4975,29 @@ yargs-parser@^7.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
+
+yargs-parser@^8.0.0, yargs-parser@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs@^10.0.3:
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^8.1.0"
 
 yargs@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
Provides also the code coverage tool that can be run by `yarn run coverage`,
The coverage tool is set to include only the TypeScript code from /src.