### PR TITLE
Fix non-firing assertions

### DIFF
--- a/kernel/base/src/test/java/com/twosigma/beakerx/kernel/magic/command/ClasspathAddMvnDepsCellMagicCommandTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/kernel/magic/command/ClasspathAddMvnDepsCellMagicCommandTest.java
@@ -116,11 +116,11 @@ public class ClasspathAddMvnDepsCellMagicCommandTest {
     processMagicCommand(singleLine);
     List<Message> stderr = EvaluatorResultTestWatcher.getStderr(kernel.getPublishedMessages());
     String text = (String) stderr.get(0).getContent().get("text");
-    Assertions.assertThat(text.equals(ClassPathAddMvnCellMagicCommand.MVN_CELL_FORMAT_ERROR_MESSAGE));
+    Assertions.assertThat(text).isEqualTo(ClassPathAddMvnCellMagicCommand.MVN_CELL_FORMAT_ERROR_MESSAGE);
     processMagicCommand(additionalCode);
     List<Message> stderr2 = EvaluatorResultTestWatcher.getStderr(kernel.getPublishedMessages());
     String text2 = (String) stderr2.get(0).getContent().get("text");
-    Assertions.assertThat(text2.equals(ClassPathAddMvnCellMagicCommand.MVN_CELL_FORMAT_ERROR_MESSAGE));
+    Assertions.assertThat(text2).isEqualTo(ClassPathAddMvnCellMagicCommand.MVN_CELL_FORMAT_ERROR_MESSAGE);
   }
 
   private void processMagicCommand(String allCode) {
@@ -139,9 +139,8 @@ public class ClasspathAddMvnDepsCellMagicCommandTest {
     String text =  (String) TestWidgetUtils.getState(updateMessage.get()).get("value");
 
     Assertions.assertThat(kernel.getClasspath().get(0)).contains(mvnDir);
-    Assertions.assertThat(expected.stream()
-            .allMatch(depNames::contains));
-    Assertions.assertThat(expected.stream().allMatch(text::contains));
+    Assertions.assertThat(depNames.containsAll(expected)).isTrue();
+    Assertions.assertThat(expected.stream().allMatch(text::contains)).isTrue();
 
     Files.walk(Paths.get(mvnDir)).forEach(path -> {
       try {

--- a/kernel/base/src/test/java/com/twosigma/beakerx/kernel/magic/command/PomFactoryTest.java
+++ b/kernel/base/src/test/java/com/twosigma/beakerx/kernel/magic/command/PomFactoryTest.java
@@ -85,7 +85,7 @@ public class PomFactoryTest {
     Dependency dependency1 = Dependency.create(asList("group", "artifact", "1.1.1"));
     Dependency dependency2 = Dependency.create(asList("other-group", "other-artifact", "1.1.1"));
     String pomAsString = pomFactory.createPom("/", asList(dependency1, dependency2), repos);
-    assertThat(removeWhitespaces(pomAsString).contains(removeWhitespaces(EXPECTED_MULTIPLE_DEP_POM)));
+    assertThat(removeWhitespaces(pomAsString)).contains(removeWhitespaces(EXPECTED_MULTIPLE_DEP_POM));
   }
 
   @Test


### PR DESCRIPTION
Some of the assertions in kernel/base tests were incomplete : the result of the assertion was not checked.
This commit should fix the few I found.