### PR TITLE
Don't discard the exception type when an unexpected error is reported

### DIFF
--- a/kernel/base/src/main/java/com/twosigma/beakerx/kernel/CodeFrame.java
+++ b/kernel/base/src/main/java/com/twosigma/beakerx/kernel/CodeFrame.java
@@ -42,7 +42,7 @@ public abstract class CodeFrame {
           seo.error(either.error());
         }
       } catch (Exception e) {
-        seo.error(e.getLocalizedMessage());
+        seo.error(e.toString());
       }
     }
   }


### PR DESCRIPTION
Found this while trying to understand why an empty array was causing the notebook to just display a red `0`.  The exception was being caused by jupyter/jvm-repr#12, but it would have been slightly less mysterious if the name of the exception were visible (as `IndexOutOfBoundsException: 0`).