### PR TITLE
Fix for issue#8134

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,7 @@ RUN conda install -y -n beakerx -c conda-forge jupyterhub jupyterlab pyzmq pytes
 ENV LANG=en_US.UTF-8
 ENV LC_CTYPE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
+ENV REMOVE_DASH_LINECOMMENT="true"
 ENV SHELL /bin/bash
 ENV NB_UID 1000
 ENV HOME /home/$NB_USER

--- a/kernel/sql/src/main/java/com/twosigma/beakerx/sql/QueryParser.java
+++ b/kernel/sql/src/main/java/com/twosigma/beakerx/sql/QueryParser.java
@@ -18,8 +18,13 @@ package com.twosigma.beakerx.sql;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import com.twosigma.beakerx.util.BeakerXSystem;
 
 public class QueryParser {
+
+  private static String rd = beakerXSystem.getenv("REMOVE_DASH_LINECOMMENT");
+  private static boolean REMOVE_DASH_LINECOMMENT = (rd==null) || (rd.equals("true"));
+
   private static final List<ParsingState> PARSING_STATES = Arrays.asList(
       new ParsingState("'", "'", false), // string literal
       new ParsingState("/*", "*/", true),
@@ -84,7 +89,7 @@ public class QueryParser {
   private static class LineCommentParsingState extends ParsingState {
 
     public LineCommentParsingState(String start) {
-      super(start, "\n", true);
+      super(start, "\n", REMOVE_DASH_LINECOMMENT);
     }
   }
 


### PR DESCRIPTION
This is a PR fix to [issue#8134](https://github.com/twosigma/beakerx/issues/8134)

I've added an environment variable that defaults to True, which will perform the default behavior of a LineCommentParsingState, which is to delete the comment from the query string before submitting the query to the Database. This change now allows anyone using beakerx against a database that utilizes comments for overrides (Derby and/or Splicemachine)

This PR will have no effect on the behavior of the current deployment.

Help from @jramineni