### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ how to install and run BeakerX.
 
 ```
 conda create -y -n beakerx 'python>=3' nodejs pandas 'openjdk=8.0.121' maven py4j requests
-source activate beakerx
+conda activate beakerx
 conda config --env --add pinned_packages 'openjdk=8.0.121'
 conda install -y -c conda-forge ipywidgets
 (cd beakerx; pip install -e . --verbose)


### PR DESCRIPTION
Instruction to activate environment did not work before.

```
source activate labx
```
returned the error "activate: No such file or directory"