### PR TITLE
Use coroutines instead of @asynchronous

### DIFF
--- a/beakerx/beakerx/handlers.py
+++ b/beakerx/beakerx/handlers.py
@@ -19,7 +19,7 @@ import tornado
 import zmq
 from notebook.base.handlers import APIHandler, IPythonHandler
 from notebook.utils import url_path_join
-from tornado import web
+from tornado import web, gen
 
 from .beakerx_autotranslation_server import start_autotranslation_server
 from .environment import *
@@ -31,7 +31,7 @@ class BeakerxRestHandler(APIHandler):
         pass
 
     @web.authenticated
-    @tornado.web.asynchronous
+    @gen.coroutine
     def post(self):
 
         data = tornado.escape.json_decode(self.request.body)
@@ -84,7 +84,7 @@ class SparkMetricsExecutorsHandler(APIHandler):
         pass
 
     @web.authenticated
-    @tornado.web.asynchronous
+    @gen.coroutine
     def get(self):
 
         def handle_response(response):


### PR DESCRIPTION
tornado >= 6.0 has now released, and it has deleted asynchronous decorator, and recommend use `@gen.coroutine` instead.

Detailed information:
1. git commit: https://github.com/tornadoweb/tornado/pull/2443/commits/920ce30d249db60bf7844487eb3759f38d673cbe
2. official document: https://www.tornadoweb.org/en/stable/releases/v6.0.0.html#tornado-web
3. document about `@gen.coroutine`: https://www.tornadoweb.org/en/stable/guide/coroutines.html#native-vs-decorated-coroutines