### PR TITLE
#6803 do not provide d3 as global variable

### DIFF
--- a/js/notebook/src/Plot.js
+++ b/js/notebook/src/Plot.js
@@ -24,8 +24,6 @@ var plotApi = require('./plot/plotApi');
 var OUTUPT_POINTS_LIMIT = 1000000;
 var OUTUPT_POINTS_PREVIEW_NUMBER = 10000;
 
-window.d3 = d3;
-
 var PlotModel = widgets.DOMWidgetModel.extend({
   defaults: function() {
     return _.extend({}, widgets.DOMWidgetModel.prototype.defaults.apply(this), {

--- a/js/notebook/webpack.config.js
+++ b/js/notebook/webpack.config.js
@@ -51,7 +51,8 @@ var plugins = [
   new webpack.ProvidePlugin({
     "$":"jquery",
     "jQuery":"jquery",
-    "window.jQuery":"jquery"
+    "window.jQuery":"jquery",
+    "d3": "d3"
   }),
   new TsconfigPathsPlugin({ configFile: tsConfigPath }),
   new ForkTsCheckerWebpackPlugin({


### PR DESCRIPTION
This needs to be tested heavily.
This PR remove the `window.d3` reference and uses the one provided by webpack.