### PR TITLE
Upgrade to Smile 1.5.2 for named variables

### DIFF
--- a/doc/groovy/Tablesaw.ipynb
+++ b/doc/groovy/Tablesaw.ipynb
@@ -20,7 +20,7 @@
     "%%classpath add mvn\n",
     "tech.tablesaw tablesaw-beakerx 0.24.5\n",
     "com.jimmoores quandl-tablesaw 2.0.0\n",
-    "com.github.haifengl smile-core 1.5.1"
+    "com.github.haifengl smile-core 1.5.2"
    ]
   },
   {
@@ -236,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "winsModel = new OLS(moneyball.as().doubleMatrix(\"W\"), runDifference.asDoubleArray());"
+    "winsModel = new OLS(moneyball.select(\"W\", \"RD\").as().smileDataset(\"RD\"));"
    ]
   },
   {
@@ -245,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "runsScored = new OLS(moneyball.as().doubleMatrix(\"OBP\", \"SLG\"), moneyball.nCol(\"RS\").asDoubleArray());"
+    "runsScored = new OLS(moneyball.select(\"OBP\", \"SLG\", \"RS\").as().smileDataset(\"RS\"));"
    ]
   },
   {


### PR DESCRIPTION
The code is a little shorter, but more importantly the regression output now uses the variable names instead of "Var 1", "Var 2", etc.