### PR TITLE
improved groovy autocomplete based on reflection

### DIFF
--- a/kernel/base/build.gradle
+++ b/kernel/base/build.gradle
@@ -30,7 +30,7 @@ compileJava {
 
 dependencies {
   compile group: 'com.opencsv', name: 'opencsv', version: '3.10'
-  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.6.5'
+  compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.3'
   compile group: 'com.github.jupyter', name: 'jvm-repr', version: '0.3.1'
   compile group: "commons-codec", name: "commons-codec", version: "1.9"
   compile group: 'commons-io', name: 'commons-io', version: '2.5'

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyAutocomplete.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyAutocomplete.java
@@ -23,6 +23,8 @@ import com.twosigma.beakerx.autocomplete.AutocompleteServiceBeakerx;
 import com.twosigma.beakerx.autocomplete.ClassUtils;
 import com.twosigma.beakerx.autocomplete.MagicCommandAutocompletePatterns;
 import com.twosigma.beakerx.kernel.Imports;
+
+import groovy.lang.Binding;
 import groovy.lang.GroovyClassLoader;
 import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
@@ -32,6 +34,7 @@ import org.antlr.v4.runtime.tree.ParseTreeWalker;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.twosigma.beakerx.groovy.autocomplete.AutocompleteRegistryFactory.setup;
 
@@ -40,15 +43,18 @@ public class GroovyAutocomplete extends AutocompleteServiceBeakerx {
   private GroovyClasspathScanner cps;
   private GroovyClassLoader groovyClassLoader;
   private Imports imports;
+  private Binding scriptBinding;
 
   public GroovyAutocomplete(GroovyClasspathScanner _cps,
                             GroovyClassLoader groovyClassLoader,
                             Imports imports,
-                            MagicCommandAutocompletePatterns autocompletePatterns) {
+                            MagicCommandAutocompletePatterns autocompletePatterns,
+                            Binding scriptBinding) {
     super(autocompletePatterns);
     cps = _cps;
     this.groovyClassLoader = groovyClassLoader;
     this.imports = imports;
+    this.scriptBinding = scriptBinding;
     registry = AutocompleteRegistryFactory.createRegistry(cps);
   }
 
@@ -84,6 +90,7 @@ public class GroovyAutocomplete extends AutocompleteServiceBeakerx {
     GroovyImportDeclarationCompletion extractor = new GroovyImportDeclarationCompletion(txt, cur, registry, cps, cu);
     GroovyNameBuilder extractor2 = new GroovyNameBuilder(registry, cu);
     GroovyNodeCompletion extractor3 = new GroovyNodeCompletion(txt, cur, registry, cu);
+    GroovyReflectionCompletion extractor4 = new GroovyReflectionCompletion(scriptBinding);
 
     walker.walk(extractor, t);
     if (extractor.getQuery() != null)
@@ -93,6 +100,9 @@ public class GroovyAutocomplete extends AutocompleteServiceBeakerx {
     if (extractor3.getQuery() != null)
       q.addAll(extractor3.getQuery());
     List<String> ret = registry.searchCandidates(q);
+    
+	List<String> reflectionCompletions = extractor4.autocomplete(txt, cur);
+	ret.addAll(reflectionCompletions);
 
     if (!ret.isEmpty()) {
       return new AutocompleteResult(ret, getStartIndex(extractor, extractor2, extractor3));

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyAutocomplete.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyAutocomplete.java
@@ -90,7 +90,7 @@ public class GroovyAutocomplete extends AutocompleteServiceBeakerx {
     GroovyImportDeclarationCompletion extractor = new GroovyImportDeclarationCompletion(txt, cur, registry, cps, cu);
     GroovyNameBuilder extractor2 = new GroovyNameBuilder(registry, cu);
     GroovyNodeCompletion extractor3 = new GroovyNodeCompletion(txt, cur, registry, cu);
-    GroovyReflectionCompletion extractor4 = new GroovyReflectionCompletion(scriptBinding);
+    GroovyReflectionCompletion extractor4 = new GroovyReflectionCompletion(scriptBinding, groovyClassLoader, imports);
 
     walker.walk(extractor, t);
     if (extractor.getQuery() != null)

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -81,24 +81,11 @@ public class GroovyReflectionCompletion {
 
 		return text.substring(prevLine, nextLine).trim();
 	}
-
-	List<String> autocompleteFromObject(List<String> parts) {
-		
-		List<String> lowPriorityCompletions = Arrays.asList("class","metaClass");
-
-		List<String> filteredCompletions = Arrays.asList("empty");
-		
-		List<String> iterableOnlyCompletions = Arrays.asList("join(");
-
-		List<String> stringCompletions = Arrays.asList(
-				"size()",
-				"split(",
-				"tokenize(",
-				"matches(",
-				"contains("
-	    );
-		
-		List<String> supplementaryCollectionCompletions = Arrays.asList(
+	
+	/**
+	 * These are groovy-fied methods that do not show up in a nice groovy way by reflection
+	 */
+	public static final List<String> SUPPLEMENTARY_COLLECTION_COMPLETIONS = Arrays.asList(
 				"isEmpty()", 
 				"size()", 
 				"collectEntries { ", 
@@ -108,7 +95,25 @@ public class GroovyReflectionCompletion {
 				"groupBy { ",
 				"countBy { "
 		);
+	
+	public final static List<String> STRING_COMPLETIONS = Arrays.asList(
+			"size()",
+			"split(",
+			"tokenize(",
+			"matches(",
+			"contains("
+	);
+	
+	List<String> autocompleteFromObject(List<String> parts) {
+		
+		List<String> lowPriorityCompletions = Arrays.asList("class","metaClass");
 
+		List<String> filteredCompletions = Arrays.asList("empty");
+		
+		List<String> iterableOnlyCompletions = Arrays.asList("join(");
+
+	
+	
 		ArrayList<String> result = new ArrayList<String>();
 		
 		try {
@@ -144,12 +149,12 @@ public class GroovyReflectionCompletion {
 			}
 			
 			if(value instanceof Iterable || value instanceof Map) {
-				result.addAll(supplementaryCollectionCompletions);
+				result.addAll(SUPPLEMENTARY_COLLECTION_COMPLETIONS);
 				result.addAll(iterableOnlyCompletions);
 			}
 			
 			if(value instanceof String) {
-				result.addAll(stringCompletions);
+				result.addAll(STRING_COMPLETIONS);
 			}
 			
 //			result.addAll(lowPri);

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -1,0 +1,165 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.twosigma.beakerx.groovy.autocomplete;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+
+import org.apache.commons.beanutils.BeanUtilsBean2;
+
+import groovy.lang.Binding;
+
+public class GroovyReflectionCompletion {
+	
+	Binding binding;
+
+	private BeanUtilsBean2 beanUtils = new BeanUtilsBean2();
+
+	public GroovyReflectionCompletion(Binding binding) {
+		this.binding = binding;
+	}
+
+	public List<String> autocomplete(String text, int pos) {
+		
+		String expr = resolveExpression(text,pos-1);
+		
+		ArrayList<String> parts = new ArrayList<String>();
+		StringTokenizer tokenizer = new StringTokenizer(expr, ".");
+		while(tokenizer.hasMoreTokens()) {
+			parts.add(tokenizer.nextToken());
+		}
+	
+		if(binding.hasVariable(parts.get(0)) && ((parts.size() > 1) || text.endsWith("."))) {
+			return autocompleteFromObject(parts);
+		}
+		else  {
+			List<String> result = 
+				((Map<String,Object>)binding.getVariables())
+											.keySet()
+											.stream()
+											.filter(x -> x.startsWith(text))
+											.collect(Collectors.toList());
+			return result;
+		}
+	}
+
+	
+	public String resolveExpression(String text, int pos) {
+		
+		int nextLine = pos;
+		while(nextLine<text.length() && !Character.isWhitespace(text.charAt(nextLine))) {
+			++nextLine;
+		}
+		
+		int prevLine = pos;
+		while(prevLine>=0 && !Character.isWhitespace(text.charAt(prevLine))) {
+			--prevLine;
+		}
+		
+		prevLine = Math.max(0,prevLine);
+		nextLine = Math.min(text.length(),nextLine);
+
+		return text.substring(prevLine, nextLine).trim();
+	}
+
+	List<String> autocompleteFromObject(List<String> parts) {
+		
+		List<String> lowPriorityCompletions = Arrays.asList("class","metaClass");
+
+		List<String> filteredCompletions = Arrays.asList("empty");
+		
+		List<String> iterableOnlyCompletions = Arrays.asList("join(");
+
+		List<String> stringCompletions = Arrays.asList(
+				"size()",
+				"split(",
+				"tokenize(",
+				"matches(",
+				"contains("
+	    );
+		
+		List<String> supplementaryCollectionCompletions = Arrays.asList(
+				"isEmpty()", 
+				"size()", 
+				"collectEntries { ", 
+				"collect { ", 
+				"find { ", 
+				"grep { ",
+				"groupBy { ",
+				"countBy { "
+		);
+
+		ArrayList<String> result = new ArrayList<String>();
+		
+		try {
+
+			Object value = binding.getVariable(parts.get(0));
+			int i = 1;
+			for(; i<parts.size()-1; ++i) {
+				value = beanUtils.getProperty(value, parts.get(i));
+			}
+			
+			String completionToken = parts.size() > 1 ? parts.get(parts.size()-1) : "";
+			
+			Map<String,String> desc = beanUtils.describe(value);
+			
+			List<String> lowPri = new ArrayList<String>();
+		
+			desc.forEach((String key, String val) -> {
+				if(key.startsWith(completionToken)) {
+					if(lowPriorityCompletions.contains(key)) {
+						lowPri.add(key);
+					}
+					else {
+						result.add(key);
+					}
+				}
+			});
+			
+			if(value instanceof Map) {
+				Map<String,?> mapValue = (Map<String,?>)value;
+				mapValue.keySet().stream()
+								 .filter(k -> k.startsWith(completionToken))
+								 .forEach(k -> result.add(k));
+			}
+			
+			if(value instanceof Iterable || value instanceof Map) {
+				result.addAll(supplementaryCollectionCompletions);
+				result.addAll(iterableOnlyCompletions);
+			}
+			
+			if(value instanceof String) {
+				result.addAll(stringCompletions);
+			}
+			
+			result.addAll(lowPri);
+			
+			result.removeIf(v -> !v.startsWith(completionToken));
+				
+			result.removeAll(filteredCompletions);
+	
+		} catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+			e.printStackTrace();
+		}
+		return result;
+	}
+	
+}

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -66,20 +66,35 @@ public class GroovyReflectionCompletion {
 	
 	public String resolveExpression(String text, int pos) {
 		
-		int nextLine = pos;
-		while(nextLine<text.length() && !Character.isWhitespace(text.charAt(nextLine))) {
+		int nextLine = pos+1;
+		char nextChar = text.charAt(nextLine);
+		while(nextLine<text.length() && Character.isJavaIdentifierPart(nextChar)) {
 			++nextLine;
+			
+			if(nextLine<text.length())
+				nextChar = text.charAt(nextLine);
+			else
+				nextChar = '\n';
 		}
 		
 		int prevLine = pos;
-		while(prevLine>=0 && !Character.isWhitespace(text.charAt(prevLine))) {
+		while(prevLine>=0 && (text.charAt(prevLine) == '.' || Character.isJavaIdentifierPart(text.charAt(prevLine)))) {
 			--prevLine;
 		}
 		
 		prevLine = Math.max(0,prevLine);
 		nextLine = Math.min(text.length(),nextLine);
-
-		return text.substring(prevLine, nextLine).trim();
+		
+		String result = text.substring(prevLine, nextLine).trim();
+		
+		if(!Character.isJavaIdentifierPart(result.charAt(result.length()-1))) {
+			result = result.substring(0, result.length()-1);
+		}
+		
+		if(!Character.isJavaIdentifierPart(result.charAt(0))) {
+			result = result.substring(1);
+		}
+		return result;
 	}
 	
 	/**

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -66,7 +66,7 @@ public class GroovyReflectionCompletion {
 	
 	public String resolveExpression(String text, int pos) {
 		
-		int nextLine = pos+1;
+		int nextLine = Math.min(text.length()-1,pos+1);
 		char nextChar = text.charAt(nextLine);
 		while(nextLine<text.length() && Character.isJavaIdentifierPart(nextChar)) {
 			++nextLine;

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -152,7 +152,7 @@ public class GroovyReflectionCompletion {
 				result.addAll(stringCompletions);
 			}
 			
-			result.addAll(lowPri);
+//			result.addAll(lowPri);
 			
 			result.removeIf(v -> !v.startsWith(completionToken));
 				

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -61,7 +61,7 @@ public class GroovyReflectionCompletion {
 				((Map<String,Object>)binding.getVariables())
 											.keySet()
 											.stream()
-											.filter(x -> x.startsWith(text))
+											.filter(x -> x.startsWith(expr))
 											.collect(Collectors.toList());
 			return result;
 		}

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/autocomplete/GroovyReflectionCompletion.java
@@ -240,17 +240,30 @@ public class GroovyReflectionCompletion {
 					"notify",
 					"notifyAll");
 	
+	boolean isNonPropertyMethod(final Method m) {
+		
+	  if(m.getName().startsWith("get") && m.getParameterCount()==0)
+		  return false;
+	  
+	  if(m.getName().equals("setYBounds")) {
+		  System.err.println("setting ybound");
+	  }
+
+	  if(m.getName().startsWith("set") && m.getParameterCount()==1)
+		  return false;
+	  
+	  return true;
+	}
 	
 	List<String> getObjectMethodCompletions(Object obj, String completionToken) {
 		
-		
+		@SuppressWarnings("rawtypes")
 		Class c = obj.getClass();
 
 		List<String> methodNames = 
 			Stream.of(c.getMethods())
 				  .filter(m -> 
-				  	!m.getName().startsWith("get") &&
-				  	!m.getName().startsWith("set") &&
+				    isNonPropertyMethod(m) &&
 				  	!IGNORE_METHODS.contains(m.getName()))
 				  .filter(m -> m.getName().startsWith(completionToken))
 				  .map(m -> {

--- a/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/evaluator/GroovyEvaluator.java
+++ b/kernel/groovy/src/main/java/com/twosigma/beakerx/groovy/evaluator/GroovyEvaluator.java
@@ -126,7 +126,7 @@ public class GroovyEvaluator extends BaseEvaluator {
   }
 
   private GroovyAutocomplete createGroovyAutocomplete(GroovyClasspathScanner c, GroovyClassLoader groovyClassLoader, Imports imports, MagicCommandAutocompletePatterns autocompletePatterns) {
-    return new GroovyAutocomplete(c, groovyClassLoader, imports, autocompletePatterns);
+    return new GroovyAutocomplete(c, groovyClassLoader, imports, autocompletePatterns, scriptBinding);
   }
 
   private String createClasspath(Classpath classPath) {

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -38,6 +38,18 @@ public class GroovyReflectionCompletionTest {
 		}
 	}
 	
+	public static class C {
+		String foo = "FOOOO";
+
+		public String getFoo() {
+			return foo;
+		}
+
+		public void setFoo(String foo) {
+			this.foo = foo;
+		}
+	}
+	
 	public static class House {
 
 		String cubby;
@@ -211,6 +223,23 @@ public class GroovyReflectionCompletionTest {
 		
 		assert !result.contains("moo(String)");
 		assert result.stream().filter(s -> s.startsWith("getHouse")).count() == 0;
+	}
+	
+	@Test
+	public void testNestedDot() {
+		Binding binding = new Binding();
+		
+		binding.setVariable("c", new C());
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		
+		List<String> result = grc.autocomplete("c.foo.", 6);
+		
+		assert !result.contains("foo");
+		assert result.contains("size()");
+		
+		System.out.println(result);
+		
 	}
 
 }

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -1,0 +1,144 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.twosigma.beakerx.groovy.evaluator.autocomplete;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.twosigma.beakerx.groovy.autocomplete.GroovyReflectionCompletion;
+
+import groovy.lang.Binding;
+
+public class GroovyReflectionCompletionTest {
+	
+	public static class A {
+		String b;
+
+		public String getB() {
+			return b;
+		}
+
+		public void setB(String b) {
+			this.b = b;
+		}
+	}
+	
+	public static class House {
+
+		String cubby;
+
+		public String getCubby() {
+			return cubby;
+		}
+
+		public void setCubby(String b) {
+			this.cubby = b;
+		}
+	}
+	
+	public static class Tree {
+
+		House house = new House();
+
+		public House getHouse() {
+			return house;
+		}
+
+		public void setHouse(House house) {
+			this.house = house;
+		}
+	}
+	
+	@Test
+	public void testExtractExpression() {
+		Binding binding = new Binding();
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+
+		assert grc.resolveExpression("hello", 3).equals("hello");
+	}
+	
+
+	@Test
+	public void testCompletePropertyNames() {
+		
+		Binding binding = new Binding();
+		
+		binding.setVariable("x", new A());
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		
+		List<String> result = grc.autocomplete("x.", 1);
+		
+		assert result.get(0).equals("b");
+	}
+	
+	@Test
+	public void testNestedObjectProperty() {
+		
+		Binding binding = new Binding();
+		
+		binding.setVariable("tree", new Tree());
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+			
+		List result = grc.autocomplete("tree.h", 5);
+		
+		assert result.size() == 1;
+
+		assert result.stream().filter(x -> x.equals("house")).count()>0;
+	}
+	
+	@Test
+	public void testMapLiteral() {
+		
+		Binding binding = new Binding();
+		
+		Map m = new HashMap();
+		m.put("cat", 5);
+		m.put("dog", 10);
+		m.put("tree", 15);
+		
+		
+		binding.setVariable("blah", m);
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+			
+		List result = grc.autocomplete("blah.c", 5);
+		
+		assert result.stream().filter(x -> x.equals("cat")).count()>0;
+		assert !result.contains("dog");
+		assert !result.contains("size()");
+	}
+	
+	@Test
+	public void testIterable() {
+		
+		Binding binding = new Binding();
+		
+		
+		binding.setVariable("blah", Arrays.asList("super","cat","dog","tree"));
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+			
+		List result = grc.autocomplete("blah.s", 5);
+		
+		assert !result.contains("dog");
+		assert result.contains("size()");
+	}
+
+}

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -13,6 +13,7 @@
  */
 package com.twosigma.beakerx.groovy.evaluator.autocomplete;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -238,8 +239,35 @@ public class GroovyReflectionCompletionTest {
 		assert !result.contains("foo");
 		assert result.contains("size()");
 		
-		System.out.println(result);
+//		System.out.println(result);
 		
 	}
 
+	@Test
+	public void testIndexedExpression() {
+		Binding binding = new Binding();
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		assert ("something[2]".equals(grc.resolveExpression("something[2].", 12)));
+	}
+	
+	@Test
+	public void testIndexedListCompletion() {
+		Binding binding = new Binding();
+		
+		List<C> list = new ArrayList<C>();
+		list.add(new C());
+		list.add(new C());
+		
+		binding.setVariable("clist", list);
+		
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		
+		List<String> result = grc.autocomplete("clist[1].", 9);
+		
+		System.out.println(result);
+		
+		assert result.contains("foo");
+	}
+	
 }

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -119,7 +119,31 @@ public class GroovyReflectionCompletionTest {
 		assert result.size() >= 1;
 
 		assert result.stream().filter(x -> x.equals("house")).count()>0;
+		
+		result = grc.autocomplete("tree.", 4);
+		
+		assert result.size() >= 1;
+		
+		assert result.stream().filter(x -> x.equals("house")).count()>0;
+		
 	}
+	
+	@Test
+	public void testExpressionInParentheses() {
+		
+		Binding binding = new Binding();
+		
+		binding.setVariable("tree", new Tree());
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+			
+		List result = grc.autocomplete("x.foo(tree.h)", 11);
+		
+		assert result.size() >= 1;
+
+		assert result.stream().filter(x -> x.equals("house")).count()>0;
+	}
+	
 	
 	@Test
 	public void testMapLiteral() {

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.twosigma.beakerx.groovy.autocomplete.GroovyReflectionCompletion;
+import com.twosigma.beakerx.groovy.autocomplete.GroovyReflectionCompletion.ConstructorMatch;
 
 import groovy.lang.Binding;
 
@@ -98,7 +99,7 @@ public class GroovyReflectionCompletionTest {
 	@Test
 	public void testExtractExpression() {
 		Binding binding = new Binding();
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 
 		assert grc.resolveExpression("hello", 3).equals("hello");
 	}
@@ -111,7 +112,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("a", new A());
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 		
 		List<String> result = grc.autocomplete("a.", 2);
 		
@@ -126,7 +127,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("x", new A());
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 		
 		List<String> result = grc.autocomplete("x.", 1);
 		
@@ -140,7 +141,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("tree", new Tree());
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 			
 		List result = grc.autocomplete("tree.h", 5);
 		
@@ -163,7 +164,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("tree", new Tree());
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 			
 		List result = grc.autocomplete("x.foo(tree.h)", 11);
 		
@@ -186,7 +187,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("blah", m);
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 			
 		List result = grc.autocomplete("blah.c", 5);
 		
@@ -203,7 +204,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("blah", Arrays.asList("super","cat","dog","tree"));
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 			
 		List result = grc.autocomplete("blah.s", 5);
 		
@@ -218,7 +219,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("blah", new Cow());
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 			
 		List<String> result = grc.autocomplete("blah.b", 5);
 		
@@ -232,7 +233,7 @@ public class GroovyReflectionCompletionTest {
 		
 		binding.setVariable("c", new C());
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 		
 		List<String> result = grc.autocomplete("c.foo.", 6);
 		
@@ -246,7 +247,7 @@ public class GroovyReflectionCompletionTest {
 	@Test
 	public void testIndexedExpression() {
 		Binding binding = new Binding();
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,this.getClass().getClassLoader(), null);
 		assert ("something[2]".equals(grc.resolveExpression("something[2].", 12)));
 	}
 	
@@ -261,7 +262,7 @@ public class GroovyReflectionCompletionTest {
 		binding.setVariable("clist", list);
 		
 		
-		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,null,null);
 		
 		List<String> result = grc.autocomplete("clist[1].", 9);
 		
@@ -269,5 +270,35 @@ public class GroovyReflectionCompletionTest {
 		
 		assert result.contains("foo");
 	}
+	
+	@Test
+	public void testConstructorAutoComplete() throws ClassNotFoundException {
+		
+		String [] testCases = new String[] {
+			  "new TestA(foo:'cow',@)",
+			  "new TestA(@)",
+			  "new TestA(\n@\n)",
+			  "new TestA(foo@)",
+			  "new TestA(foo:'cow', bar@)",
+			  "new TestA(foo:'cow', @)",
+			  "new TestA(\nfoo@\n)",
+			  "new TestA(\nbar:'hello',\nfoo@\n)"
+		};
+		
+		
+		Binding binding = new Binding();
+
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding,this.getClass().getClassLoader(), null);
+
+		for(String testCase : testCases) {
+			ConstructorMatch match = grc.tryMatchConstructor(testCase.replaceAll("@", ""),testCase.indexOf('@'));
+			assert match != null;
+		}
+		
+		String testCase = "new TestA(\nbar:'hello',\nfoo:@\n)";
+		ConstructorMatch match = grc.tryMatchConstructor(testCase.replaceAll("@", ""),testCase.indexOf('@'));
+		assert match == null;
+	}
+	
 	
 }

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -64,6 +64,24 @@ public class GroovyReflectionCompletionTest {
 		}
 	}
 	
+	public static class Cow {
+
+		House house = new House();
+		
+		void moo(Tree tree) {
+			System.out.println("Moo " + tree.toString());
+		}
+
+		public House getHouse() {
+			return house;
+		}
+
+		public void setHouse(House house) {
+			this.house = house;
+		}
+	}
+	
+	
 	@Test
 	public void testExtractExpression() {
 		Binding binding = new Binding();
@@ -98,7 +116,7 @@ public class GroovyReflectionCompletionTest {
 			
 		List result = grc.autocomplete("tree.h", 5);
 		
-		assert result.size() == 1;
+		assert result.size() >= 1;
 
 		assert result.stream().filter(x -> x.equals("house")).count()>0;
 	}
@@ -122,7 +140,7 @@ public class GroovyReflectionCompletionTest {
 		
 		assert result.stream().filter(x -> x.equals("cat")).count()>0;
 		assert !result.contains("dog");
-		assert !result.contains("size()");
+//		assert !result.contains("size()");
 	}
 	
 	@Test
@@ -139,6 +157,21 @@ public class GroovyReflectionCompletionTest {
 		
 		assert !result.contains("dog");
 		assert result.contains("size()");
+	}
+
+	@Test
+	public void testMethods() {
+		
+		Binding binding = new Binding();
+		
+		binding.setVariable("blah", new Cow());
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+			
+		List<String> result = grc.autocomplete("blah.b", 5);
+		
+		assert !result.contains("moo(String)");
+		assert result.stream().filter(s -> s.startsWith("getHouse")).count() == 0;
 	}
 
 }

--- a/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
+++ b/kernel/groovy/src/test/java/com/twosigma/beakerx/groovy/evaluator/autocomplete/GroovyReflectionCompletionTest.java
@@ -90,6 +90,21 @@ public class GroovyReflectionCompletionTest {
 		assert grc.resolveExpression("hello", 3).equals("hello");
 	}
 	
+	
+	@Test
+	public void testCompletePropertyNames2() {
+		
+		Binding binding = new Binding();
+		
+		binding.setVariable("a", new A());
+		
+		GroovyReflectionCompletion grc = new GroovyReflectionCompletion(binding);
+		
+		List<String> result = grc.autocomplete("a.", 2);
+		
+		assert result.get(0).equals("b");
+	}
+		
 
 	@Test
 	public void testCompletePropertyNames() {


### PR DESCRIPTION
This change adds improved autocomplete functions for Groovy notebooks.

See #8116 for some of the limitations of the current autocomplete approach. This change is a partial implementation of #8116. It supplements the existing autocomplete options by adding entries that are determined through runtime introspection of the variable under the cursor. 

For example, in the scenario below, the existing autocomplete cannot offer any suggestions, however this change enables the below:

![image](https://user-images.githubusercontent.com/138868/74215374-00a91180-4cf5-11ea-979a-66164c2f177d.png)

This is quite useful with the plotting functionality as valid plot attributes can be suggested now which makes them much easier to learn:

<img width="164" alt="image" src="https://user-images.githubusercontent.com/138868/74215861-ad37c300-4cf6-11ea-9550-c27a06ca5064.png">

Apart from actual JavaBean properties, the implemenation also supports Groovy Map notation so that map entries are autocompleted as well:

<img width="222" alt="image" src="https://user-images.githubusercontent.com/138868/74215732-2c78c700-4cf6-11ea-8946-bcc68abff572.png">

Finally, some intelligence has been added so that when the object under the cursor is an iterable or Map, various suggestions for valid Groovy methods on those types are included in the completions:

<img width="249" alt="image" src="https://user-images.githubusercontent.com/138868/74215938-f4be4f00-4cf6-11ea-8693-c32df829f813.png">

It would be great to be able to have this integrated to BeakerX as I think it makes a big difference ot the usability of the Groovy kernel.
