### PR TITLE
fix #334 - copy and paste off by one column in table display

### DIFF
--- a/js/beakerx_tabledisplay/src/tableDisplay/dataGrid/cell/CellManager.ts
+++ b/js/beakerx_tabledisplay/src/tableDisplay/dataGrid/cell/CellManager.ts
@@ -268,7 +268,7 @@ export default class CellManager {
     };
 
     function getStartIndex(has_index) {
-        return (has_index) ?0:1;
+        return (has_index) ?1:0;
     }
 
     function exportCells(cells, exportOptions) {

--- a/js/beakerx_tabledisplay/test/src/tableDisplay/dataGrid/cell/CellManager.spec.ts
+++ b/js/beakerx_tabledisplay/test/src/tableDisplay/dataGrid/cell/CellManager.spec.ts
@@ -106,8 +106,8 @@ describe('CellManager', () => {
     expect(cellManager).to.have.property('exportCellsTo');
     expect(cellManager.exportCellsTo).to.be.a('Function');
     const cells = cellManager.getSelectedCells();
-    const resultCsv = `"column"\n":)"\n`;
-    const resultTabs = `column\n:)\n`;
+    const resultCsv = `"test","column"\n"1",":)"\n`;
+    const resultTabs = `test\tcolumn\n1\t:)\n`;
 
     expect(cellManager.exportCellsTo(cells, 'csv')).to.equal(resultCsv);
     expect(cellManager.exportCellsTo(cells, 'tabs')).to.equal(resultTabs);
@@ -116,7 +116,7 @@ describe('CellManager', () => {
   it('should implement getCSVFromCells method', () => {
     expect(cellManager).to.have.property('getCSVFromCells');
     expect(cellManager.getCSVFromCells).to.be.a('Function');
-    const result = `"column"\n":)"\n`;
+    const result = `"test","column"\n"1",":)"\n`;
 
     expect(cellManager.getCSVFromCells(true)).to.equal(result);
   });


### PR DESCRIPTION
This change fixes https://github.com/twosigma/beakerx/issues/8166

ie: that when "Copy Selected Columns" is used the actual columns copied are offest by one and mising a column from those selected in the table.

Note:  I did have to modify the tests to accept new behavior as a result of this change. To the best of my understanding however, the new test spec is correct and the old was incorrect. That is, it tests copying columns 0 - 1, and it should expect 2 columns in the output, not one. So I have changed it to expect the updated values.
