### PR TITLE
Kotlin Version Update from 1.2.21 to 1.3.21

### DIFF
--- a/kernel/kotlin/build.gradle
+++ b/kernel/kotlin/build.gradle
@@ -40,10 +40,10 @@ repositories {
 
 dependencies {
   provided project(':base')
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: '1.3.31'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '1.3.31'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.31'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.3.31'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: '1.3.21'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '1.3.21'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.21'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.3.21'
 
   testCompile project(':base').sourceSets.test.output
 }

--- a/kernel/kotlin/build.gradle
+++ b/kernel/kotlin/build.gradle
@@ -40,10 +40,10 @@ repositories {
 
 dependencies {
   provided project(':base')
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: '1.2.21'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '1.2.21'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-runtime', version: '1.2.21'
-  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.2.21'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-compiler-embeddable', version: '1.3.31'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-script-runtime', version: '1.3.31'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.3.31'
+  compile group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.3.31'
 
   testCompile project(':base').sourceSets.test.output
 }

--- a/kernel/kotlin/src/main/java/com/twosigma/beakerx/kotlin/evaluator/ReplWithClassLoaderFactory.java
+++ b/kernel/kotlin/src/main/java/com/twosigma/beakerx/kotlin/evaluator/ReplWithClassLoaderFactory.java
@@ -19,7 +19,7 @@ import com.twosigma.beakerx.jvm.classloader.BeakerXUrlClassLoader;
 import com.twosigma.beakerx.kernel.ImportPath;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.kotlin.cli.common.repl.ReplClassLoader;
-import org.jetbrains.kotlin.cli.jvm.repl.ConsoleReplConfiguration;
+import org.jetbrains.kotlin.cli.jvm.repl.configuration.ConsoleReplConfiguration;
 import org.jetbrains.kotlin.cli.jvm.repl.ReplInterpreter;
 import org.jetbrains.kotlin.config.CommonConfigurationKeys;
 import org.jetbrains.kotlin.config.CompilerConfiguration;


### PR DESCRIPTION
Later versions (1.3.30+) don't seam to be compatible right now, since these would lead to test failures.