### PR TITLE
Makes the base_url configurable (docker)

### DIFF
--- a/docker/jupyter_notebook_config.py
+++ b/docker/jupyter_notebook_config.py
@@ -12,6 +12,10 @@ c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
 
+# configure a path prefix for the app if it had been set
+if 'CONTEXT_PATH' in os.environ:
+  c.NotebookApp.base_url = os.environ['CONTEXT_PATH']
+
 # Generate a self-signed certificate
 if 'GEN_CERT' in os.environ:
   dir_name = jupyter_data_dir()


### PR DESCRIPTION
This change to the configuration makes the **base_url** for the service configurable using the environment variable **CONTEXT_PATH**.
This helps in conjunction with reverse proxies. 
Standard usage in Docker which opens on _localhost:8888_
```
docker run -p 8888:8888 beakerx/beakerx
```
whereas
```
docker run -p 8888:8888 -e CONTEXT_PATH=beakerx beakerx/beakerx
```
would open on _localhost:8888/beakerx_
