### PR TITLE
Fix repaint after image onload() event.

### DIFF
--- a/js/notebook/src/tableDisplay/dataGrid/cell/HTMLCellRenderer.ts
+++ b/js/notebook/src/tableDisplay/dataGrid/cell/HTMLCellRenderer.ts
@@ -75,7 +75,7 @@ export default class HTMLCellRenderer extends BeakerXCellRenderer {
     img.src = "data:image/svg+xml," + data;
 
     if (!img.complete) {
-      img.onload = () => { this.dataGrid.repaint(config.x, config.y, config.width, config.height); };
+      img.onload = this.repaintCellCallback(config.x, config.y, config.width, config.height);
     } else {
       gc.drawImage(img, x, y, width, height);
     }
@@ -125,5 +125,9 @@ export default class HTMLCellRenderer extends BeakerXCellRenderer {
 
   getCacheKey(config, vAlign, hAlign) {
     return `${JSON.stringify(config)}|${vAlign}|${hAlign}`;
+  }
+
+  private repaintCellCallback(x: number, y: number, width: number, height: number) {
+    return () => this.dataGrid.repaint(x, y, width, height);
   }
 }


### PR DESCRIPTION
Store appropriate values of x, y, width, height for each individual cell
using closure, instead of using values of last cell in grid.

Fixes:
HTML format bug #8058