### PR TITLE
Fix python enums

### DIFF
--- a/beakerx/beakerx/plot/legend.py
+++ b/beakerx/beakerx/plot/legend.py
@@ -17,8 +17,8 @@ from beakerx.utils import *
 
 
 class LegendLayout(Enum):
-    HORIZONTAL = 1
-    VERTICAL = 2
+    HORIZONTAL = "HORIZONTAL"
+    VERTICAL = "VERTICAL"
 
 
 class LegendPosition():
@@ -34,11 +34,11 @@ class LegendPosition():
             self.y = None
     
     class Position(Enum):
-        TOP = 1
-        LEFT = 2
-        BOTTOM = 3
-        RIGHT = 4
-        TOP_LEFT = 5
-        TOP_RIGHT = 6
-        BOTTOM_LEFT = 7
-        BOTTOM_RIGHT = 8
+        TOP = "TOP"
+        LEFT = "LEFT"
+        BOTTOM = "BOTTOM"
+        RIGHT = "RIGHT"
+        TOP_LEFT = "TOP_LEFT"
+        TOP_RIGHT = "TOP_RIGHT"
+        BOTTOM_LEFT = "BOTTOM_LEFT"
+        BOTTOM_RIGHT = "BOTTOM_RIGHT"

--- a/beakerx/beakerx/plot/plotitem.py
+++ b/beakerx/beakerx/plot/plotitem.py
@@ -24,39 +24,39 @@ import uuid
 
 
 class ShapeType(Enum):
-    SQUARE = 1
-    CIRCLE = 2
-    TRIANGLE = 3
-    DIAMOND = 4
-    DCROSS = 5
-    CROSS = 6
-    DEFAULT = 7
-    LEVEL = 8
-    VLEVEL = 9
-    LINECROSS = 10
-    DOWNTRIANGLE = 11
+    SQUARE = "SQUARE"
+    CIRCLE = "CIRCLE"
+    TRIANGLE = "TRIANGLE"
+    DIAMOND = "DIAMOND"
+    DCROSS = "DCROSS"
+    CROSS = "CROSS"
+    DEFAULT = "DEFAULT"
+    LEVEL = "LEVEL"
+    VLEVEL = "VLEVEL"
+    LINECROSS = "LINECROSS"
+    DOWNTRIANGLE = "DOWNTRIANGLE"
 
 
 class StrokeType(Enum):
-    NONE = 1
-    SOLID = 2
-    DASH = 3
-    DOT = 4
-    DASHDOT = 5
-    LONGDASH = 6
+    NONE = "NONE"
+    SOLID = "SOLID"
+    DASH = "DASH"
+    DOT = "DOT"
+    DASHDOT = "DASHDOT"
+    LONGDASH = "LONGDASH"
 
 
 class PlotOrientationType(Enum):
-    VERTICAL = 1
-    HORIZONTAL = 2
+    VERTICAL = "VERTICAL"
+    HORIZONTAL = "HORIZONTAL"
 
 
 class LabelPositionType(Enum):
-    VALUE_OUTSIDE = 1
-    VALUE_INSIDE = 2
-    CENTER = 3
-    BASE_OUTSIDE = 4
-    BASE_INSIDE = 5
+    VALUE_OUTSIDE = "VALUE_OUTSIDE"
+    VALUE_INSIDE = "VALUE_INSIDE"
+    CENTER = "CENTER"
+    BASE_OUTSIDE = "BASE_OUTSIDE"
+    BASE_INSIDE = "BASE_INSIDE"
 
 
 class GradientColor:

--- a/beakerx/beakerx/plot/plotitem_treemap.py
+++ b/beakerx/beakerx/plot/plotitem_treemap.py
@@ -60,8 +60,8 @@ class Mode(Enum):
     SLICE_DIC = "slice-dic" # alternating between horizontal and vertical subdivision.
 
 class ValueAccessor(Enum):
-    VALUE = 1
-    WEIGHT = 2
+    VALUE = "VALUE"
+    WEIGHT = "WEIGHT"
 
 
 class ColorProvider:

--- a/beakerx/beakerx/utils.py
+++ b/beakerx/beakerx/utils.py
@@ -170,7 +170,7 @@ class ObjectEncoder(json.JSONEncoder):
         if isinstance(obj, datetime):
             return self.default(date_time_2_millis(obj))
         elif isinstance(obj, Enum):
-            return self.default(obj.name)
+            return self.default(obj.value)
         elif isinstance(obj, Color):
             return self.default(obj.hex())
         elif isinstance(obj, pd.Series):


### PR DESCRIPTION
Use Enum.value for serialization, because sometimes we want on front sth different than Enum.name. 
Use strings instead of integers in Enum.value