### PR TITLE
#7751 add Scala GradientColor

### DIFF
--- a/kernel/scala/src/main/java/com/twosigma/beakerx/scala/kernel/ScalaDefaultVariables.java
+++ b/kernel/scala/src/main/java/com/twosigma/beakerx/scala/kernel/ScalaDefaultVariables.java
@@ -32,6 +32,7 @@ public class ScalaDefaultVariables extends DefaultJVMVariables {
         "com.twosigma.beakerx.chart.heatmap.HeatMap",
         "com.twosigma.beakerx.chart.histogram.*",
         "com.twosigma.beakerx.chart.treemap.*",
+        "com.twosigma.beakerx.chart.GradientColor",
         "com.twosigma.beakerx.table.*"
     );
 
@@ -43,6 +44,7 @@ public class ScalaDefaultVariables extends DefaultJVMVariables {
         "com.twosigma.beakerx.scala.chart.heatmap.HeatMap",
         "com.twosigma.beakerx.scala.chart.histogram.Histogram",
         "com.twosigma.beakerx.scala.chart.treemap.TreeMap",
+        "com.twosigma.beakerx.scala.chart.GradientColor",
         "com.twosigma.beakerx.scala.easyform.EasyForm",
         "com.twosigma.beakerx.easyform.formitem._",
         "com.twosigma.beakerx.scala.table._",

--- a/kernel/scala/src/main/scala/com/twosigma/beakerx/scala/chart/GradientColor.scala
+++ b/kernel/scala/src/main/scala/com/twosigma/beakerx/scala/chart/GradientColor.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 TWO SIGMA OPEN SOURCE, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.twosigma.beakerx.scala.chart
+
+import com.twosigma.beakerx.scala.JavaAdapter._
+import scala.collection.JavaConverters._
+
+class GradientColor[T <: AnyRef : BeakerColor](colors: Seq[T]) extends
+  com.twosigma.beakerx.chart.GradientColor(colors.toObjects.asJava)
+
+object GradientColor {
+  def apply[T <: AnyRef : BeakerColor](colors: T*) = new GradientColor(colors)
+}


### PR DESCRIPTION
This addresses #7751 by adding a Scala version of `GradientColor` (including removing the import of the Java version).  A companion object with an apply method is included for convenience.