### PR TITLE
#7834 row number has to be based on position in values as column is

### DIFF
--- a/js/notebook/src/tableDisplay/dataGrid/contextMenu/createCellContextMenuItems.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/contextMenu/createCellContextMenuItems.ts
@@ -54,8 +54,8 @@ export default function createCellContextMenuItems(
         dataGrid.commSignal.emit({
           event: 'CONTEXT_MENU_CLICK',
           itemKey : item,
-          row : data.row,
-          column : selectColumnIndexByPosition(dataGrid.store.state, ColumnManager.createPositionFromCell(data))
+          row : dataGrid.rowManager.getRow(data.row).index,
+          column : selectColumnIndexByPosition(dataGrid.store.state, ColumnManager.createPositionFromCell(data)),
         });
       }
     }));
@@ -82,7 +82,7 @@ export default function createCellContextMenuItems(
           const params = {
             actionType: 'CONTEXT_MENU_CLICK',
             contextMenuItem: name,
-            row: data.row,
+            row: dataGrid.rowManager.getRow(data.row).index,
             col: selectColumnIndexByPosition(dataGrid.store.state, ColumnManager.createPositionFromCell(data))
           };
 


### PR DESCRIPTION
Values positions are not changing its original positions when we move columns or sort them.
 
That's because we have to be able to return to original "sort" when user selects **no sort** from header drop down menu.