### PR TITLE
#7699 use scala.math instead of java.Math

### DIFF
--- a/doc/scala/Plot.ipynb
+++ b/doc/scala/Plot.ipynb
@@ -54,9 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot()\n",
@@ -74,9 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot { title = \"Elo\" }\n",
@@ -94,9 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot { title = \"Changing Point Size, Color, Shape\" }\n",
@@ -125,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot { title = \"Changing point properties with list\" }\n",
@@ -167,9 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot()\n",
@@ -191,9 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val p = new Plot()\n",
@@ -212,9 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val y1 = Seq(1,5,3,2,3)\n",
@@ -228,9 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val p = new Plot()\n",
@@ -259,9 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val constBand = new ConstantBand { x = Seq(1, 2); y = Seq(1, 3) }\n",
@@ -274,9 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val p = new Plot() \n",
@@ -289,9 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot()\n",
@@ -304,8 +282,8 @@
     "})\n",
     "\n",
     "def label(i: Int, ys: Seq[Double]): String = {\n",
-    "  val leftSign = Math.signum(ys(i) - ys(i - 1))\n",
-    "  val rightSign = Math.signum(ys(i + 1) - ys(i))\n",
+    "  val leftSign = math.signum(ys(i) - ys(i - 1))\n",
+    "  val rightSign = math.signum(ys(i + 1) - ys(i))\n",
     "  (leftSign, rightSign) match {\n",
     "    case (1, -1) => \"max\"\n",
     "    case (-1, 1) => \"min\"\n",
@@ -332,9 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val ch = new Crosshair {\n",
@@ -374,9 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val rates = new CSV().readFile(\"../resources/data/interest-rates.csv\")\n",
@@ -392,16 +366,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val points = 100\n",
     "val logBase = 10\n",
     "\n",
     "val xs = for (i <- 0 to points) yield i / 15.0\n",
-    "val expys = for (x <- xs) yield Math.exp(x)\n",
+    "val expys = for (x <- xs) yield math.exp(x)\n",
     "\n",
     "val cplot = new CombinedPlot()\n",
     "val logYPlot = new Plot {\n",
@@ -449,15 +421,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val points = 100\n",
     "val logBase = 10\n",
     "val xs = for (i <- 0 to points) yield i / 15.0\n",
-    "val expys = for (x <- xs) yield Math.exp(x)\n",
+    "val expys = for (x <- xs) yield math.exp(x)\n",
     "\n",
     "val plot = new Plot { \n",
     "    title = \"Log x, Log y\"\n",
@@ -487,9 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import java.util.{Calendar, Date}\n",
@@ -526,9 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import java.util.Date\n",
@@ -547,9 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import scala.util.Random\n",
@@ -571,9 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import java.nio.file.Files\n",
@@ -622,9 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "val plot = new Plot { title = \"Setting 2nd Axis bounds\" }\n",
@@ -663,7 +623,7 @@
    "mimetype": "",
    "name": "Scala",
    "nbconverter_exporter": "",
-   "version": "2.11.11"
+   "version": "2.11.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
#7699 Importing `MIMEContainer.Math` created a conflict with Java `Math`. Use Scala `math` instead.